### PR TITLE
fix(gui): crisper settings gear + real hover chip on the header button

### DIFF
--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -328,7 +328,7 @@ class App:
         # is held on self or Tk garbage-collects it and the button goes blank.
         self._gear_icon = None
         try:
-            self._gear_icon = make_gear_icon(scaled(18), FG)
+            self._gear_icon = make_gear_icon(scaled(20), MUT)
         except Exception as _exc:
             crashlog.note(_exc, "gui.app")
         if self._gear_icon is not None:

--- a/beantester/gui/icon.py
+++ b/beantester/gui/icon.py
@@ -1,7 +1,10 @@
 """Window icon: loads ``bean.png`` / ``bean.ico`` or draws the bean itself."""
+import base64
 import math
 import os
+import struct
 import sys
+import zlib
 import tkinter as tk
 
 from ..paths import resource_path
@@ -74,36 +77,89 @@ def _running_variant(idle, size=64):
         return make_bean_icon(size, active=True)
 
 
-def make_gear_icon(size, color, teeth=8):
-    """Draw a settings gear as a transparent PhotoImage in ``color``.
+def _rgba_png(size, rgba):
+    """Encode a ``size``x``size`` RGBA byte buffer as PNG bytes (stdlib only)."""
+    def chunk(tag, data):
+        body = tag + data
+        return (struct.pack(">I", len(data)) + body
+                + struct.pack(">I", zlib.crc32(body) & 0xffffffff))
+    raw = b"".join(b"\x00" + rgba[y * size * 4:(y + 1) * size * 4]
+                   for y in range(size))
+    return (b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw, 9))
+            + chunk(b"IEND", b""))
 
-    Pure ``PhotoImage.put`` (no PIL, like the bean): an annulus body, ``teeth``
-    rectangular teeth around it and a hollow centre. Only the gear pixels are
-    stamped, so the rest stays transparent and the button background shows
-    through. ``size`` is already DPI-scaled by the caller (convention 12).
-    """
-    size = max(8, int(size))
+
+def _gear_covers(px, py, c, r_hole, r_body, r_out, tooth_half, step):
+    """True when supersample point ``(px, py)`` falls on the gear shape."""
+    dx, dy = px - c, py - c
+    r = math.hypot(dx, dy)
+    if r <= r_hole or r > r_out:
+        return False
+    if r <= r_body:
+        return True                     # solid ring body
+    ang = math.atan2(dy, dx) % step     # between body and tips: tooth sector only
+    return min(ang, step - ang) <= tooth_half
+
+
+def _make_gear_icon_put(size, color, teeth):
+    """Legacy aliased gear (single ``PhotoImage.put`` per pixel), kept as a
+    fallback for a Tk build without PNG support (or the test tkinter stub)."""
     img = tk.PhotoImage(width=size, height=size)
     c = (size - 1) / 2.0
-    r_out = size * 0.46            # tooth tips
-    r_body = size * 0.34           # ring outer edge (tooth base)
-    r_hole = size * 0.16           # centre hole
-    tooth_half = (math.pi / teeth) * 0.55   # angular half-width of one tooth
+    r_out, r_body, r_hole = size * 0.46, size * 0.34, size * 0.16
+    tooth_half = (math.pi / teeth) * 0.55
     step = 2.0 * math.pi / teeth
     for y in range(size):
         for x in range(size):
-            dx, dy = x - c, y - c
-            r = math.hypot(dx, dy)
-            if r <= r_hole or r > r_out:
-                continue
-            if r <= r_body:
-                img.put(color, to=(x, y))   # solid ring body
-                continue
-            # between body and tips: a pixel only counts inside a tooth sector
-            ang = math.atan2(dy, dx) % step
-            if min(ang, step - ang) <= tooth_half:
+            if _gear_covers(x, y, c, r_hole, r_body, r_out, tooth_half, step):
                 img.put(color, to=(x, y))
     return img
