### PR TITLE
fix(gui): remember the last profile when it is one of the user's own

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -60,6 +60,28 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   a number copied out of its source file drifts, which is exactly what convention "one fact,
   one source" is about.
 
+### GUI fix: "restore the last profile" ignored the user's own profiles
+
+- **`App._set_profile_key(key)` is now the single writer of `_profile_key`** (`gui/app.py`).
+  Three paths change the current profile - `select_profile`, `save_profile`, `delete_profile` -
+  but only the first also wrote `ui["profile"]`, the key the `restore_profile` preference reads
+  on startup. Since **saving** is how a user ends up on their own profile, the preference
+  restored the preset picked before the save; picking an own profile from the list already
+  worked, which is why this looked like "it does not work for custom profiles". `delete_profile`
+  now remembers the fallback (`DEFAULT_PROFILE`) instead of the deleted name.
+- **The key is persisted on the spot** (`ui.persist()` inside `_set_profile_key`), the rule
+  `set_pref` already follows: a deliberate user choice must survive an unclean exit, unlike
+  session state written in `on_close`. One small atomic write per profile change.
+- **`App.__init__` keeps a plain `self._profile_key = DEFAULT_PROFILE`** (commented): routing it
+  through `_set_profile_key` would write the default into `ui.json` before
+  `_restore_last_profile` reads the remembered one.
+- **`_restore_last_profile` clears a dead pointer**: a name that resolves to neither a preset nor
+  a stored profile (deleted by hand, `profiles.json` quarantined as corrupt, removed by another
+  instance) is still ignored without an error, but `ui["profile"]` is reset so the file stops
+  carrying a ghost.
+- **Test:** `tests/test_prefs.py::test_restore_last_profile_covers_the_users_own_profiles` -
+  save remembers, delete falls back, a vanished profile is ignored AND forgotten.
+
 ### Docs: intro wording and third-party links
 
 - **README intro (EN + PL)** reworded: leads with the product name (branding + the auto-snippet),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **"Restore the last profile on startup" now works for your own profiles.** Saving a profile
+  makes it the one you are using, but the tool remembered only profiles picked from the list -
+  so after "Save...", closing and reopening the app brought back whichever ready-made profile you
+  had picked before saving. Your choice is also written to disk the moment you make it, so it
+  survives even if the app is killed rather than closed. Deleting a profile no longer leaves the
+  setting pointing at it, and a profile that disappears while the app is closed is simply
+  ignored on the next start, as before.
+
 - **Secondary windows now open with the dark title bar right away.** The About, Settings and
   Event-log windows briefly showed a white Windows title bar until you clicked them; they now
   paint dark from the moment they open.

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -172,6 +172,9 @@ class App:
         # NOT the displayed text: preset names are translated, so storing the label
         # meant that switching the language left the combobox showing an English
         # name over a Polish list (and any lookup by that name failed).
+        # A plain assignment on purpose: _set_profile_key() would write this
+        # default into ui.json before _restore_last_profile() gets to read the
+        # remembered one.
         self._profile_key = DEFAULT_PROFILE
         self.profile_var = tk.StringVar(value="")
         self.loop_var = tk.BooleanVar(value=False)
@@ -223,8 +226,16 @@ class App:
         if not self.pref("restore_profile"):
             return
         key = str(self.ui.get("profile", "") or "")
-        if key and (key in PRESETS or key in self.profiles):
+        if not key:
+            return
+        if key in PRESETS or key in self.profiles:
             self.select_profile(key)
+        else:
+            # the profile is gone (deleted by hand, file quarantined as corrupt,
+            # removed by another instance): forget it instead of carrying a name
+            # that will never resolve again
+            self.ui.set("profile", "")
+            self.ui.persist()
 
     def _reveal(self):
         """Show the window once it is laid out (see the withdraw() above)."""
@@ -834,13 +845,27 @@ class App:
         unhighlight_combobox(event)      # readonly comboboxes stay "selected" otherwise
         self.load_selected_profile()
 
