### PR TITLE
fix(gui): make the profile picker the same dropdown as the traffic fi…

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,49 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI: the profile picker is a ttk.Combobox again (convention 41)
+
+- **`gui/pages/control.py::_build_profiles`: `ttk.Menubutton` + `tk.Menu` -> `ttk.Combobox`**
+  (readonly, no named style - the shared `TCombobox` look), bound to
+  `App.on_profile_selected` (`unhighlight_combobox` + `load_selected_profile`), i.e. exactly
+  how the traffic filter is built in `form.py`. The menu was introduced so group headings
+  could be rendered non-pickable, but the headings had already been dropped from the menu, so
+  all it still bought was a dropdown that could not be made to match: **on Windows a `tk.Menu`
+  is a native Win32 popup**, so its frame (a light system border), its width (no `-width`
+  option, so it is sized to the longest label instead of to the button) and the highlight on
+  the current entry are outside Tk's reach - no amount of styling closes that gap.
+- **Group headings dropped entirely** (owner's decision, convention 41: every row in a list
+  must DO something). `App.profile_names()` is now `presets + own profiles`, full stop;
+  `App._profile_separators` and the snap-back branch in `App.load_selected_profile` are gone,
+  `_is_reserved_profile_name` is down to the preset check (a user profile may now be called
+  "Presets"), and the `profiles.presets_separator` / `profiles.mine_separator` keys are
+  deleted from `lang/en.json` + `lang/pl.json`. `smoke_gui.py`'s separator check is replaced
+  by one asserting the picker offers presets then own profiles and nothing else.
+- **Removed:** `App._rebuild_profile_menu`, `App._post_profile_menu` (a workaround for the
+  Menubutton's post-on-mouse-down toggle - a combobox has no such problem), the
+  `App.profile_menu` attribute, the `Profile.TMenubutton` layout/configure/map and the bare
+  `TMenubutton` styles in `gui/theme.py`, and the `like_combobox` parameter of
+  `theme.style_menu` (context menus were its only other caller). `App.profile_mb` ->
+  `App.profile_cb`.
+- **`theme.popdown_height(values)`** (+ `POPDOWN_ROWS = 20`) is now the single source for the
+  "a list that fits must not spawn the popdown scrollbar" rule, used by the profile picker,
+  the traffic filter (`form.py`) and the language box (`panels/settings.py`), which each had
+  their own `height=len(...)`. The profile list is the only one the user can grow without
+  limit, hence the cap at ttk's own default rather than a dropdown taller than the screen.
+  `App._sync_profile_widgets` now refills `values=`/`height=` instead of rebuilding a menu.
+- **Tests:** `test_gui_release_fixes.py::test_profile_menu_has_no_indicator_gutter` and
+  `::test_profile_picker_uses_the_combobox_field_style` (both about the retired Menubutton)
+  replaced by `::test_profile_picker_is_the_same_widget_as_the_traffic_filter`, which checks
+  the built widget (readonly, no style override, `values` == `profile_names()`, `height` ==
+  item count) AND greps `gui/pages/control.py` for `Menubutton`/`tk.Menu(`, so the imitation
+  cannot come back.
+- **PROJECT_NOTES convention 41** rewritten with two lessons: same role -> same widget (do not
+  imitate a sibling widget with styles - the imitation has a ceiling that is invisible in the
+  code), and every row in a list must do something. The stale "405 keys per lang file" figure
+  in the repo-structure section (really 465) was replaced by the command that counts them -
+  a number copied out of its source file drifts, which is exactly what convention "one fact,
+  one source" is about.
+
 ### Docs: intro wording and third-party links
 
 - **README intro (EN + PL)** reworded: leads with the product name (branding + the auto-snippet),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,18 +152,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 - **The traffic-filter dropdown no longer keeps a highlight after you pick a value.** The
   combobox held keyboard focus after a selection, leaving it outlined as if still active.
 - **Short dropdowns no longer show a stray scrollbar.** Lists that already fit (traffic filter,
-  language) used to draw a light scrollbar strip down the side for nothing.
-- **The profile picker lost a stray left indent.** A leftover indicator column from the removed
-  selection checkbox left an empty gap in front of every entry.
-- **The profile picker now matches the traffic-filter dropdown.** It was a flat button next to a
-  proper field; it now has the same outlined field and boxed arrow, so the two read as siblings.
+  profiles, language) used to draw a light scrollbar strip down the side for nothing.
+- **The profile list now looks exactly like the traffic-filter list.** It was built differently
+  under the hood, so it opened as a pale, system-drawn list with a light border, a width of its
+  own and no highlight on the profile you are using. It is now the same kind of dropdown as
+  every other one in the app: same dark colours, same width as the box above it, and your
+  current profile highlighted when it opens.
+- **The profile list no longer has "Presets" and "My profiles" rows.** They were headings you
+  could click and get nothing from. The list is now just the profiles themselves - the ready-made
+  ones first, your own saved ones after them.
 - **The Connections highlight follows the current target, not a flow's last packet.** A connection
   that was in scope before you narrowed the target (e.g. to `chrome`) kept its amber highlight and
   "yes" in the scope column while sitting idle, so unrelated apps like `firefox` looked like they
   were being hit. The highlight and that column are now recomputed against the target as it stands.
