### PR TITLE
fix(gui): make the window menu dark like the rest of the app

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,32 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI: dark mode for the parts Windows draws itself (system menu, menu frames)
+
+- **New `theme.apply_dark_app_mode()`**, called once from the top of
+  `theme.apply_dark_titlebar` (module flag `_app_mode_applied`, one attempt per process).
+  Piggy-backed there deliberately: `App`, every `PanelWindow` in the registry and `dialogs.py`
+  already call `apply_dark_titlebar`, so no window can ask for a dark frame and still get a
+  white system menu - and no caller needed changing.
+- **Why a second mechanism at all:** `DWMWA_USE_IMMERSIVE_DARK_MODE` is a PER-WINDOW attribute
+  and only covers the DWM-drawn frame. The system menu (title-bar icon / Alt+Space) and the
+  frame user32 puts around a classic `tk.Menu` popup follow a PROCESS-WIDE flag in undocumented
+  `uxtheme` exports instead, which nothing in the package was setting - so every window had a
+  white system menu, and the Connections context menu kept the light rim noted in convention 41
+  ("Tk reaches the entries but not the system-drawn frame").
+- **Implementation:** `uxtheme` ordinals 135 (`SetPreferredAppMode`, `AllowDarkModeForApp` on
+  1809) and 136 (`FlushMenuThemes`). `ForceDark` (2), not `AllowDark` (1): the UI is dark
+  unconditionally, so following the system theme would leave a light menu for a user running
+  Windows in light mode. The flush is required - the menu theme is cached per process and is
+  already light by the time we get here. Gated on `sys.getwindowsversion().build >= 17763`
+  (first build with these exports), wrapped in `crashlog.note` (convention 30): the exports are
+  undocumented, and the worst case on failure is the light menu we had before.
+- Side effect, accepted by the owner: the native `filedialog` pickers render dark now. They stay
+  native on purpose (see the `dialogs.py` docstring) and dark is the consistent look.
+- **No test guard.** This is pixels painted by the OS outside the widget tree - the tkinter
+  fake cannot observe it and `tools/ci_gui_render.py` only sees the client area. Verified by
+  render on Windows 11 build 26200 (convention 41: check live, not from the code).
+
 ### GUI fixes: truncated About text, a button left highlighted, and a render check that lied
 
 - **`panels/about.py` uses `labels.wrapping_label` for every prose line** (author, copyright,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The window menu is now dark, like the rest of the app.** Clicking the bean icon in the title
+  bar (or pressing Alt+Space) opened a bright white "Minimise / Maximise / Close" menu in every
+  window, and the right-click menu on the Connections table had a light rim around it. Both now
+  match the dark interface. The file pickers ("Save file...", "Load file...") are dark too.
 - **The "About" window no longer cuts off its text.** The licence sentence and the "sends no
   data anywhere" line ran off the right edge and were simply chopped - in Polish, where the
   sentences are longer than the English they were translated from. They now wrap to the width

--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -313,6 +313,20 @@ def init_style(root=None):
 # a dialog looked half-white until you clicked it.
 DWMWA_USE_IMMERSIVE_DARK_MODE = 20        # 19 on Windows 10 builds < 19041
 
+# The title bar is only half of what Windows draws for us. The SYSTEM MENU (the
+# one behind the icon in the title bar, or Alt+Space) and the frame around a
+# classic ``tk.Menu`` popup are painted by the system too, and they ignore the
+# per-window DWM attribute above - they follow a PROCESS-WIDE dark-mode flag that
+# lives in undocumented uxtheme exports. Without it a dark app shows a bright
+# white system menu in every window (and a light rim around our context menus).
+# The exports have no names, only ordinals:
+_UXTHEME_SET_PREFERRED_APP_MODE = 135     # AllowDarkModeForApp(BOOL) on 1809
+_UXTHEME_FLUSH_MENU_THEMES = 136          # drops the cached (light) menu theme
+_PREFERRED_APP_MODE_FORCE_DARK = 2        # not "allow": our UI is dark ALWAYS,
+# so following the system theme would leave a light menu on a light Windows.
+_DARK_MODE_MIN_BUILD = 17763              # first build with these exports
+_app_mode_applied = False
+
 
 _GWL_STYLE = -16
 _WS_MAXIMIZEBOX = 0x00010000
@@ -344,6 +358,43 @@ def disable_maximize(window):
         return False
 
 
+def apply_dark_app_mode():
+    """Put the whole PROCESS in dark mode, for the parts Windows draws itself.
+
+    Covers what ``apply_dark_titlebar`` cannot: the system menu behind the title
+    bar icon, the frame Windows puts around a ``tk.Menu`` popup and the native
+    file pickers. It is a process flag, not a window one, so calling it once is
+    enough - every window created afterwards inherits it.
+
+    Undocumented on purpose (these uxtheme exports have ordinals, no names), so
+    it is gated on the build that introduced them and every failure is silent:
+    the worst case is the light menu we already had. No-op off Windows.
+    """
+    global _app_mode_applied
+    if _app_mode_applied or not sys.platform.startswith("win"):
+        return False
+    _app_mode_applied = True          # one attempt per process, success or not
+    try:
+        import ctypes
+        if sys.getwindowsversion().build < _DARK_MODE_MIN_BUILD:
+            return False
+        uxtheme = ctypes.windll.uxtheme
+        set_mode = uxtheme[_UXTHEME_SET_PREFERRED_APP_MODE]
+        set_mode.restype = ctypes.c_int
+        set_mode.argtypes = (ctypes.c_int,)
+        set_mode(_PREFERRED_APP_MODE_FORCE_DARK)
+        # Menu themes are cached per process and the cache is already filled with
+        # the light one by the time we get here, so asking is not enough.
+        flush = uxtheme[_UXTHEME_FLUSH_MENU_THEMES]
+        flush.restype = None
+        flush.argtypes = ()
+        flush()
+        return True
+    except Exception as _exc:
+        crashlog.note(_exc, "gui.theme")
+    return False
+
+
 def apply_dark_titlebar(window):
     """Ask DWM for a dark title bar on this window. No-op off Windows.
 
@@ -356,6 +407,9 @@ def apply_dark_titlebar(window):
     """
     if not sys.platform.startswith("win"):
         return False
+    # Piggy-backed here (it is a no-op after the first call) so that no window can
+    # ever ask for a dark frame and still get a white system menu inside it.
+    apply_dark_app_mode()
     try:
         import ctypes
         window.update_idletasks()


### PR DESCRIPTION
Clicking the bean icon in the title bar (or Alt+Space) opened a bright white system menu in every window, and the Connections context menu kept a light rim around it. DWMWA_USE_IMMERSIVE_DARK_MODE, which is all we were setting, is a PER-WINDOW attribute covering the DWM-drawn frame only. The system menu and the frame user32 puts around a classic tk.Menu follow a PROCESS-WIDE flag in undocumented uxtheme exports instead - nothing in the package was setting it.

New theme.apply_dark_app_mode() calls uxtheme ordinals 135 (SetPreferredAppMode) and 136 (FlushMenuThemes). The flush is required: the menu theme is cached per process and is already light by the time we run. ForceDark, not AllowDark - the UI is dark unconditionally, so following the system theme would leave a light menu for anyone running Windows in light mode.

- called once per process from the top of theme.apply_dark_titlebar, so App, every PanelWindow in the registry and dialogs.py get it with no caller change and no window can hold a dark frame around a white menu
- gated on build >= 17763 (first build with these exports); failures go to crashlog.note (convention 30) and degrade to the light menu we had before
- the native filedialog pickers render dark now too - accepted by the owner, they stay native on purpose and dark is the consistent look

No test guard is possible: this is painted by the OS outside the widget tree, where neither the tkinter fake nor tools/ci_gui_render.py can see it. Verified by render on Windows 11 build 26200 (convention 41).