+
+
+def make_gear_icon(size, color, teeth=8, _ss=4):
+    """Draw an anti-aliased settings gear as a transparent PhotoImage in ``color``.
+
+    Supersampled ``_ss``x and emitted as an RGBA PNG (stdlib ``zlib``/``struct``,
+    no PIL), so edge pixels carry partial alpha and the teeth stay crisp on ANY
+    button background - the old per-pixel ``put`` had no alpha and rasterised
+    jagged teeth at header size. ``size`` is already DPI-scaled (convention 12).
+    Falls back to the aliased routine if the Tk build cannot read PNG data.
+    """
+    size = max(8, int(size))
+    try:
+        r, g, b = (int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16))
+    except (ValueError, IndexError):
+        r = g = b = 0xE4                 # sensible light-grey if colour is odd
+    ss = max(1, int(_ss))
+    span = size * ss
+    c = (span - 1) / 2.0
+    r_out, r_body, r_hole = span * 0.47, span * 0.33, span * 0.17
+    tooth_half = (math.pi / teeth) * 0.5
+    step = 2.0 * math.pi / teeth
+    area = ss * ss
+    buf = bytearray(size * size * 4)
+    for oy in range(size):
+        base_y = oy * ss
+        for ox in range(size):
+            base_x = ox * ss
+            cov = 0
+            for sy in range(ss):
+                yy = base_y + sy
+                for sx in range(ss):
+                    if _gear_covers(base_x + sx, yy, c, r_hole, r_body, r_out,
+                                    tooth_half, step):
+                        cov += 1
+            if cov:
+                i = (oy * size + ox) * 4
+                buf[i], buf[i + 1], buf[i + 2] = r, g, b
+                buf[i + 3] = (255 * cov) // area
+    try:
+        return tk.PhotoImage(data=base64.b64encode(_rgba_png(size, bytes(buf))),
+                             format="png")
+    except tk.TclError:
+        return _make_gear_icon_put(size, color, teeth)
 
 
 def apply_window_icon(root):

--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -175,14 +175,20 @@ def init_style(root=None):
                 padding=(scaled(2), scaled(3)), anchor="w")
     s.map("Section.TButton", background=[("focus", BG2), ("active", BG2)])
 
-    # header gear: an icon-only button that opens the Settings window. Flat and
-    # on the header background so it sits quietly next to the status/donate, and
-    # lights up to BG2 on hover/focus like the section headers.
-    s.configure("Gear.TButton", background=BG, borderwidth=0, focuscolor=ACC,
-                relief="flat", padding=(scaled(4), scaled(2)))
+    # header gear: an icon-only button that opens the Settings window. Flat on the
+    # header at rest (bevel colours pinned to BG so clam draws no raised edge), but
+    # a small icon needs a REAL hover chip - the old BG->BG2 map was a one-shade
+    # change nobody could see, so it never read as clickable. Hover/focus light up
+    # to the secondary-button surface; press goes a shade lighter.
+    s.configure("Gear.TButton", background=BG, bordercolor=BG, lightcolor=BG,
+                darkcolor=BG, borderwidth=0, focuscolor=ACC, relief="flat",
+                padding=scaled(5))
     s.map("Gear.TButton",
-          background=[("focus", BG2), ("active", BG2), ("pressed", BG2),
-                      ("disabled", BG)])
+          background=[("disabled", BG), ("pressed", BTN_HOVER),
+                      ("focus", BTN_BG), ("active", BTN_BG)],
+          bordercolor=[("focus", ACC), ("active", BTN_BORDER)],
+          lightcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)],
+          darkcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)])
 
     # -- checkbuttons ------------------------------------------------------- #
     # clam's built-in indicator is a flat, tiny, badly aligned square that no


### PR DESCRIPTION
The header Settings gear read as "thrown in": the icon was rasterised one opaque pixel at a time (no alpha, jagged teeth at 18 px) in harsh white, and the Gear.TButton hover only swapped BG -> BG2 - a one-shade change nobody could see, so it never looked clickable.

- icon.py: make_gear_icon now supersamples 4x and emits an RGBA PNG (stdlib zlib/struct, no PIL), so edges carry partial alpha and stay crisp on any button background. The old aliased put routine stays as a fallback for a Tk build without PNG support (e.g. the test tkinter stub).
- app.py: the gear is drawn in MUT (matches the native window-control glyphs above it) at scaled(20), instead of harsh FG at scaled(18).
- theme.py: Gear.TButton is flat on the header at rest (bevel colours pinned to BG) and lights up to a clearly lighter BTN_BG chip on hover/focus, BTN_HOVER on press - a real button affordance.

## What and why

<!-- What does this change do, and why? Link any related issue, e.g. "Fixes #123". -->

## Checklist

- [ ] `python -m pytest tests` passes locally.
- [ ] New behaviour has tests (see `tests/` for the style).
- [ ] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [ ] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [ ] Commits follow Conventional Commits (`type(scope): summary`).
- [ ] No version bump - the owner closes a version via `VERSION.txt`.
