### PR TITLE
docs(readme): reword intro, add PyDivert + third-party links

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,15 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### Docs: intro wording and third-party links
+
+- **README intro (EN + PL)** reworded: leads with the product name (branding + the auto-snippet),
+  compares to Clumsy/NetLimiter by what the tool *does* rather than by the driver - NetLimiter does
+  not use WinDivert, and the old phrasing implied it did - and names WinDivert **via PyDivert**, both
+  linked.
+- **Third-party section (EN + PL):** each named component now links to its homepage/source
+  (WinDivert, PyDivert, psutil, CPython, Tcl/Tk, PyInstaller).
+
 ### CI: one run per commit
 
 - **`ci.yml` `push` trigger scoped to `master`.** With `on: [push, pull_request]` a branch that

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
 
-A tool for testers and developers: check how your application behaves on a poor
-connection. It intercepts network traffic with the **[WinDivert](https://www.reqrypt.org/windivert.html)** driver (like
-Clumsy / NetLimiter) and lets you deliberately "break" it - add ping, drop
-packets, cap the speed, tear connections down and so on. It is called **Bean
-Network Tester** and ships with a clear windowed interface with tooltips plus a
-command-line mode for CI.
+**Bean Network Tester** is a tool for testers and developers: check how your application behaves
+on a poor connection. Like Clumsy or NetLimiter, it lets you deliberately degrade the network -
+add ping, drop packets, cap the speed, tear connections down, and more. It works by intercepting
+traffic with the **[WinDivert](https://www.reqrypt.org/windivert.html)** driver (via
+**[PyDivert](https://github.com/ffalcinelli/pydivert)**), and offers both a clear windowed
+interface with tooltips and a command-line mode for CI.
 
 > This is the English documentation. Polish version: [README.pl.md](README.pl.md).
 
@@ -973,8 +973,11 @@ under the same GPLv3 terms and make the corresponding source available. The prog
 
 ## Third-party components
 
-The program uses libraries by other authors, under their own licenses - among them **WinDivert** and
-**PyDivert** under **LGPLv3**, **psutil** (BSD), **CPython** (PSF), **Tcl/Tk** and the **PyInstaller**
+The program uses libraries by other authors, under their own licenses - among them
+**[WinDivert](https://www.reqrypt.org/windivert.html)** and
+**[PyDivert](https://github.com/ffalcinelli/pydivert)** under **LGPLv3**,
+**[psutil](https://github.com/giampaolo/psutil)** (BSD), **[CPython](https://www.python.org/)** (PSF),
+**[Tcl/Tk](https://www.tcl-lang.org/)** and the **[PyInstaller](https://pyinstaller.org/)**
 bootloader. The full list, versions and source addresses are in
 [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), and the full license texts are in the `licenses/`
 directory. From within the program: `--license` (CLI) or the **About** button in the interface.

--- a/README.pl.md
+++ b/README.pl.md
@@ -6,10 +6,12 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
 
-Narzędzie dla testerów i deweloperów: sprawdź, jak aplikacja zachowuje się przy słabym
-internecie. Przechwytuje ruch sieciowy sterownikiem **[WinDivert](https://www.reqrypt.org/windivert.html)** (jak Clumsy / NetLimiter)
-i pozwala go kontrolowanie „psuć” - dodać ping, gubić pakiety, ograniczyć prędkość, zrywać
-połączenia itd. Nazywa się **Bean Network Tester** i ma czytelny interfejs okienkowy z podpowiedziami oraz tryb wiersza poleceń do CI.
+**Bean Network Tester** to narzędzie dla testerów i deweloperów: sprawdź, jak aplikacja zachowuje
+się przy słabym internecie. Podobnie jak Clumsy czy NetLimiter, pozwala celowo pogarszać sieć -
+dodać ping, gubić pakiety, ograniczyć prędkość, zrywać połączenia i więcej. Działa przez
+przechwytywanie ruchu sterownikiem **[WinDivert](https://www.reqrypt.org/windivert.html)** (przez
+**[PyDivert](https://github.com/ffalcinelli/pydivert)**) i daje zarówno czytelny interfejs okienkowy
+z podpowiedziami, jak i tryb wiersza poleceń do CI.
 
 **Spis treści**
 
@@ -880,8 +882,10 @@ bez gwarancji i bez odpowiedzialności autora. Autorem jest **DonislawDev**.
 ## Komponenty firm trzecich
 
 Program korzysta z bibliotek innych autorów, na ich własnych licencjach - m.in.
-**WinDivert** i **PyDivert** na licencji **LGPLv3**, **psutil** (BSD),
-**CPython** (PSF), **Tcl/Tk** i bootloader **PyInstaller**. Pełna lista, wersje i
+**[WinDivert](https://www.reqrypt.org/windivert.html)** i
+**[PyDivert](https://github.com/ffalcinelli/pydivert)** na licencji **LGPLv3**,
+**[psutil](https://github.com/giampaolo/psutil)** (BSD), **[CPython](https://www.python.org/)** (PSF),
+**[Tcl/Tk](https://www.tcl-lang.org/)** i bootloader **[PyInstaller](https://pyinstaller.org/)**. Pełna lista, wersje i
 adresy źródeł są w [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), a pełne
 teksty licencji w katalogu `licenses/`. Z poziomu programu: `--license` (CLI)
 albo przycisk **O programie** w interfejsie.


### PR DESCRIPTION
- intro (EN + PL): lead with the product name; compare to Clumsy/NetLimiter by what the tool does, not by the driver (NetLimiter does not use WinDivert - the old wording implied it did); name WinDivert via PyDivert, both linked
- third-party section (EN + PL): link every named component to its home/source (WinDivert, PyDivert, psutil, CPython, Tcl/Tk, PyInstaller)

## What and why

<!-- What does this change do, and why? Link any related issue, e.g. "Fixes #123". -->

## Checklist

- [ ] `python -m pytest tests` passes locally.
- [ ] New behaviour has tests (see `tests/` for the style).
- [ ] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [ ] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [ ] Commits follow Conventional Commits (`type(scope): summary`).
- [ ] No version bump - the owner closes a version via `VERSION.txt`.
