### PR TITLE
fix(gui): stop the About window cutting its text and buttons staying lit

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,36 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI fixes: truncated About text, a button left highlighted, and a render check that lied
+
+- **`panels/about.py` uses `labels.wrapping_label` for every prose line** (author, copyright,
+  licence, licence terms, the no-telemetry line, the third-party heading). A plain `ttk.Label`
+  never wraps - it is CUT at the frame edge - and the helper written for exactly this was not
+  being used here. `pad` is `2 * 12 + 16`: the `padx` on both sides plus the few pixels a wrapped
+  `ttk.Label` requests on top of its `wraplength` (measured against the render check, not
+  guessed - at `pad=30` the widest wrapped line still overhung by 12 px).
+- **`App._release_focus()`, called from `App.open_window`.** ttk gives a button keyboard focus
+  when it is clicked and `theme.py` paints `focus` exactly like `active` (both -> `BTN_HOVER` +
+  `ACC` border), so closing a window handed focus back to the button that opened it and it kept
+  looking hovered. Focus goes to the toplevel instead, and the invoking widget's `active`/`focus`
+  flags are cleared - the same remedy `theme.unhighlight_combobox` applies to a readonly combobox.
+- **`tools/ci_gui_render.py` now FAILS on a truncated label** instead of filing every clipped
+  label under "it probably wraps". The split is `wraplength > 0` -> note (it re-wraps), no
+  `wraplength` -> `TRUNCATED LABEL`, which is a real defect. This check had been printing the two
+  About lines as harmless notes for as long as they had been broken.
+- **The render check also opens EVERY window in the `WINDOWS` registry** (it only ever opened
+  About), and runs against an **empty user state** - `UiStateStore`/`ProfileStore` are pointed at
+  a temp dir like `tests/gui_harness.py` does. It was reading the developer's own
+  `bean_network_tester_ui.json`, so the `--lang en` pass rendered whatever language that file
+  remembered (the "en" run was reporting Polish strings), and a saved geometry could have hidden
+  the very clipping the check exists to find.
+- **`tests/fake_tk.py`** models keyboard focus (`FOCUS`, `focus_set`/`focus_get`) and ttk state
+  flags (`W.states`, `state(["!active"])` sets/clears; `Root.state()` still answers `"normal"`,
+  since a toplevel's `state()` is the window state, not ttk flags).
+- **Tests:** `tests/test_windows.py::test_opening_a_window_takes_the_highlight_off_the_button_that_opened_it`
+  and `::test_every_prose_label_in_the_about_window_can_wrap`. Both were confirmed to fail against
+  the pre-fix code, and the render check was confirmed to report `2 truncated label(s)` on it.
+
 ### GUI: the profile picker is a ttk.Combobox again (convention 41)
 
 - **`gui/pages/control.py::_build_profiles`: `ttk.Menubutton` + `tk.Menu` -> `ttk.Combobox`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The "About" window no longer cuts off its text.** The licence sentence and the "sends no
+  data anywhere" line ran off the right edge and were simply chopped - in Polish, where the
+  sentences are longer than the English they were translated from. They now wrap to the width
+  of the window, at any size and any display scaling.
+- **A button no longer stays lit after you close the window it opened.** Clicking "About" or the
+  settings gear left the button looking as if the mouse were still hovering over it, for the rest
+  of the session.
+
 - **"Restore the last profile on startup" now works for your own profiles.** Saving a profile
   makes it the one you are using, but the tool remembered only profiles picked from the list -
   so after "Save...", closing and reopening the app brought back whichever ready-made profile you

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -613,7 +613,24 @@ class App:
         gets the dark title bar, the DPI sizing, the remembered geometry and the
         language-switch rebuild.
         """
+        self._release_focus()
         return self.windows.open(window_id)
+
+    def _release_focus(self):
+        """Take focus (and any stale hover) off the control that just acted.
+
+        ttk hands a button keyboard focus when it is clicked, and this theme paints
+        `focus` exactly like `active` - so a button that opened a window sat there
+        looking permanently hovered once that window was closed and focus came back
+        to it. Giving focus to the window itself is what ``unhighlight_combobox``
+        does about the same symptom on a readonly combobox.
+        """
+        with crashlog.quiet("gui.app"):
+            widget = self.root.focus_get()
+            if widget is not None and widget is not self.root:
+                with crashlog.quiet("gui.app"):
+                    widget.state(["!active", "!focus"])     # ttk widgets only
+            self.root.focus_set()
 
     def row_limit(self):
         """Most rows a table may show (0 = no limit).

--- a/beantester/gui/panels/about.py
+++ b/beantester/gui/panels/about.py
@@ -16,6 +16,7 @@ The donate button is here as well as in the header - deliberately. Being in two
 places is not clutter for a voluntary ask that funds the work; being nowhere near
 the "who made this" screen would be strange.
 """
+from functools import partial
 import tkinter as tk
 from tkinter import ttk
 import webbrowser
@@ -24,6 +25,7 @@ from ... import crashlog, legal
 from ...appinfo import (APP_NAME, AUTHOR, COPYRIGHT, LICENSE_NAME, SUPPORT_URL,
                         __version__)
 from ...i18n import T
+from ..labels import wrapping_label
 from ..scaling import scaled
 from ..theme import FIELD, FG, MONO_FONT, MUT
 from ..tooltip import add_tooltip
@@ -48,22 +50,30 @@ class AboutWindow(PanelWindow):
                   style="Muted.TLabel").pack(side="left", padx=(scaled(10), 0),
                                              anchor="s", pady=(0, scaled(3)))
 
-        ttk.Label(body, text=T("about.author", author=AUTHOR)).pack(
-            side="top", anchor="w", padx=pad)
-        ttk.Label(body, text=COPYRIGHT, style="Muted.TLabel").pack(
-            side="top", anchor="w", padx=pad, pady=(0, scaled(8)))
+        # Every line here is PROSE, and prose in a translation is longer than the
+        # English it was written from - the licence sentence and the privacy line
+        # both ran off the right edge and were simply cut. A plain ttk.Label never
+        # wraps; wrapping_label ties its wraplength to the window (see gui/labels.py).
+        # The pad allows for the padx below on BOTH sides, plus the few pixels a
+        # wrapped ttk.Label asks for on top of its wraplength (measured, not
+        # guessed: at pad=30 the widest wrapped line still overhung by 12 px).
+        line = partial(wrapping_label, body, pad=2 * 12 + 16)
+        line(text=T("about.author", author=AUTHOR), style="TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad)
+        line(text=COPYRIGHT, style="Muted.TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad, pady=(0, scaled(8)))
 
-        ttk.Label(body, text=T("about.license", license=LICENSE_NAME)).pack(
-            side="top", anchor="w", padx=pad)
-        ttk.Label(body, text=T("about.license_terms"), style="Muted.TLabel").pack(
-            side="top", anchor="w", padx=pad, pady=(0, scaled(8)))
+        line(text=T("about.license", license=LICENSE_NAME), style="TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad)
+        line(text=T("about.license_terms"), style="Muted.TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad, pady=(0, scaled(8)))
 
         # The privacy line is the one people came here to read.
-        ttk.Label(body, text=T("about.no_telemetry"), style="Good.TLabel").pack(
-            side="top", anchor="w", padx=pad, pady=(0, scaled(10)))
+        line(text=T("about.no_telemetry"), style="Good.TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad, pady=(0, scaled(10)))
 
-        ttk.Label(body, text=T("about.third_party")).pack(
-            side="top", anchor="w", padx=pad)
+        line(text=T("about.third_party"), style="TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad)
 
         # A read-only text box, not a table: this is prose plus links, and it has
         # to be selectable so someone can copy a URL into a browser or a ticket.

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -17,6 +17,7 @@ SCREEN = [1920, 1080]     # mutable: tests can pretend to be on a 1366x768 lapto
 DPI = [96.0]
 CLIPBOARD = []            # what the app copied (Ctrl+C, "copy row", repro CLI)
 GRAB = [None]             # what currently holds the Tk grab (an open popdown)
+FOCUS = [None]            # the widget holding keyboard focus (ttk paints it)
 
 
 class TclError(Exception):
@@ -44,6 +45,7 @@ class W:
         self.pack_info = None
         self.grid_info = None
         self.bindings = {}
+        self.states = set()         # ttk widget state flags (active, focus, ...)
         master = args[0] if args else kw.get("master")
         self.master = master if isinstance(master, W) else None
         if isinstance(master, W):
@@ -187,8 +189,26 @@ class W:
             self.kw["minsize"] = tuple(a)
         return self.kw.get("minsize")
 
-    def state(self, *a):
-        return "normal"
+    def focus_set(self):
+        FOCUS[0] = self
+
+    focus_force = focus_set
+
+    def focus_get(self):
+        return FOCUS[0]
+
+    def state(self, spec=None):
+        """ttk state flags: ``state(["!active"])`` clears one, ``["active"]`` sets it.
+
+        A Toplevel's ``state()`` is a different call (window state), so with no
+        argument the Root keeps answering "normal" - see Root.state below.
+        """
+        for flag in spec or ():
+            if str(flag).startswith("!"):
+                self.states.discard(str(flag)[1:])
+            else:
+                self.states.add(str(flag))
+        return tuple(sorted(self.states))
 
     def after(self, _ms, func=None, *a):
         return None                 # timers never fire on their own in the fake
@@ -211,6 +231,10 @@ class W:
 
 
 class Root(W):
+    def state(self, spec=None):
+        """A toplevel's window state, not ttk flags ("normal" / "iconic")."""
+        return "normal"
+
     def geometry(self, spec=None):
         if spec is None:
             return self.winfo_geometry()

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -277,3 +277,45 @@ def test_about_window_shows_version_author_licence_and_third_parties():
         panel.close()
         assert not panel.is_open()
     """, lang="pl")
+
+
+def test_opening_a_window_takes_the_highlight_off_the_button_that_opened_it():
+    """A ttk button keeps keyboard focus after a click, and this theme paints
+    `focus` exactly like `active` - so a button that opened a window sat there
+    looking hovered for the rest of the session once the window was closed."""
+    run_gui("""
+        import fake_tk
+        from tkinter import ttk
+
+        button = ttk.Button(root, text="About")
+        button.focus_set()
+        button.state(["active", "focus"])
+        assert root.focus_get() is button
+
+        app.open_window("about")
+        assert root.focus_get() is root, root.focus_get()
+        assert button.state() == (), button.state()
+    """)
+
+
+def test_every_prose_label_in_the_about_window_can_wrap():
+    """The licence and privacy sentences are longer in translation than in English
+    and were CUT at the window edge (a plain ttk.Label never wraps). Every one of
+    them goes through wrapping_label now; tools/ci_gui_render.py fails on a
+    truncated label, this keeps the intent visible in the fast suite."""
+    run_gui("""
+        panel = app.open_window("about")
+
+        def labels(widget, found=None):
+            found = [] if found is None else found
+            for child in widget.winfo_children():
+                if child.kw.get("text") and "wraplength" in child.kw:
+                    found.append(child)
+                labels(child, found)
+            return found
+
+        wrapping = labels(panel.body)
+        texts = [w.kw["text"] for w in wrapping]
+        for key in ("about.license_terms", "about.no_telemetry", "about.third_party"):
+            assert bnt.T(key) in texts, (key, texts)
+    """)

--- a/tools/ci_gui_render.py
+++ b/tools/ci_gui_render.py
@@ -33,9 +33,22 @@ try:
 except (AttributeError, ValueError):
     pass
 
+import tempfile                                      # noqa: E402
 import tkinter as tk                                 # noqa: E402
 
+import beantester.gui.profiles as _profiles          # noqa: E402
+import beantester.gui.ui_state as _ui_state          # noqa: E402
+
+# Run against EMPTY user state. Reading the developer's own bean_network_tester_ui.json
+# made this check a liar: the file remembers a language, so the "en" pass rendered
+# whatever language the last real run had left behind - and a saved window geometry
+# would have hidden exactly the clipping we are here to find.
+_TMP = tempfile.mkdtemp()
+_ui_state.UiStateStore.__init__.__defaults__ = (os.path.join(_TMP, "ui.json"),)
+_profiles.ProfileStore.__init__.__defaults__ = (os.path.join(_TMP, "profiles.json"),)
+
 import bean_network_tester as n                      # noqa: E402
+from beantester.gui.windows import WINDOWS           # noqa: E402
 
 GEOMETRY = "1366x768"
 BUTTON_CLASSES = ("TButton", "Button")
@@ -67,8 +80,24 @@ def _clip(widget):
     return req, got
 
 
+def _wraps(widget):
+    """True when the label is allowed to wrap (a wraplength is set)."""
+    try:
+        return int(str(widget.cget("wraplength")) or 0) > 0
+    except (tk.TclError, ValueError):
+        return False
+
+
 def _scan(root):
-    buttons, labels = [], []
+    """Clipped widgets, split into the three kinds that mean different things.
+
+    ``cut`` is the damaging one: a label with no wraplength that does not fit is
+    TRUNCATED on screen - there is nowhere for the rest of the sentence to go.
+    That is what happened to the About window's licence and privacy lines, and it
+    went unnoticed for as long as every clipped label was filed under "it wraps,
+    probably". A label that does wrap is still reported, but only as a note.
+    """
+    buttons, labels, cut = [], [], []
     for widget in _walk(root):
         try:
             if not widget.winfo_ismapped():
@@ -86,8 +115,13 @@ def _scan(root):
         if not clip:
             continue
         req, got = clip
-        (buttons if is_button else labels).append((text, req, got))
-    return buttons, labels
+        if is_button:
+            buttons.append((text, req, got))
+        elif _wraps(widget):
+            labels.append((text, req, got))
+        else:
+            cut.append((text, req, got))
+    return buttons, labels, cut
 
 
 def _cancel_afters(root):
@@ -110,33 +144,49 @@ def check_language(code):
     root.update_idletasks()
     root.update()
 
-    buttons, labels = [], []
+    buttons, labels, cut = [], [], []
+
+    def scan():
+        b, l, c = _scan(root)
+        buttons.extend(b)
+        labels.extend(l)
+        cut.extend(c)
+
     for page in ("control", "statistics", "connections"):
         app.select_page(page)
         root.update_idletasks()
         root.update()
-        b, l = _scan(root)
-        buttons += b
-        labels += l
-    try:
-        app.open_window("about")
-        root.update_idletasks()
-        root.update()
-        b, l = _scan(root)
-        buttons += b
-        labels += l
-    except Exception as exc:                     # noqa: BLE001 - report, keep going
-        print(f"  [{code}] could not open the About window: {exc}")
+        scan()
+    # EVERY registered window, not just About: a window nobody renders here is a
+    # window whose clipping nobody finds until a user sends a screenshot.
+    for window_id in sorted(WINDOWS):
+        try:
+            app.open_window(window_id)
+            root.update_idletasks()
+            root.update()
+            scan()
+            app.windows.close(window_id)
+        except Exception as exc:                 # noqa: BLE001 - report, keep going
+            print(f"  [{code}] could not open the {window_id!r} window: {exc}")
 
     buttons = sorted(set(buttons))
     labels = sorted(set(labels))
+    cut = sorted(set(cut))
     for text, req, got in labels:
         print(f"  [{code}] note: label narrower than requested "
               f"(req={req} got={got}): {text!r}")
+    for text, req, got in cut:
+        print(f"  [{code}] TRUNCATED LABEL - no wraplength, the text is CUT "
+              f"(req={req} got={got}): {text!r}")
     for text, req, got in buttons:
         print(f"  [{code}] CLIPPED BUTTON (req={req} got={got}): {text!r}")
-    ok = not buttons
-    print(f"  [{code}] {'OK' if ok else f'{len(buttons)} clipped button(s)'}")
+    ok = not buttons and not cut
+    problems = []
+    if buttons:
+        problems.append(f"{len(buttons)} clipped button(s)")
+    if cut:
+        problems.append(f"{len(cut)} truncated label(s)")
+    print(f"  [{code}] {'OK' if ok else ', '.join(problems)}")
 
     # Teardown is best-effort: the result above is already computed, and a noisy
     # Tk destroy (registered windows, scheduled callbacks) must never fail the run.


### PR DESCRIPTION
The About window built its prose with plain ttk.Labels, which never wrap: the licence sentence and the "sends no data anywhere" line ran off the right edge and were chopped. It happened in Polish, where the sentences are longer than the English they came from - which is also why nobody saw it. They go through labels.wrapping_label now, like the note that taught us this the first time.

A ttk button takes keyboard focus when clicked, and this theme paints `focus` exactly like `active`, so closing a window handed focus back to the button that opened it and left it looking hovered. App.open_window releases focus to the toplevel and clears the invoking widget's state flags - the same remedy theme.unhighlight_combobox applies to a readonly combobox.

The render check had been printing both clipped lines as harmless notes for as long as they were broken, because it assumed a clipped label wraps. It now fails on a clipped label with NO wraplength (the text really is cut), opens every window in the registry instead of only About, and runs against an empty user state - it was reading the developer's own ui.json, so the "en" pass rendered whatever language that file remembered.

Verified: the two new tests in tests/test_windows.py and the render check all fail against the pre-fix code and pass after it; full pytest and the GUI smoke are green.


