### PR TITLE
fix(gui): throughput caption tracks chart_seconds instead of hardcode…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   row used to leave a blank row looking selected.
 - **The throughput chart reads cleanly at any window size.** An idle chart used to stack
   duplicate "1 1 0 0" numbers up the Y axis; the axis labels are now distinct, the chart
-  drops to two labels when the window is short, and the "last ~84 s" caption matches the axis.
+  drops to two labels when the window is short, and the caption tracks the chosen history
+  length (e.g. "last ~120 s") so it always matches the axis.
 - **No `crashes/` folder appears just from launching the tool.** The `crashes/native-crash.txt`
   file used to be created on every launch, which looked as if something had crashed. Native
   crash capture is now armed only when a real capture starts (the only moment a hard crash can

--- a/beantester/gui/pages/stats.py
+++ b/beantester/gui/pages/stats.py
@@ -123,7 +123,8 @@ class StatsPage:
         scope.pack(fill="x", padx=scaled(10), pady=(scaled(2), 0))
         add_tooltip(scope, "tips.scope_note")
 
-        frame = ttk.LabelFrame(parent, text=T("frames.throughput"))
+        self._chart_frame = ttk.LabelFrame(parent, text=self._throughput_title())
+        frame = self._chart_frame
         frame.pack(fill="both", expand=True, padx=scaled(8), pady=scaled(6))
         self.canvas = tk.Canvas(frame, bg=BG2, highlightthickness=0,
                                 height=scaled(180))
@@ -212,6 +213,12 @@ class StatsPage:
             self._chart_job = None
             self.draw_chart()
 
+    def _throughput_title(self):
+        """Frame caption reflecting the actual chart window (the ``chart_seconds``
+        preference), so it never drifts from the live X-axis label."""
+        secs = self.app.pref("chart_seconds")
+        return T("frames.throughput", s=f"{secs:.0f}")
+
     def draw_chart(self):
         self._chart_job = None
         try:
@@ -252,6 +259,7 @@ class StatsPage:
             self.refresh_events()
 
     def refresh_counters(self):
+        self._chart_frame.config(text=self._throughput_title())
         snap = self.app.last_snapshot or {}
         rates = self.app.last_rates
         self.stat_labels["down"].config(text=f"{rates[0]:.0f}")

--- a/lang/en.json
+++ b/lang/en.json
@@ -211,7 +211,7 @@
   "frames.speed_limit": "Speed limit  (0 = unlimited)",
   "frames.tables": "Tables",
   "frames.target_process": "Target process  (name, PID, list, wildcard, re: ...; empty = all traffic)",
-  "frames.throughput": "Throughput (last ~84 s)",
+  "frames.throughput": "Throughput (last ~{s} s)",
   "frames.traffic": "Traffic to modify",
   "log.applied_changes": "Applied changes",
   "log.apply_needed": "Click \"Apply changes\" to push this to the running session.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -211,7 +211,7 @@
   "frames.speed_limit": "Limit prędkości  (0 = bez limitu)",
   "frames.tables": "Tabele",
   "frames.target_process": "Celuj w proces  (nazwa, PID, lista, wildcard, re: ...; puste = cały ruch)",
-  "frames.throughput": "Przepustowość (ostatnie ~84 s)",
+  "frames.throughput": "Przepustowość (ostatnie ~{s} s)",
   "frames.traffic": "Ruch do modyfikacji",
   "log.applied_changes": "Zastosowano zmiany",
   "log.apply_needed": "Kliknij „Zastosuj zmiany”, aby przekazać to do działającej sesji.",


### PR DESCRIPTION
…d 84s

The frame caption "Throughput (last ~84 s)" was a baked-in literal from when the chart held a fixed 120 samples at 0.7 s. The window is now driven by the chart_seconds preference (default 120 s), so the caption disagreed with the live X-axis label ("-120 s"). Give frames.throughput an {s} placeholder and feed it the actual window from pref("chart_seconds"), refreshed each tick so it also follows a live change in Settings.

## What and why

<!-- What does this change do, and why? Link any related issue, e.g. "Fixes #123". -->

## Checklist

- [ ] `python -m pytest tests` passes locally.
- [ ] New behaviour has tests (see `tests/` for the style).
- [ ] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [ ] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [ ] Commits follow Conventional Commits (`type(scope): summary`).
- [ ] No version bump - the owner closes a version via `VERSION.txt`.
