### PR TITLE
fix(gui): keep a tooltip over its text instead of the whole row

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -68,6 +68,22 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   highlighted" fix above: that one stops focus LANDING on the button, this one stops focus from
   being painted as hover in the first place.
 
+### GUI fix: a tooltip covered the whole row, not the text
+
+- **A tooltip belongs to a WIDGET, so a label packed `fill`/`expand` shows its bubble over the
+  blank space next to the sentence.** Measured on real Tk at 1366x768: `App.summary` was **508 px
+  wider and 17 px taller than its own text** (it filled the fixed-height summary strip), so the
+  bubble fired over empty header background nowhere near the line it explains. Same shape, smaller
+  numbers, on the two `wrapping_label` scope notes (`pages/stats.py` 118 px, `pages/conns.py`).
+- **Fix:** pack them to their content - `App.summary` -> `side="left", anchor="nw"`, both scope
+  notes -> `anchor="w"` instead of `fill="x"`. A `wrapping_label` does NOT need `fill` to wrap:
+  `labels.bind_wraplength` follows the PARENT's `<Configure>`, so the wrap width is unchanged.
+- **Test:** `tests/test_gui_layout.py::test_a_tooltip_never_covers_empty_space` - walks all three
+  pages and fails on any LEAF widget that has a tooltip, carries `text`, no `command`, and is
+  packed with `fill`/`expand`. Containers are exempt on purpose (a stat tile or a `LabelFrame`
+  with a tooltip does answer for everything inside it), and so are entries/comboboxes/buttons,
+  where the whole box is the control. Confirmed to report all three offenders before the fix.
+
 ### GUI: the profile picker is a ttk.Combobox again (convention 41)
 
 - **`gui/pages/control.py::_build_profiles`: `ttk.Menubutton` + `tk.Menu` -> `ttk.Combobox`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   same way whether the mouse was over it or the keyboard had landed on it, so you could not tell
   the two apart - and a button that kept focus looked as if the cursor were parked on it. Hover
   still fills the button; keyboard focus now draws a thin outline inside it instead.
+- **Tooltips no longer pop up far away from the text they explain.** The summary line under the
+  title ("Active: ...") stretched across the whole window even when it was one short sentence, so
+  hovering the empty space beside it - halfway across the header - still brought up its tooltip.
+  The same went for the notes above the Statistics counters and the Connections table. Those
+  tooltips now appear only over the text itself.
 
 - **"Restore the last profile on startup" now works for your own profiles.** Saving a profile
   makes it the one you are using, but the tool remembered only profiles picked from the list -

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -380,7 +380,11 @@ class App:
         self.summary = ttk.Label(self.summary_holder, text=T("summary.none"),
                                  style="Muted.TLabel", justify="left", anchor="nw",
                                  wraplength=scaled(620))
-        self.summary.pack(fill="both", expand=True)
+        # Packed to its TEXT, not to the strip. Filling the (full-width, fixed-height)
+        # holder made the label 500 px wider than its own sentence, and a tooltip
+        # covers the WIDGET - so the bubble fired over empty background halfway
+        # across the header, nowhere near the line it explains.
+        self.summary.pack(side="left", anchor="nw")
         add_tooltip(self.summary, "tips.summary")
         # Not admin -> the WinDivert driver will not load and START will fail. Say
         # it up front, as a banner, instead of only a line in the log strip at the

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -103,7 +103,7 @@ class ConnsPage:
         self.count.pack(side="right")
 
         scope = wrapping_label(self.frame, T("conns.scope_note"))
-        scope.pack(fill="x", padx=scaled(10), pady=(0, scaled(4)))
+        scope.pack(anchor="w", padx=scaled(10), pady=(0, scaled(4)))
         add_tooltip(scope, "tips.scope_note")
 
         holder = ttk.Frame(self.frame)

--- a/beantester/gui/pages/stats.py
+++ b/beantester/gui/pages/stats.py
@@ -119,8 +119,11 @@ class StatsPage:
         self.grid.bind("<Configure>", self._on_grid_configure)
         self._relayout_cells(4)
 
+        # anchor, not fill: the wraplength follows the PARENT's width either way
+        # (gui/labels.py), while filling would hand the note - and its tooltip -
+        # the empty space to the right of the sentence.
         scope = wrapping_label(parent, T("stats.scope_note"))
-        scope.pack(fill="x", padx=scaled(10), pady=(scaled(2), 0))
+        scope.pack(anchor="w", padx=scaled(10), pady=(scaled(2), 0))
         add_tooltip(scope, "tips.scope_note")
 
         self._chart_frame = ttk.LabelFrame(parent, text=self._throughput_title())

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -282,3 +282,35 @@ def test_expanding_a_section_scrolls_it_into_view():
         assert seen == [panel.frame], seen
         assert "profiles" not in app.collapsed_sections
     """)
+
+
+def test_a_tooltip_never_covers_empty_space():
+    """A tooltip belongs to the WIDGET, so a label stretched across its row shows
+    its bubble over the blank space beside the sentence too. The summary strip did
+    exactly that: measured on real Tk, the label was 508 px wider and 17 px taller
+    than its own text, so hovering the empty header fired "what the tool is doing
+    with your traffic" nowhere near the line it explains.
+
+    Exempt: buttons, entries and comboboxes (there the whole box IS the control,
+    so covering all of it is right) and containers - a group box or a stat tile
+    with a tooltip is meant to answer for everything inside it.
+    """
+    run_gui("""
+        def stretched(widget, found=None):
+            found = [] if found is None else found
+            for child in widget.winfo_children():
+                info = child.pack_info or {}
+                text = child.kw.get("text")
+                is_leaf_label = (bool(text) and not child.kw.get("command")
+                                 and not child.winfo_children())
+                if (hasattr(child, "_bnt_tooltip") and is_leaf_label
+                        and (info.get("fill") in ("x", "both") or info.get("expand"))):
+                    found.append((text, info))
+                stretched(child, found)
+            return found
+
+        for page in ("control", "statistics", "connections"):
+            app.select_page(page)
+        bad = stretched(root)
+        assert not bad, bad
+    """)


### PR DESCRIPTION
A tooltip belongs to a widget, so a label packed fill/expand shows its bubble over the blank space beside the sentence too. Measured on real Tk at 1366x768, App.summary was 508 px wider and 17 px taller than its own text - it filled the full-width summary strip - so "what the tool is doing with your traffic" fired over empty header background halfway across the window. The two wrapping_label scope notes (Statistics, Connections) had the same shape at 118 px.

All three now pack to their content. A wrapping_label does not need fill to wrap: bind_wraplength follows the parent's <Configure>, so the wrap width is unchanged. Entries and comboboxes stay wide - there the whole box is the control, so a bubble over all of it is correct.

Guarded by tests/test_gui_layout.py::test_a_tooltip_never_covers_empty_space, which reports all three offenders against the pre-fix layout.