-- **The profile dropdown now opens reliably.** The profile picker could intermittently
-  refuse to open (it toggled shut again on the same click); it now posts on click every
-  time, and the list is always current.
 - **Connection rows are highlighted only when a target is actually narrowing the traffic.**
   With no target set, every connection is in scope, so the whole table used to be
   highlighted for nothing. The highlight now appears only when some connections are targeted

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -58,7 +58,8 @@ from .scaling import (geometry_fits, init_scaling, initial_geometry,
                       max_window_size, min_window_size, scaled)
 from .scrollable import WheelDispatcher
 from .theme import (BG, FIELD, FG, MONO_FONT, MUT, apply_dark_titlebar,
-                    disable_maximize, init_style)
+                    disable_maximize, init_style, popdown_height,
+                    unhighlight_combobox)
 from .tooltip import add_tooltip
 from .ui_state import DEFAULTS as UI_DEFAULTS, UiStateStore
 from . import prefs
@@ -191,8 +192,7 @@ class App:
         self._summary_text = None
         self._dirty_style = None
         self.scenario_lbl = None
-        self.profile_mb = None        # the profile picker (a grouped Menubutton)
-        self.profile_menu = None      # its dropdown menu (rebuilt on every change)
+        self.profile_cb = None        # the profile picker (the same widget as the filter)
         self.btn_delete_profile = None
         self.target_warning = None      # "no process matched" banner
 
@@ -785,19 +785,18 @@ class App:
         return [self._short_label(key) for key in non_profile_active(s)]
 
     def _is_reserved_profile_name(self, name):
-        """True for names taken by built-in presets (any language) / separators."""
-        if name in getattr(self, "_profile_separators", ()):
-            return True
+        """True for names taken by a built-in preset (in any language)."""
         return resolve_preset(name) is not None
 
     def profile_names(self):
+        """Everything the picker offers: presets first, then the user's own.
+
+        Nothing else - no group headings. The dropdown sits under the "Profiles"
+        heading and every row in it is a profile, so a row that only says which
+        group comes next is a row the user can pick and get nothing from.
+        """
         self._preset_disp2canon = {T(k): k for k in PRESETS}
-        self._profile_separators = {T("profiles.presets_separator"),
-                                    T("profiles.mine_separator")}
-        names = [T("profiles.presets_separator")] + [T(k) for k in PRESETS]
-        if self.profiles:
-            names += [T("profiles.mine_separator")] + self.profiles.names()
-        return names
+        return [T(k) for k in PRESETS] + self.profiles.names()
 
     def profile_label(self, key):
         """Displayed name of a profile id (presets are translated, own ones are not)."""
@@ -808,10 +807,14 @@ class App:
         return getattr(self, "_preset_disp2canon", {}).get(label, label)
 
     def _sync_profile_widgets(self):
-        """Rebuild the profile menu, show the selection, gate the Delete button."""
-        if self.profile_mb is None:
+        """Refill the profile list, show the selection, gate the Delete button."""
+        if self.profile_cb is None:
             return
-        self._rebuild_profile_menu()
+        try:
+            names = self.profile_names()      # also refreshes the label<->key lookups
+            self.profile_cb.config(values=names, height=popdown_height(names))
+        except Exception as _exc:
+            crashlog.note(_exc, "gui.app")
         try:
             self.profile_var.set(self.profile_label(self._profile_key))
         except Exception as _exc:
