### PR TITLE
docs(readme): add a "What it can do" feature list to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ interface with tooltips and a command-line mode for CI.
 
 > This is the English documentation. Polish version: [README.pl.md](README.pl.md).
 
+**What it can do**
+
+- **Add lag and jitter** - fixed or random delay.
+- **Drop, corrupt or duplicate packets** - fake a flaky link.
+- **Cap download/upload speed** - throttle to a set KB/s.
+- **Tear connections down** - TCP resets or a dead link.
+- **Flap the link on and off** - outages that come and go.
+- **Block ports or IPs** - a small built-in firewall, plus LAN mode (no internet).
+- **Aim at one app** - by process, PID, IP or port.
+- **Presets and saved profiles** - 56k modem, Cafe WiFi, Satellite and more.
+- **Run scripted scenarios** - timed steps that change the network on their own.
+- **Reproducible by seed** - replay the exact same random loss and jitter.
+- **Watch it live** - chart, connections table, counters.
+- **Command-line mode** - scriptable for CI.
+- **No telemetry, fully offline** - sends no data anywhere.
+
 <p align="center">
   <img src="docs/demo.gif" alt="Bean Network Tester adding lag and packet loss to a live ping" width="820">
 </p>

--- a/README.pl.md
+++ b/README.pl.md
@@ -13,6 +13,22 @@ przechwytywanie ruchu sterownikiem **[WinDivert](https://www.reqrypt.org/windive
 **[PyDivert](https://github.com/ffalcinelli/pydivert)**) i daje zarówno czytelny interfejs okienkowy
 z podpowiedziami, jak i tryb wiersza poleceń do CI.
 
+**Co potrafi**
+
+- **Dodaje opóźnienie i jitter** - stałe lub losowe.
+- **Gubi, uszkadza i duplikuje pakiety** - udaje kapryśne łącze.
+- **Ogranicza prędkość pobierania/wysyłania** - dławi do zadanych KB/s.
+- **Zrywa połączenia** - resety TCP albo martwe łącze.
+- **Miga łączem** - przerwy, które przychodzą i znikają.
+- **Blokuje porty lub adresy IP** - mały wbudowany firewall, plus tryb LAN (bez internetu).
+- **Celuje w jedną aplikację** - po nazwie procesu, PID, IP lub porcie.
+- **Presety i zapisane profile** - modem 56k, kawiarniane WiFi, łącze satelitarne i więcej.
+- **Odtwarza skryptowane scenariusze** - kroki w czasie, które same zmieniają sieć.
+- **Powtarzalne dzięki seedowi** - odtwórz te same losowe straty i jitter.
+- **Podgląd na żywo** - wykres, tabela połączeń, liczniki.
+- **Tryb wiersza poleceń** - skryptowalny do CI.
+- **Zero telemetrii, w pełni offline** - niczego nigdzie nie wysyła.
+
 <p align="center">
   <img src="docs/demo.gif" alt="Bean Network Tester dodający opóźnienie i straty pakietów do działającego pinga" width="820">
 </p>


### PR DESCRIPTION
A short, plain-language bullet list of what the tool does sits between the intro and the demo gif, so a visitor grasps the capabilities at a glance: impairments, speed cap, connection tear-down, flapping, the built-in firewall + LAN mode, per-app targeting, presets/profiles, scripted scenarios, seed reproducibility, the live view, the CLI, and the no-telemetry stance. Mirrored in README.pl.md.

## What and why

<!-- What does this change do, and why? Link any related issue, e.g. "Fixes #123". -->

## Checklist

- [ ] `python -m pytest tests` passes locally.
- [ ] New behaviour has tests (see `tests/` for the style).
- [ ] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [ ] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [ ] Commits follow Conventional Commits (`type(scope): summary`).
- [ ] No version bump - the owner closes a version via `VERSION.txt`.