+    def _set_profile_key(self, key):
+        """Make ``key`` the current profile AND the one remembered for next start.
+
+        The single place that writes ``_profile_key``. It used to be written by
+        each of the three paths that change the current profile, and only one of
+        them (picking from the list) also remembered it - so saving a new profile,
+        which is how a user ENDS UP on their own profile, left "Restore the last
+        profile on startup" pointing at the preset picked before it. Persisting
+        right here, not on close, is the same rule preferences follow: a
+        deliberate choice must survive an unclean exit.
+        """
+        self._profile_key = key
+        self.ui.set("profile", key)
+        self.ui.persist()
+
     def select_profile(self, key):
         """Fill the form from a preset/profile id. Never applies by itself."""
         preset = PRESETS.get(key) or self.profiles.get(key)
         if not preset:
             return
-        self._profile_key = key
-        self.ui.set("profile", key)       # remembered for the restore-on-start pref
+        self._set_profile_key(key)
         for setting, value in preset_to_settings(preset).items():
             self.vars[setting].set(number_string(value))
         self._sync_profile_widgets()
@@ -885,7 +910,7 @@ class App:
             dialogs.show_error(self.root, T("log.error"), T("dialogs.values_numbers"))
             return
         self._persist_profiles()
-        self._profile_key = name
+        self._set_profile_key(name)      # saving one also SELECTS it - remember that
         self._sync_profile_widgets()
         self.log(f"{T('log.profile_saved')}: {name}")
 
@@ -895,7 +920,8 @@ class App:
             return                    # presets are not deletable (button is disabled)
         self.profiles.delete(name)
         self._persist_profiles()
-        self._profile_key = DEFAULT_PROFILE
+        # remember what we fall back TO, not the name that no longer exists
+        self._set_profile_key(DEFAULT_PROFILE)
         self._sync_profile_widgets()
         self.log(f"{T('log.profile_deleted')}: {name}")
 

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -123,6 +123,39 @@ def test_restore_last_profile_fills_only_when_enabled():
     """)
 
 
+def test_restore_last_profile_covers_the_users_own_profiles():
+    """Saving a profile is how a user ends up ON their own profile, and that path
+    used to change the current profile without remembering it - so the restore
+    preference reopened on the preset picked before the save. Deleting one must
+    remember the fallback, not the name that no longer exists."""
+    run_gui("""
+        import beantester.gui.dialogs as _dlg
+        app.set_pref("restore_profile", True)
+        app.select_profile("presets.terrible")
+
+        _dlg.ask_string = lambda *a, **k: "My VPN"
+        app.save_profile()
+        assert app._profile_key == "My VPN", app._profile_key
+        assert app.ui.get("profile") == "My VPN", app.ui.get("profile")
+
+        # a fresh start would refill it, not the preset picked before the save
+        app.select_profile("presets.perfect")
+        app.ui.set("profile", "My VPN")
+        app._restore_last_profile()
+        assert app._profile_key == "My VPN", app._profile_key
+
+        app.delete_profile()
+        assert app.ui.get("profile") == "presets.perfect", app.ui.get("profile")
+
+        # a profile that vanished while the app was closed: ignored, and the dead
+        # pointer is dropped rather than kept forever
+        app.ui.set("profile", "gone for good")
+        app._restore_last_profile()
+        assert app._profile_key == "presets.perfect", app._profile_key
+        assert app.ui.get("profile") == "", app.ui.get("profile")
+    """)
+
+
 def test_settings_window_number_field_validates_before_persisting():
     """A numeric preference edited in the window persists only when valid, and
     paints the field red (without storing garbage) when it is not."""


### PR DESCRIPTION
"Restore the last profile on startup" only ever restored presets and profiles picked from the dropdown. Three paths change the current profile - select_profile, save_profile, delete_profile - and only the first also wrote ui["profile"], the key the preference reads on startup. Saving is how a user ends up ON their own profile, so after "Save..." the setting still pointed at the preset picked before the save, and the app reopened on that.

_set_profile_key() is now the single writer of _profile_key: it sets the key, remembers it and persists ui.json on the spot - the rule set_pref already follows, so a deliberate choice survives an unclean exit rather than waiting for on_close. __init__ keeps a plain assignment (commented), or the default would overwrite the remembered key before _restore_last_profile reads it.

Deleting a profile now remembers the fallback instead of the deleted name, and a profile that vanished while the app was closed (deleted by hand, profiles.json quarantined as corrupt, removed by another instance) is still ignored without an error - but the dead pointer is dropped instead of living in ui.json forever.

Guarded by tests/test_prefs.py::test_restore_last_profile_covers_the_users_own_profiles.