@@ -826,65 +829,10 @@ class App:
             except Exception as _exc:
                 crashlog.note(_exc, "gui.app")
 
-    def _rebuild_profile_menu(self):
-        """Fill the profile dropdown: presets, then the user's own profiles.
-
-        A plain, crisp list. There are no group HEADINGS: a disabled menu entry
-        renders as muddy, washed-out text that reads as "blurry" next to the
-        real items, and a menu radiobutton's native tick renders as a stretched
-        blob at high DPI. The two groups are separated by a rule instead, and the
-        current profile is shown in the button itself (``textvariable``), so the
-        menu needs no in-list marker. The old combobox could not do this - it
-        listed the headings as pickable options that snapped back - which is why
-        this is a menu, but the headings themselves are gone.
-        """
-        menu = self.profile_menu
-        if menu is None:
-            return
-        self.profile_names()          # refresh the display<->key lookups it maintains
-        try:
-            menu.delete(0, "end")
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.app")
-        try:
-            # hidemargin drops the empty indicator column tk.Menu reserves for a
-            # check/radio tick: this menu has none, and the leftover gutter read as
-            # a stray indent (a ghost of the removed checkbox).
-            for key in PRESETS:
-                menu.add_command(label=T(key), hidemargin=True,
-                                 command=lambda k=key: self.select_profile(k))
-            if self.profiles:
-                menu.add_separator()
-                for name in self.profiles.names():
-                    menu.add_command(label=name, hidemargin=True,
-                                     command=lambda k=name: self.select_profile(k))
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.app")
-
-    def _post_profile_menu(self, _event=None):
-        """Open the profile menu explicitly (see the bind in ``control.py``).
-
-        A ttk.Menubutton posts on mouse-down and a quick release can toggle it
-        shut again; rebuilding and posting it here on click is deterministic and
-        keeps the list current. Returns ``"break"`` so the default toggle does
-        not also run.
-        """
-        if self.profile_mb is None:
-            return None
-        self._rebuild_profile_menu()
-        mb, menu = self.profile_mb, self.profile_menu
-        try:
-            x = mb.winfo_rootx()
-            y = mb.winfo_rooty() + mb.winfo_height()
-            menu.tk_popup(x, y)
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.app")
-        finally:
-            try:
-                menu.grab_release()
-            except Exception as _exc:
-                crashlog.note(_exc, "gui.app")
-        return "break"
+    def on_profile_selected(self, event=None):
+        """``<<ComboboxSelected>>`` on the profile picker."""
+        unhighlight_combobox(event)      # readonly comboboxes stay "selected" otherwise
+        self.load_selected_profile()
 
     def select_profile(self, key):
         """Fill the form from a preset/profile id. Never applies by itself."""
@@ -904,17 +852,12 @@ class App:
             self.log(T("log.apply_needed"))
 
     def load_selected_profile(self):
-        """Load whatever ``profile_var`` currently names (compat entry point).
+        """Load whatever ``profile_var`` currently names.
 
-        The menu radiobuttons call ``select_profile`` directly; this remains for
-        callers that set ``profile_var`` and expect it to take effect, and it
-        ignores the non-selectable group headings.
+        Every row in the picker is a real profile (``profile_names``), so there
+        is nothing to pick that does not load something.
         """
-        label = self.profile_var.get()
-        if label in getattr(self, "_profile_separators", ()):
-            self._sync_profile_widgets()
-            return
-        self.select_profile(self.profile_key_for(label))
+        self.select_profile(self.profile_key_for(self.profile_var.get()))
 
     def save_profile(self):
         # warn up front (once, contextually) when active settings fall outside the

--- a/beantester/gui/form.py
+++ b/beantester/gui/form.py
@@ -31,7 +31,7 @@ from . import dialogs
 from .accordion import CollapsibleSection
 from .labels import wrapping_label
 from .scaling import scaled
-from .theme import unhighlight_combobox
+from .theme import popdown_height, unhighlight_combobox
 from .tooltip import add_tooltip
 from .. import crashlog
 
@@ -198,11 +198,8 @@ class ControlForm:
             var = app.vars[field.key]
             if var.get() not in display:
                 var.set(display[0])
-            # height = item count: a short list must not spawn a popdown scrollbar
-            # (it renders as a light bar against the near-black dropdown - an eyesore
-            # for a list that fits without scrolling)
             widget = ttk.Combobox(row, textvariable=var, values=display,
-                                  state="readonly", height=len(display))
+                                  state="readonly", height=popdown_height(display))
             widget.pack(side="left", fill="x", expand=True)
             widget.bind("<<ComboboxSelected>>", self._on_choice, add="+")
             add_tooltip(widget, field.tip)

--- a/beantester/gui/pages/control.py
+++ b/beantester/gui/pages/control.py
@@ -3,7 +3,6 @@
 Contains no natively scrollable widget (no Treeview/Text), which is the rule
 that keeps the mouse-wheel dispatcher unambiguous.
 """
