### PR TITLE
fix(gui): tell keyboard focus apart from mouse hover

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -47,6 +47,27 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   and `::test_every_prose_label_in_the_about_window_can_wrap`. Both were confirmed to fail against
   the pre-fix code, and the render check was confirmed to report `2 truncated label(s)` on it.
 
+### GUI: focus is a ring, hover is a fill (they used to be the same picture)
+
+- **`gui/theme.py`: every `("focus", <colour>)` entry that duplicated the style's `("active",
+  <colour>)` is gone** (`TButton`, `Accent`, `Stop`, `Dirty`, `Help`, `Donate`, `Section`,
+  `Gear`). Hover keeps the fill; focus is drawn by clam's **`Button.focus` element** through
+  `focuscolor` (`focusthickness=1`, `focussolid=True` on `TButton`, inherited by the derived
+  styles; the coloured buttons keep their own ink colour, because an accent ring on an
+  accent-blue button is invisible). Measured, not assumed: at thickness 1 the ring costs no
+  space (a button is 82x31 either way) and at 3 it grows to 86x35 - which is why this one
+  number is not `scaled()`.
+- **`tools/ci_gui_render.py` fails when a style paints `focus` and `active` the same.** The
+  styles it checks come from two places, neither hand-kept: the widgets actually on screen, plus
+  every name `theme.py` configures or maps (regex over the module source) - `Stop.TButton` only
+  exists while a capture runs and `Dirty.TButton` only while the form is dirty, so a screen walk
+  alone missed exactly the styles nobody looks at. Against the pre-fix theme it reports all 8
+  offending styles; after the fix, none.
+- Theme module docstring gained the rule as a third invariant, next to "no hard pixels" and
+  "a disabled widget must look disabled". This is the other half of the "button left
+  highlighted" fix above: that one stops focus LANDING on the button, this one stops focus from
+  being painted as hover in the first place.
+
 ### GUI: the profile picker is a ttk.Combobox again (convention 41)
 
 - **`gui/pages/control.py::_build_profiles`: `ttk.Menubutton` + `tk.Menu` -> `ttk.Combobox`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 - **A button no longer stays lit after you close the window it opened.** Clicking "About" or the
   settings gear left the button looking as if the mouse were still hovering over it, for the rest
   of the session.
+- **Keyboard focus and mouse hover no longer look the same.** Every button lit up in exactly the
+  same way whether the mouse was over it or the keyboard had landed on it, so you could not tell
+  the two apart - and a button that kept focus looked as if the cursor were parked on it. Hover
+  still fills the button; keyboard focus now draws a thin outline inside it instead.
 
 - **"Restore the last profile on startup" now works for your own profiles.** Saving a profile
   makes it the one you are using, but the tool remembered only profiles picked from the list -

--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -8,6 +8,12 @@ Two rules this file exists to enforce:
   entry whose ``state`` is ``disabled`` keeps its normal colours unless the
   style declares a ``disabled`` map. Every interactive style below therefore
   carries one - otherwise the user cannot tell whether a field is live.
+* **Focus must not look like hover.** Both states existed and both painted the
+  same lighter fill, so "the keyboard is here" and "the mouse is over this" were
+  the same picture - and a button that kept focus after its window closed read as
+  stuck under the cursor. Hover is the FILL; focus is the RING (clam's
+  ``Button.focus`` element, via ``focuscolor``). No style may map ``focus`` to a
+  colour it also maps for ``active``; ``tools/ci_gui_render.py`` fails if one does.
 
 The combobox popdown is a classic Tk listbox living in its own toplevel; ttk
 styles do not reach it, so its colours are set through the option database in
@@ -111,51 +117,50 @@ def init_style(root=None):
     s.configure("TLabelframe.Label", background=BG, foreground=ACC, font=(FONT, 9, "bold"))
 
     # -- buttons ------------------------------------------------------------ #
+    # FOCUS AND HOVER MUST NOT LOOK THE SAME (see the module docstring). Hover is
+    # the fill; focus is the ring clam's ``Button.focus`` element draws INSIDE the
+    # button - every clam button layout has it, and at thickness 1 it costs no
+    # space (measured: a button is 82x31 with and without it; at 3 it grows to
+    # 86x35, which is why this is not scaled()).
     s.configure("TButton", background=BTN_BG, foreground=FG, borderwidth=1,
                 bordercolor=BTN_BORDER, lightcolor=BTN_BG, darkcolor=BTN_BG,
-                focuscolor=BTN_BG, relief="flat",
+                focuscolor=ACC, focusthickness=1, focussolid=True, relief="flat",
                 padding=(scaled(10), scaled(5)), font=(FONT, 9))
-    # A focused control MUST look focused (WCAG 2.4.7). clam draws a focus ring
-    # from the widget's focuscolor / the border's colour; the theme used to gag it
-    # by setting focuscolor to the background, so keyboard users could not tell
-    # where they were. Bordered buttons get a solid accent outline on focus; the
-    # flat coloured buttons below get a contrasting focuscolor so their ring shows.
     s.map("TButton",
           background=[("disabled", DIS_BG), ("pressed", BTN_BORDER),
-                      ("focus", BTN_HOVER), ("active", BTN_HOVER)],
-          bordercolor=[("disabled", DIS_BG), ("focus", ACC), ("active", ACC)],
-          lightcolor=[("focus", ACC), ("active", BTN_HOVER)],
-          darkcolor=[("focus", ACC), ("active", BTN_HOVER)],
+                      ("active", BTN_HOVER)],
+          bordercolor=[("disabled", DIS_BG)],
+          lightcolor=[("active", BTN_HOVER)],
+          darkcolor=[("active", BTN_HOVER)],
           foreground=[("disabled", DIS_FG)])
+    # The coloured buttons carry their ring in their own ink colour: an accent-blue
+    # ring on an accent-blue button would be invisible.
     s.configure("Accent.TButton", background=ACC, foreground="#0c1220",
                 font=(FONT, 10, "bold"), padding=scaled(8), borderwidth=0,
                 focuscolor="#0c1220")
     s.map("Accent.TButton",
-          background=[("disabled", DIS_BG), ("focus", "#6fb0ff"),
-                      ("active", "#6fb0ff")],
+          background=[("disabled", DIS_BG), ("active", "#6fb0ff")],
           foreground=[("disabled", DIS_FG)])
     # STOP is a different action -> a different colour
     s.configure("Stop.TButton", background=STOP_C, foreground="#1a0d0c",
                 font=(FONT, 10, "bold"), padding=scaled(8), borderwidth=0,
                 focuscolor="#1a0d0c")
     s.map("Stop.TButton",
-          background=[("disabled", DIS_BG), ("focus", "#ff8378"),
-                      ("active", "#ff8378")],
+          background=[("disabled", DIS_BG), ("active", "#ff8378")],
           foreground=[("disabled", DIS_FG)])
     # "Apply changes" while the form differs from what the engine runs
     s.configure("Dirty.TButton", background=UP_C, foreground="#20160a",
                 font=(FONT, 9, "bold"), padding=scaled(6), borderwidth=0,
                 focuscolor="#20160a")
     s.map("Dirty.TButton",
-          background=[("disabled", DIS_BG), ("focus", "#ffc978"),
-                      ("active", "#ffc978")],
+          background=[("disabled", DIS_BG), ("active", "#ffc978")],
           foreground=[("disabled", DIS_FG)])
     # the "?" cheat-sheet button next to a filter-expression field
     s.configure("Help.TButton", background=BG2, foreground=ACC,
                 font=(FONT, 9, "bold"), borderwidth=0, focuscolor=ACC,
                 padding=(scaled(3), 0))
     s.map("Help.TButton",
-          background=[("focus", BTN_BG), ("active", BTN_BG), ("disabled", BG2)],
+          background=[("active", BTN_BG), ("disabled", BG2)],
           foreground=[("disabled", DIS_FG)])
 
     # Donate: visible, but an outline button - it must not compete with START,
@@ -164,29 +169,28 @@ def init_style(root=None):
                 bordercolor=DONATE_C, lightcolor=BG, darkcolor=BG, focuscolor=DONATE_C,
                 font=(FONT, 9, "bold"), borderwidth=1, padding=(scaled(10), scaled(4)))
     s.map("Donate.TButton",
-          background=[("focus", "#3a2b33"), ("active", "#3a2b33"),
-                      ("disabled", DIS_BG)],
+          background=[("active", "#3a2b33"), ("disabled", DIS_BG)],
           foreground=[("disabled", DIS_FG)],
-          bordercolor=[("focus", DONATE_C), ("active", DONATE_C)])
+          bordercolor=[("active", DONATE_C)])
 
     # collapsible section header
     s.configure("Section.TButton", background=BG, foreground=ACC,
                 font=(FONT, 9, "bold"), borderwidth=0, focuscolor=ACC,
                 padding=(scaled(2), scaled(3)), anchor="w")
-    s.map("Section.TButton", background=[("focus", BG2), ("active", BG2)])
+    s.map("Section.TButton", background=[("active", BG2)])
 
     # header gear: an icon-only button that opens the Settings window. Flat on the
     # header at rest (bevel colours pinned to BG so clam draws no raised edge), but
     # a small icon needs a REAL hover chip - the old BG->BG2 map was a one-shade
-    # change nobody could see, so it never read as clickable. Hover/focus light up
-    # to the secondary-button surface; press goes a shade lighter.
+    # change nobody could see, so it never read as clickable. Hover lights up to
+    # the secondary-button surface; press goes a shade lighter.
     s.configure("Gear.TButton", background=BG, bordercolor=BG, lightcolor=BG,
                 darkcolor=BG, borderwidth=0, focuscolor=ACC, relief="flat",
                 padding=scaled(5))
     s.map("Gear.TButton",
           background=[("disabled", BG), ("pressed", BTN_HOVER),
-                      ("focus", BTN_BG), ("active", BTN_BG)],
-          bordercolor=[("focus", ACC), ("active", BTN_BORDER)],
+                      ("active", BTN_BG)],
+          bordercolor=[("active", BTN_BORDER)],
           lightcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)],
           darkcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)])
 

--- a/tools/ci_gui_render.py
+++ b/tools/ci_gui_render.py
@@ -35,6 +35,7 @@ except (AttributeError, ValueError):
 
 import tempfile                                      # noqa: E402
 import tkinter as tk                                 # noqa: E402
+from tkinter import ttk                              # noqa: E402
 
 import beantester.gui.profiles as _profiles          # noqa: E402
 import beantester.gui.ui_state as _ui_state          # noqa: E402
@@ -88,7 +89,7 @@ def _wraps(widget):
         return False
 
 
-def _scan(root):
+def _scan(root, styles=None):
     """Clipped widgets, split into the three kinds that mean different things.
 
     ``cut`` is the damaging one: a label with no wraplength that does not fit is
@@ -105,6 +106,12 @@ def _scan(root):
             cls = widget.winfo_class()
         except tk.TclError:
             continue
+        # Collect the styles actually on screen, so the focus-vs-hover check below
+        # needs no hand-kept list: a new styled control is covered the day it ships.
+        if styles is not None:
+            name = _style_of(widget)
+            if name:
+                styles.add(name)
         is_button = cls in BUTTON_CLASSES
         if not is_button and cls not in LABEL_CLASSES:
             continue
@@ -122,6 +129,62 @@ def _scan(root):
         else:
             cut.append((text, req, got))
     return buttons, labels, cut
+
+
+PAINT_OPTIONS = ("background", "foreground", "bordercolor", "lightcolor", "darkcolor")
+
+
+def _declared_styles():
+    """Every style name gui/theme.py configures or maps.
+
+    Walking the widget tree only finds the styles that are on SCREEN, and some of
+    the most important ones are not: "Stop.TButton" exists only while a capture
+    runs, "Dirty.TButton" only while the form differs from the engine. Reading the
+    names out of the theme covers them without a list to keep in step by hand.
+    """
+    import re
+
+    from beantester.gui import theme
+    try:
+        with open(theme.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+    except OSError:
+        return set()
+    return set(re.findall(r's\.(?:configure|map)\(\s*"([\w.]+)"', source))
+
+
+def _style_of(widget):
+    """The ttk style a widget actually draws with ("" for a plain tk widget)."""
+    try:
+        return str(widget.cget("style") or widget.winfo_class())
+    except tk.TclError:
+        return ""
+
+
+def _focus_looks_like_hover(style, name):
+    """Options this style paints identically for `focus` and for `active`.
+
+    Hover is the fill, focus is the ring - a style that maps both states to the
+    same colour makes "the mouse is here" and "the keyboard is here" the same
+    picture, which is how a button that kept focus after its window closed ended
+    up looking permanently hovered.
+    """
+    same = []
+    for option in PAINT_OPTIONS:
+        focus = hover = None
+        try:
+            spec = style.map(name, option)
+        except tk.TclError:
+            continue
+        for entry in spec or ():
+            states, value = tuple(entry[:-1]), str(entry[-1])
+            if states == ("focus",):
+                focus = value
+            elif states == ("active",):
+                hover = value
+        if focus is not None and focus == hover:
+            same.append(f"{option}={focus}")
+    return same
 
 
 def _cancel_afters(root):
@@ -145,9 +208,10 @@ def check_language(code):
     root.update()
 
     buttons, labels, cut = [], [], []
+    styles = _declared_styles()
 
     def scan():
-        b, l, c = _scan(root)
+        b, l, c = _scan(root, styles)
         buttons.extend(b)
         labels.extend(l)
         cut.extend(c)
@@ -169,6 +233,10 @@ def check_language(code):
         except Exception as exc:                 # noqa: BLE001 - report, keep going
             print(f"  [{code}] could not open the {window_id!r} window: {exc}")
 
+    style = ttk.Style(root)
+    twins = [(name, same) for name in sorted(styles)
+             for same in [_focus_looks_like_hover(style, name)] if same]
+
     buttons = sorted(set(buttons))
     labels = sorted(set(labels))
     cut = sorted(set(cut))
@@ -178,14 +246,18 @@ def check_language(code):
     for text, req, got in cut:
         print(f"  [{code}] TRUNCATED LABEL - no wraplength, the text is CUT "
               f"(req={req} got={got}): {text!r}")
+    for name, same in twins:
+        print(f"  [{code}] FOCUS LOOKS LIKE HOVER in {name}: {', '.join(same)}")
     for text, req, got in buttons:
         print(f"  [{code}] CLIPPED BUTTON (req={req} got={got}): {text!r}")
-    ok = not buttons and not cut
+    ok = not buttons and not cut and not twins
     problems = []
     if buttons:
         problems.append(f"{len(buttons)} clipped button(s)")
     if cut:
         problems.append(f"{len(cut)} truncated label(s)")
+    if twins:
+        problems.append(f"{len(twins)} style(s) where focus looks like hover")
     print(f"  [{code}] {'OK' if ok else ', '.join(problems)}")
 
     # Teardown is best-effort: the result above is already computed, and a noisy


### PR DESCRIPTION
Every button mapped the `focus` state to the same fill as `active`, so "the mouse is over this" and "the keyboard is here" were the same picture - and a button that kept focus read as stuck under the cursor.

Hover keeps the fill. Focus is now the ring clam already reserves space for: the `Button.focus` element in every button layout, which the theme had been deliberately gagging by painting focuscolor in the button's own background. The coloured buttons (START/STOP/Apply) carry the ring in their ink colour, since an accent ring on an accent-blue button is invisible. Thickness stays 1 because that is the width clam already reserves: measured, a button is 82x31 with the ring and without it, and 86x35 at thickness 3 - so this one number is deliberately not scaled().

tools/ci_gui_render.py now fails when a style paints focus and active the same. The styles it checks are the ones on screen PLUS every name theme.py configures or maps, read from the module source: Stop.TButton exists only while a capture runs and Dirty.TButton only while the form is dirty, so a screen walk alone missed exactly the styles nobody ever looks at. It reports all 8 offending styles against the old theme and none against this one.

