### PR TITLE
fix(gui): fill the throughput chart when its history is widened

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,27 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI fix: a widened throughput chart crept into its new window instead of filling it
+
+- **`App._reconcile_chart_len` now zero-pads when GROWING** (new `App._resized_hist(hist, n)`).
+  Two paths build the history and only one padded: `__init__` creates
+  `deque([0] * n, maxlen=n)`, while the reconcile did `deque(hist, maxlen=n)` - correct when
+  shrinking (the deque drops the oldest itself), but on a grow it left `len` at the OLD value
+  and only raised `maxlen`.
+- **Why it was visible:** `chart.draw_throughput_chart` labels the X axis from
+  `len(down_hist) * sample_interval_s`, so raising `chart_seconds` from ~20 s to 250 s left the
+  axis reading "-28 s" and counting up one sample per `TICK_MS`, ~4 minutes to fill, while
+  `stats._throughput_title` reads the preference directly and said 250 immediately - breaking
+  the invariant its own docstring promises ("never drifts from the live X-axis label"). The
+  series is also drawn across the full plot width (`x = i / (len - 1)`), so the horizontal
+  scale crept with every tick. `chart.py` and `stats.py` are unchanged: with `len == maxlen`
+  restored as an invariant, both are already right.
+- Tests: `test_prefs.py::test_a_resized_chart_spans_its_whole_window_at_once` (len matches the
+  window after growing AND shrinking, newest sample stays newest, padding lands on the left).
+  Verified to fail on the pre-fix code with `(171, 357)`. The existing
+  `test_chart_history_length_follows_the_preference` asserted `maxlen` only, which was correct
+  throughout - the bug lived in `len`, which is what the axis is computed from.
+
 ### GUI: dark mode for the parts Windows draws itself (system menu, menu frames)
 
 - **New `theme.apply_dark_app_mode()`**, called once from the top of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Making the chart history longer now widens the chart immediately.** Setting "Chart history"
+  to a bigger number left the graph on its old span: the label under the left edge still read
+  "-28 s" and crawled towards the new value one tick at a time, taking minutes to get there,
+  while the caption above the graph already said "last ~250 s". The graph now covers the full
+  span at once, with the time you have not recorded yet drawn as a flat zero line - exactly how
+  it looks right after the app starts. Shortening the history was never affected.
 - **The window menu is now dark, like the rest of the app.** Clicking the bean icon in the title
   bar (or pressing Alt+Space) opened a bright white "Minimise / Maximise / Close" menu in every
   window, and the right-click menu on the Connections table had a light rim around it. Both now

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -667,14 +667,29 @@ class App:
         secs = self.pref("chart_seconds")
         return max(2, round(secs / (self.TICK_MS / 1000.0)))
 
+    @staticmethod
+    def _resized_hist(hist, n):
+        """History resized to ``n`` samples: newest kept, missing past zero-filled.
+
+        The zero padding is the whole point. The chart's X axis is labelled from
+        the number of samples it was handed, so a history that is merely ALLOWED
+        to grow to the new length keeps reporting the OLD window and creeps
+        towards the new one one tick at a time - raising the preference to 250 s
+        left the axis reading "-28 s" and counting up for four minutes while the
+        caption already claimed 250. Padding makes a widened chart look exactly
+        like a freshly started one, which is what ``__init__`` builds.
+        Shrinking needs no padding: the deque drops the oldest samples itself.
+        """
+        pad = [0] * max(0, n - len(hist))
+        return deque(pad + list(hist), maxlen=n)
+
     def _reconcile_chart_len(self):
-        """Resize the throughput history to match the current preference, keeping
-        the most recent samples (a deque with a new maxlen drops from the left)."""
+        """Resize the throughput history to match the current preference."""
         n = self.chart_samples()
         if getattr(self, "down_hist", None) is None or self.down_hist.maxlen == n:
             return
-        self.down_hist = deque(self.down_hist, maxlen=n)
-        self.up_hist = deque(self.up_hist, maxlen=n)
+        self.down_hist = self._resized_hist(self.down_hist, n)
+        self.up_hist = self._resized_hist(self.up_hist, n)
 
     def reset_ui_layout(self):
         """Forget remembered window state: geometry, collapsed sections, table

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -92,6 +92,35 @@ def test_chart_history_length_follows_the_preference():
     """)
 
 
+def test_a_resized_chart_spans_its_whole_window_at_once():
+    """A widened chart must FILL the new window, not creep into it.
+
+    The X axis is labelled from the number of samples the chart is handed, so a
+    history that only grows a sample per tick keeps reporting the old window:
+    raising the preference used to leave the axis at "-28 s", counting up for
+    minutes, under a caption that already said 250. maxlen alone (the assertion
+    above) never saw it - maxlen was right the whole time, len was not.
+    """
+    run_gui("""
+        app.down_hist.append(11.0)           # newest sample, must stay newest
+        app.up_hist.append(22.0)
+
+        app.set_pref("chart_seconds", 250)
+        app._reconcile_chart_len()
+        n = app.chart_samples()
+        assert len(app.down_hist) == n, (len(app.down_hist), n)
+        assert len(app.up_hist) == n, (len(app.up_hist), n)
+        assert app.down_hist[-1] == 11.0 and app.up_hist[-1] == 22.0
+        assert app.down_hist[0] == 0 and app.up_hist[0] == 0
+
+        app.set_pref("chart_seconds", 30)    # shrinking keeps the newest samples
+        app._reconcile_chart_len()
+        n = app.chart_samples()
+        assert len(app.down_hist) == n, (len(app.down_hist), n)
+        assert app.down_hist[-1] == 11.0 and app.up_hist[-1] == 22.0
+    """)
+
+
 def test_log_length_follows_the_preference():
     run_gui("""
         app.set_pref("log_lines", 50)


### PR DESCRIPTION
Raising "Chart history" left the graph on its old span. The X axis is labelled from len(down_hist) * sample_interval, so going from ~20 s to 250 s left it reading "-28 s" and counting up one sample per tick - about four minutes to reach the new window - while the caption above already said "last ~250 s". The series is drawn across the full plot width too (x = i / (len - 1)), so the horizontal scale crept with every tick until the history caught up.

Two paths build that history and only one padded it: __init__ creates deque([0] * n, maxlen=n), while _reconcile_chart_len did deque(hist, maxlen=n). That is right when shrinking - the deque drops the oldest samples itself - but on a grow it left len at the old value and only raised maxlen.

- new App._resized_hist(hist, n): newest samples kept, missing past zero-filled, so a widened chart looks exactly like a freshly started one
- chart.py and stats.py are untouched: with len == maxlen restored as an invariant, both were already correct

Guarded by tests/test_prefs.py::test_a_resized_chart_spans_its_whole_window_at_once (len matches the window after growing AND shrinking, the newest sample stays newest, padding lands on the left). It fails on the pre-fix code with (171, 357). The existing test asserted maxlen only, which was correct the whole time - the bug lived in len, which is what the axis is computed from.