-import tkinter as tk
 from tkinter import ttk
 
 from ...i18n import T
@@ -11,7 +10,7 @@ from ..form import ControlForm
 from ..labels import wrapping_label
 from ..scaling import scaled
 from ..scrollable import ScrollableFrame
-from ..theme import style_menu
+from ..theme import popdown_height
 from ..tooltip import add_tooltip
 
 
@@ -72,27 +71,26 @@ class ControlPage:
         app = self.app
         row = ttk.Frame(body, style="Card.TFrame")
         row.pack(fill="x", pady=(scaled(6), 0))
-        # A grouped MENU, not a combobox: "-- presets --" / "-- mine --" are group
-        # headings, and a menu can render them disabled so they cannot be picked.
-        # The combobox listed them as ordinary options that silently snapped back.
-        app.profile_mb = ttk.Menubutton(row, textvariable=app.profile_var,
-                                        width=24, direction="below",
-                                        style="Profile.TMenubutton")
-        app.profile_menu = style_menu(tk.Menu(app.profile_mb, tearoff=0),
-                                      like_combobox=True)
-        app.profile_mb["menu"] = app.profile_menu
-        # Post the menu ourselves on click: a ttk.Menubutton posts on mouse-down
-        # and the quick release can toggle it straight back shut, which is the
-        # intermittent "the profile dropdown would not open". Doing it explicitly
-        # is deterministic and rebuilds the list so it is always current.
-        app.profile_mb.bind("<Button-1>", app._post_profile_menu)
-        app.profile_mb.pack(side="left")
+        # The SAME widget as the traffic filter, deliberately: a dropdown built
+        # from a tk.Menu can never match a combobox popdown, because on Windows a
+        # menu is a native Win32 popup - Tk styles reach the entries but not the
+        # frame Windows draws around it (a light border), the width cannot be tied
+        # to the button, and the current entry is not highlighted on open. Two
+        # pickers sitting on the same page must not look like two different tools.
+        # Group headings stay in the list and snap back when picked (see
+        # App.load_selected_profile).
+        names = app.profile_names()
+        app.profile_cb = ttk.Combobox(row, textvariable=app.profile_var,
+                                      values=names, state="readonly", width=24,
+                                      height=popdown_height(names))
+        app.profile_cb.bind("<<ComboboxSelected>>", app.on_profile_selected)
+        app.profile_cb.pack(side="left")
         save = ttk.Button(row, text=T("buttons.save_as"), command=app.save_profile)
         save.pack(side="left", padx=scaled(6))
         delete = ttk.Button(row, text=T("buttons.delete"), command=app.delete_profile)
         delete.pack(side="left")
         app.btn_delete_profile = delete
-        add_tooltip(app.profile_mb, "tips.profiles")
+        add_tooltip(app.profile_cb, "tips.profiles")
         add_tooltip(save, "tips.save_profile")
         add_tooltip(delete, "tips.delete_profile")
 

--- a/beantester/gui/panels/settings.py
+++ b/beantester/gui/panels/settings.py
@@ -25,7 +25,7 @@ from ..accordion import CollapsibleSection
 from ..form import ControlForm
 from ..prefs import ACTION, BOOL, PREF_GROUPS, PREFS_BY_KEY
 from ..scaling import scaled
-from ..theme import unhighlight_combobox
+from ..theme import popdown_height, unhighlight_combobox
 from ..tooltip import add_tooltip
 from ..windows import PanelWindow, register_window
 
