### PR TITLE
fix(gui): show the running icon on the window, not just on future ones

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI fix: the running-state icon never reached the main window (Tk `-default` trap)
+
+- **`gui/icon.py`: new `show_running_icon` / `show_idle_icon`** (over `_set_icon`), called from
+  `App._sync_running_ui` in place of the bare `root.iconphoto(True, icon)`.
+- **Root cause:** `iconphoto(True, img)` is Tk's `-default` - the icon for toplevels created
+  from then on. On Windows it lands on the window CLASS, and a window owning an icon of its own
+  keeps that one; the main window owns `bean.ico` from `apply_window_icon`'s `iconbitmap`. So
+  the swap was a no-op where it mattered and DID paint the dot on the next Toplevel opened
+  (the close-confirmation dialog), which is how the owner spotted it. Measured, not guessed:
+  `WM_GETICON` on the toplevel returned the same `HICON` before and after `iconphoto(True, ...)`
+  and a different one after `iconphoto(False, ...)`. Both calls are kept - `False` for this
+  window, `True` so panels opened later carry the state too.
+- **Idle restores through `iconbitmap(bean.ico)`, not the photo.** `bean.ico` ships 16/24/32/48/
+  64/128/256 px frames; `bean.png` is 256 px only, so restoring through the photo would leave
+  the taskbar on a downscale of it permanently after the first capture. Windows-only, guarded,
+  falls back to the photo.
+- The 0.2.0 entry below ("swaps `root.iconphoto` between an idle and a running icon") described
+  a feature that only half-worked on the one platform this tool targets.
+- Tests: `test_gui_state.py::test_the_running_icon_lands_on_the_window_not_just_the_default`
+  asserts the swap hits BOTH the window and the default. Needed a fake that can see it -
+  `fake_tk.Root` now records `iconphoto`/`iconbitmap` into `kw["icons"]` instead of swallowing
+  them in `W.__getattr__`. Verified to fail pre-fix with `[('default', ...)]` alone. Limits:
+  the fake can only prove which call we make - that Windows repaints the taskbar is not
+  testable here (convention 41: confirmed by render).
+
 ### GUI fix: a widened throughput chart crept into its new window instead of filling it
 
 - **`App._reconcile_chart_len` now zero-pads when GROWING** (new `App._resized_hist(hist, n)`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The app icon now shows the red dot while a capture is running.** The dot was only ever
+  reaching windows opened after you pressed START - which is why it turned up on the "close the
+  app?" box and nowhere else. The icon in the title bar and on the taskbar stayed the resting
+  bean for the whole session, so a minimised window gave no sign the tool was still touching
+  your traffic. It now switches on START and back on STOP, and going back drops you on the
+  original crisp icon rather than a blurrier copy of it.
 - **Making the chart history longer now widens the chart immediately.** Setting "Chart history"
   to a bigger number left the graph on its old span: the label under the left edge still read
   "-28 s" and crawled towards the new value one tick at a time, taking minutes to get there,

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -49,7 +49,8 @@ from ..summary import settings_summary
 from ..utils import number_string
 from ..views import avg_packet_bytes, connection_proc, filter_sort_connections
 from . import dialogs
-from .icon import apply_window_icon, make_gear_icon
+from .icon import (apply_window_icon, make_gear_icon, show_idle_icon,
+                   show_running_icon)
 from .pages import PAGES
 from .profiles import ProfileStore
 from .rates import PeakWindow
@@ -1512,9 +1513,10 @@ class App:
             self.root.title(
                 "%s  %s" % (APP_NAME, T("app.title.running")) if running
                 else APP_NAME)
-            icon = self._icon_running if running else self._icon_idle
-            if icon is not None:
-                self.root.iconphoto(True, icon)
+            if running:
+                show_running_icon(self.root, self._icon_running)
+            else:
+                show_idle_icon(self.root, self._icon_idle)
         except Exception as _exc:
             crashlog.note(_exc, "gui.app")
         # lang_cb is None whenever the Settings window is closed - it lives there

--- a/beantester/gui/icon.py
+++ b/beantester/gui/icon.py
@@ -188,3 +188,47 @@ def apply_window_icon(root):
         except Exception:
             idle = running = None
     return idle, running
+
+
+# Tk's ``iconphoto(True, img)`` is ``-default``: the icon for toplevels created
+# FROM NOW ON. On Windows that lands on the window CLASS, and a window that owns
+# an icon of its own - which the main window does, from ``iconbitmap(bean.ico)``
+# above - keeps showing that one. So the running swap used to be invisible
+# exactly where it matters (title bar, taskbar) while the recording dot DID show
+# up on the next dialog opened, which is how the bug was spotted. Both calls are
+# needed: ``False`` for this window, ``True`` so later windows match the state.
+def _set_icon(window, image, default_too=True):
+    try:
+        if default_too:
+            window.iconphoto(True, image)
+        window.iconphoto(False, image)
+        return True
+    except Exception as _exc:
+        crashlog.note(_exc, "gui.icon")
+        return False
+
+
+def show_running_icon(window, running):
+    """Put the recording-dot icon on ``window`` (and on windows opened later)."""
+    if running is None:
+        return False
+    return _set_icon(window, running)
+
+
+def show_idle_icon(window, idle):
+    """Back to the resting icon, preferring the shipped ``bean.ico``.
+
+    The .ico carries hand-drawn 16/24/32 px frames; ``bean.png`` is a single
+    256 px image, so restoring through the photo would leave the taskbar on a
+    downscale of it for the rest of the session - softer than the icon the app
+    started with, and permanently so after the first capture.
+    """
+    ok = _set_icon(window, idle) if idle is not None else False
+    try:
+        ico = resource_path("bean.ico")
+        if sys.platform.startswith("win") and os.path.exists(ico):
+            window.iconbitmap(ico)
+            return True
+    except Exception as _exc:
+        crashlog.note(_exc, "gui.icon")
+    return ok

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -250,6 +250,17 @@ class Root(W):
     def title(self, text=None):
         self.kw["title"] = text
 
+    # Recorded, not swallowed by W.__getattr__: which icon call the app makes is
+    # the whole difference between a running-state icon that shows and one that
+    # does not. Tk's "default" flag feeds FUTURE toplevels, so a swap made only
+    # with it never reaches the window the user is looking at.
+    def iconphoto(self, default=False, *images):
+        self.kw.setdefault("icons", []).append(
+            ("default" if default else "window", images[0] if images else None))
+
+    def iconbitmap(self, path=None, **_kw):
+        self.kw.setdefault("icons", []).append(("bitmap", path))
+
     def protocol(self, *a):
         return None
 

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -30,6 +30,32 @@ def test_language_switch_keeps_running_state():
     """)
 
 
+def test_the_running_icon_lands_on_the_window_not_just_the_default():
+    """The recording dot must reach the window the user is looking at.
+
+    ``iconphoto(True, img)`` is Tk's ``-default``: the icon for toplevels created
+    from then on. On Windows it lands on the window class, and the main window
+    keeps the icon it owns from ``iconbitmap(bean.ico)`` - so the swap showed the
+    dot on the next dialog opened and never on the title bar or the taskbar,
+    which is exactly how the bug reached a release. Measured with WM_GETICON: the
+    window's icon handle did not change at all until the ``False`` call was added.
+    """
+    run_gui("""
+        app.root.kw["icons"] = []               # forget the startup icon calls
+        app.running = True
+        app._sync_running_ui()
+        icons = app.root.kw["icons"]
+        assert ("window", app._icon_running) in icons, icons
+        assert ("default", app._icon_running) in icons, icons   # future toplevels
+
+        app.root.kw["icons"] = []
+        app.running = False
+        app._sync_running_ui()
+        icons = app.root.kw["icons"]
+        assert ("window", app._icon_idle) in icons, icons
+    """)
+
+
 def test_language_switch_keeps_scenario_and_loop():
     run_gui("""
         import json, tempfile, os


### PR DESCRIPTION
The recording dot only ever reached toplevels created after START - it showed up on the close-confirmation box and never on the title bar or the taskbar, so a minimised window gave no sign the tool was still touching the user's traffic.

iconphoto(True, img) is Tk's -default: the icon for windows created from then on. On Windows it lands on the window CLASS, and a window that owns an icon of its own keeps that one - the main window owns bean.ico, set by iconbitmap in apply_window_icon. Measured with WM_GETICON: the toplevel's HICON was unchanged after iconphoto(True, ...) and changed after iconphoto(False, ...).

- gui/icon.py: show_running_icon / show_idle_icon over _set_icon, which makes both calls - False for this window, True so panels opened later match
- idle restores through iconbitmap(bean.ico): the .ico carries 16/24/32 px frames while bean.png is 256 px only, so restoring through the photo left the taskbar on a downscale of it permanently after the first capture
- gui/app.py: _sync_running_ui calls the helpers instead of iconphoto directly

Guarded by test_gui_state.py::test_the_running_icon_lands_on_the_window_not_ just_the_default, which needed a fake that can see the difference: fake_tk.Root now records iconphoto/iconbitmap into kw["icons"] instead of swallowing them in W.__getattr__. It fails pre-fix with [('default', ...)] alone. The fake can only prove which call we make; that Windows repaints the taskbar is confirmed by render (convention 41).