@@ -51,7 +51,7 @@ class SettingsWindow(PanelWindow):
         names = [name for _, name in available_languages()]
         cb = ttk.Combobox(lang_row, textvariable=app.lang_var, values=names,
                           state="disabled" if app.running else "readonly",
-                          width=14, height=len(names))
+                          width=14, height=popdown_height(names))
         cb.pack(side="left", padx=(scaled(8), 0))
         # Switching the language rebuilds the whole UI (and this window with it),
         # so it is not safe mid-session - locked exactly like on the header before.

--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -231,49 +231,11 @@ def init_style(root=None):
           selectbackground=[("readonly", FIELD), ("!focus", FIELD)],
           selectforeground=[("readonly", FG), ("!focus", FG)])
 
-    # -- menubutton (the profile picker: a grouped menu, not a combobox) ----- #
-    # Styled to read like the old combobox (dark field + a down arrow), so the
-    # only visible change is that its dropdown groups presets and own profiles
-    # under headings that cannot be picked.
-    s.configure("TMenubutton", background=FIELD, foreground=FG, arrowcolor=MUT,
-                bordercolor=BORDER, lightcolor=BORDER, darkcolor=BORDER,
-                relief="flat", borderwidth=1, padding=scaled(3), focuscolor=FIELD,
-                anchor="w")
-    s.map("TMenubutton",
-          background=[("disabled", DIS_BG), ("focus", "#20242e"), ("active", "#20242e")],
-          foreground=[("disabled", DIS_FG)],
-          arrowcolor=[("disabled", DIS_FG)],
-          bordercolor=[("disabled", DIS_BG), ("focus", ACC), ("active", ACC)],
-          lightcolor=[("focus", ACC), ("active", ACC)],
-          darkcolor=[("focus", ACC), ("active", ACC)])
-
-    # The profile picker must read like the traffic-filter combobox: a FLAT dark
-    # field, no raised arrow button. Borrow the combobox's own field element (same
-    # outline + fieldbackground, so the two are pixel-siblings), but for the arrow
-    # use the plain ``Menubutton.indicator`` triangle - NOT ``Combobox.downarrow``.
-    # clam draws the downarrow as a bordered, sunken button (a lighter #39404e box
-    # around the arrow), which stood out as a "white arrow" next to the flat filter
-    # combobox; the menubutton indicator is a bare triangle with no box. The label
-    # still comes from the menubutton (textvariable) and clicking posts the grouped
-    # menu. See gui/pages/control.py.
-    try:
-        s.layout("Profile.TMenubutton", [
-            ("Combobox.field", {"sticky": "nswe", "children": [
-                ("Menubutton.indicator", {"side": "right", "sticky": ""}),
-                ("Combobox.padding", {"sticky": "nswe", "children": [
-                    ("Menubutton.label", {"sticky": "w"})]})]})])
-    except Exception as _exc:
-        crashlog.note(_exc, "gui.theme")
-    s.configure("Profile.TMenubutton", fieldbackground=FIELD, background=FIELD,
-                foreground=FG, arrowcolor=MUT, bordercolor=BORDER, lightcolor=BORDER,
-                darkcolor=BORDER, borderwidth=1, padding=scaled(2), anchor="w")
-    s.map("Profile.TMenubutton",
-          fieldbackground=[("disabled", DIS_BG)],
-          foreground=[("disabled", DIS_FG)],
-          arrowcolor=[("disabled", DIS_FG)],
-          bordercolor=[("disabled", DIS_BG), ("focus", ACC), ("active", ACC)],
-          lightcolor=[("focus", ACC), ("active", ACC)],
-          darkcolor=[("focus", ACC), ("active", ACC)])
+    # NOTE: the profile picker is a plain readonly TCombobox on purpose - it used
+    # to be a Menubutton + tk.Menu styled to imitate one, and the imitation could
+    # never be finished: on Windows a tk.Menu is a native Win32 popup, so its
+    # frame, its width and the highlight on the current entry are outside Tk's
+    # reach. Two dropdowns on the same page must be the same widget.
 
     # -- scrollbars --------------------------------------------------------- #
     for orient in ("Vertical.TScrollbar", "Horizontal.TScrollbar"):
@@ -408,17 +370,14 @@ def apply_dark_titlebar(window):
     return False
 
 
-def style_menu(menu, like_combobox=False):
+def style_menu(menu):
     """Dark-theme a classic ``tk.Menu`` (ttk styles do not reach it).
 
-    ``like_combobox`` paints the menu like a readonly combobox's popdown - the
-    darker ``FIELD`` surface used by ``*TCombobox*Listbox`` in ``init_style`` -
-    so the profile picker's dropdown matches the traffic-filter combobox it sits
-    next to (a menu on the lighter ``BG2`` card colour read as a different, paler
-    control). Context menus keep the default card colour.
+    Only context menus use this now - a menu is never a stand-in for a dropdown
+    (see the note next to the combobox styles in ``init_style``).
     """
     try:
-        menu.configure(background=FIELD if like_combobox else BG2, foreground=FG,
+        menu.configure(background=BG2, foreground=FG,
                        activebackground=ACC, activeforeground="#0c1220",
                        disabledforeground=DIS_FG, selectcolor=ACC,
                        borderwidth=0, relief="flat", activeborderwidth=0,
@@ -426,6 +385,22 @@ def style_menu(menu, like_combobox=False):
     except Exception as _exc:
         crashlog.note(_exc, "gui.theme")
     return menu
+
+
+POPDOWN_ROWS = 20                 # ttk's own default popdown height, in rows
+
+
+def popdown_height(values):
+    """Rows to give a combobox popdown so a list that FITS gets no scrollbar.
+
+    ttk adds the popdown scrollbar as soon as the list is longer than ``height``,
+    and it renders as a light bar over the near-black dropdown - an eyesore for a
+    list that would fit anyway. Asking for exactly as many rows as there are
+    values removes it; past ``POPDOWN_ROWS`` we fall back to ttk's own default
+    instead of growing a dropdown taller than the screen (the profile list is the
+    only one the user can grow without limit).
+    """
+    return min(len(values), POPDOWN_ROWS)
 
 
 def unhighlight_combobox(event=None, widget=None):

--- a/lang/en.json
+++ b/lang/en.json
@@ -305,8 +305,6 @@
   "presets.satellite": "Satellite link",
   "presets.terrible": "Terrible network",
   "presets.weak_wifi": "Weak WiFi",
-  "profiles.mine_separator": "My profiles",
-  "profiles.presets_separator": "Presets",
   "session.avg_rate": "Avg throughput",
   "session.down_mb": "Downloaded (MB)",
   "session.duration": "Duration",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -305,8 +305,6 @@
   "presets.satellite": "Łącze satelitarne",
   "presets.terrible": "Fatalna sieć",
   "presets.weak_wifi": "Słabe WiFi",
-  "profiles.mine_separator": "Moje profile",
-  "profiles.presets_separator": "Presety",
   "session.avg_rate": "Śr. przepustowość",
   "session.down_mb": "Pobrano (MB)",
   "session.duration": "Czas trwania",

--- a/smoke_gui.py
+++ b/smoke_gui.py
@@ -121,7 +121,7 @@ app.lang_var.set("Polski")
 app._switch_language()
 check("GUI: switch back to Polish", app._lang == "pl")
 
-# -- profiles: scope warning, reserved names, separator selection -------------
+# -- profiles: scope warning, reserved names ----------------------------------
 # (the app uses its own themed dialogs, not the native white message boxes)
 import beantester.gui.dialogs as _dlg             # noqa: E402
 warnings, errors = [], []
@@ -149,10 +149,9 @@ _dlg.ask_string = lambda *a, **k: "Moje VPN"
 app._save_profile()
 check("GUI: valid profile name is saved", app.profiles.names() == ["Moje VPN"])
 
-app.profile_var.set(n.T("profiles.presets_separator"))
-app._load_selected_profile()
-check("GUI: selecting a separator restores the previous selection",
-      app.profile_var.get() == "Moje VPN", f"(got={app.profile_var.get()!r})")
+check("GUI: the picker offers presets then own profiles, nothing else",
+      app._profile_names() == [n.T(k) for k in n.PRESETS] + ["Moje VPN"],
+      f"({app._profile_names()[-3:]})")
 
 # -- preset only fills the form; it never applies by itself -------------------
 app.profile_var.set(n.T("presets.terrible"))

--- a/tests/test_gui_release_fixes.py
+++ b/tests/test_gui_release_fixes.py
@@ -1,4 +1,6 @@
 """GUI regressions for the 1.3 release fixes (run on the fake tkinter)."""
+from pathlib import Path
+
 from gui_harness import run_gui
 
 
@@ -106,7 +108,7 @@ def test_tooltip_is_suppressed_while_a_dropdown_is_open():
     covering the very options the user was about to pick."""
     run_gui("""
         from beantester.gui import tooltip
-        w = app.profile_mb
+        w = app.profile_cb
 
         assert tooltip._grab_active(w) is False           # nothing grabbing yet
 
@@ -127,13 +129,22 @@ def test_short_dropdowns_do_not_spawn_a_popdown_scrollbar():
     """)
 
 
-def test_profile_menu_has_no_indicator_gutter():
-    """The removed checkbox left tk.Menu's indicator column as a stray left indent;
-    hidemargin on every entry drops it."""
+def test_profile_picker_is_the_same_widget_as_the_traffic_filter():
+    """Conv 41: a dropdown looks like its sibling by BEING it. The picker spent a
+    while as a Menubutton + tk.Menu imitating a combobox, and the imitation could
+    not be finished - on Windows a tk.Menu is a native Win32 popup, so its frame,
+    its width and the highlight on the current row are outside Tk's reach."""
+    source = (Path(__file__).resolve().parents[1]
+              / "beantester" / "gui" / "pages" / "control.py").read_text(encoding="utf-8")
+    assert "ttk.Combobox(" in source
+    assert "Menubutton" not in source and "tk.Menu(" not in source
     run_gui("""
-        app._rebuild_profile_menu()
-        items = [c for c in app.profile_menu.commands if "separator" not in c]
-        assert items and all(c.get("hidemargin") for c in items), app.profile_menu.commands
+        cb = app.profile_cb
+        assert cb.kw.get("state") == "readonly", cb.kw
+        assert not cb.kw.get("style"), cb.kw        # the plain, shared TCombobox look
+        assert list(cb.kw["values"]) == app.profile_names(), cb.kw
+        # a list that fits must not spawn the popdown scrollbar
+        assert cb.kw["height"] == len(app.profile_names()), cb.kw
     """)
 
 
@@ -152,14 +163,6 @@ def test_shortcut_buttons_advertise_their_key():
     run_gui("""
         assert "F5" in app.btn_start._bnt_tooltip.text, app.btn_start._bnt_tooltip.text
         assert "Ctrl+Enter" in app.btn_apply._bnt_tooltip.text, app.btn_apply._bnt_tooltip.text
-    """)
-
-
-def test_profile_picker_uses_the_combobox_field_style():
-    """The profile Menubutton borrows the combobox field+downarrow so the two read
-    as siblings instead of a flat button next to a proper field."""
-    run_gui("""
-        assert app.profile_mb.kw.get("style") == "Profile.TMenubutton", app.profile_mb.kw
     """)
 
 


### PR DESCRIPTION
…lter

The picker was a ttk.Menubutton + tk.Menu styled to imitate a combobox. The imitation could not be finished: on Windows a tk.Menu is a native Win32 popup, so its frame (a light system border), its width (no -width option, so it is sized to the longest label instead of to the button) and the highlight on the current entry are outside Tk's reach. It is a plain readonly ttk.Combobox again
- the widget the traffic filter uses - so the two are siblings by construction rather than by styling (convention 41).

The menu existed so group headings could be rendered non-pickable, but the headings had already been dropped from it, and they are now gone for good: a dropdown sitting under the "Profiles" heading does not need rows explaining that it contains profiles, and a row the user can click for nothing is a bug. profile_names() is presets + own profiles, full stop.

Removed with them: App._rebuild_profile_menu / _post_profile_menu (a workaround for the Menubutton's post-on-mouse-down toggle), App._profile_separators, the Profile.TMenubutton and TMenubutton styles, style_menu's like_combobox flag and the profiles.*_separator i18n keys. theme.popdown_height() is now the single source for "a list that fits must not spawn the popdown scrollbar", shared by the profile, traffic-filter and language boxes.

Verified on real Tk (tools/ci_gui_render.py, en + pl), the fake-tk smoke and the full pytest run.


