### PR TITLE
fix(gui): say why a numeric preference is red, not just paint it

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,26 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [0.3.0]
 
+### GUI fix: numeric preferences went red without a reason
+
+- **`gui/panels/settings.py`: the `Pref` NUMBER rows grew the error line the registry fields
+  already had.** `_on_pref_number` caught the `ValueError` from `parse_number` and dropped it,
+  keeping only `style="Bad.TEntry"` - yet that exception already carries the translated
+  `errors.field_range` / `errors.field_number` text, min and max included. The same window
+  rendered the row limit through `ControlForm`, which does show it (`form.py::validate_section`),
+  so one dialog answered the user's "what is allowed here?" for one field and stonewalled for the
+  other two.
+- **Shape copied from `ControlForm`, not invented:** one `Bad.TLabel` per `PREF_GROUPS` group
+  (`wrapping_label`, packed only while non-empty so the card keeps its height), reasons joined
+  with the same `"  •  "` separator, live messages kept per pref key in `_pref_messages` so
+  fixing one field clears only its own reason. `_pref_errors[group] = (label, number_keys)`.
+- No new i18n keys and no registry change: `prefs.py` is untouched, the text comes from the
+  `errors.*` keys that already exist in both languages (convention 9 needs nothing here).
+  Persisting is unchanged - an invalid value still never reaches `App.set_pref`.
+- Tests: `test_prefs.py::test_settings_window_number_field_says_why_it_is_red` asserts the reason
+  appears with its bounds, that a second bad field in the group ADDS a reason instead of replacing
+  it, that fixing one field clears only its own, and that the last fix unpacks the line again.
+
 ### GUI fix: the running-state icon never reached the main window (Tk `-default` trap)
 
 - **`gui/icon.py`: new `show_running_icon` / `show_idle_icon`** (over `_set_icon`), called from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **"Chart history" and "Log lines kept" now say what went wrong, not just turn red.** Typing a
+  value they do not accept outlined the box in red and left it at that, so the only way to find
+  the allowed range was to guess - while "Row limit", one card above in the same window, has
+  always spelled it out. Both now show the same sentence under their card, naming the field and
+  the range it accepts, and it disappears as soon as the value is good again. As before, a value
+  that is not accepted is never saved.
 - **The app icon now shows the red dot while a capture is running.** The dot was only ever
   reaching windows opened after you pressed START - which is why it turned up on the "close the
   app?" box and nowhere else. The icon in the title bar and on the taskbar stayed the resting

--- a/beantester/gui/panels/settings.py
+++ b/beantester/gui/panels/settings.py
@@ -23,7 +23,8 @@ from ...utils import number_string
 from ...validators import parse_number
 from ..accordion import CollapsibleSection
 from ..form import ControlForm
-from ..prefs import ACTION, BOOL, PREF_GROUPS, PREFS_BY_KEY
+from ..labels import wrapping_label
+from ..prefs import ACTION, BOOL, NUMBER, PREF_GROUPS, PREFS_BY_KEY
 from ..scaling import scaled
 from ..theme import popdown_height, unhighlight_combobox
 from ..tooltip import add_tooltip
@@ -43,6 +44,8 @@ class SettingsWindow(PanelWindow):
         app = self.app
         self._pref_vars = {}
         self._pref_entries = {}
+        self._pref_errors = {}      # group label -> (error label, its number keys)
+        self._pref_messages = {}    # pref key -> live validation message
 
         # -- language (not a registry field: it lives in *_ui.json) ------------ #
         lang_row = ttk.Frame(body)
@@ -91,6 +94,12 @@ class SettingsWindow(PanelWindow):
         panel.pack()
         for key in keys:
             self._build_pref_row(panel.body, PREFS_BY_KEY[key])
+        numbers = tuple(k for k in keys if PREFS_BY_KEY[k].kind == NUMBER)
+        if numbers:
+            # Same error line the registry fields get from ControlForm: packed only
+            # while it says something, so the card does not reserve a blank row.
+            err = wrapping_label(panel.body, "", style="Bad.TLabel")
+            self._pref_errors[group_label] = (err, numbers)
 
     def _build_pref_row(self, card, pref):
         app = self.app
@@ -135,17 +144,36 @@ class SettingsWindow(PanelWindow):
         entry.bind("<FocusOut>", handler, add="+")
 
     def _on_pref_number(self, pref):
-        """Validate a numeric preference and persist it; paint the field red on a
-        bad value (out of range or not a number) instead of storing garbage."""
+        """Validate a numeric preference and persist it; a bad value (out of range
+        or not a number) paints the field red and SAYS WHY, instead of storing
+        garbage. The red border alone never named the allowed range - the registry
+        fields above it did, which made the same mistake look like two bugs."""
         var = self._pref_vars[pref.key]
         entry = self._pref_entries[pref.key]
         try:
             value = parse_number(str(var.get()).strip(), pref.label, pref.bounds)
+        except ValueError as exc:
+            entry.config(style="Bad.TEntry")
+            self._pref_messages[pref.key] = str(exc)
+        else:
             entry.config(style="TEntry")
+            self._pref_messages.pop(pref.key, None)
             self.app.set_pref(
                 pref.key, int(value) if float(value).is_integer() else value)
-        except ValueError:
-            entry.config(style="Bad.TEntry")
+        self._show_pref_errors()
+
+    def _show_pref_errors(self):
+        """List every live reason under its group, the way ControlForm does."""
+        for err, keys in self._pref_errors.values():
+            messages = [self._pref_messages[k] for k in keys
+                        if k in self._pref_messages]
+            if messages:
+                err.config(text="  •  ".join(messages))
+                if not err.winfo_ismapped():
+                    err.pack(fill="x", pady=(scaled(5), 0))
+            else:
+                err.config(text="")
+                err.pack_forget()
 
     def close(self):
         # Drop the App's handle to our language box before the widgets die, so

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -213,6 +213,42 @@ def test_settings_window_number_field_validates_before_persisting():
     """)
 
 
+def test_settings_window_number_field_says_why_it_is_red():
+    """A red border is not a reason. The registry field on the same window (the
+    row limit) named its allowed range from day one, while the preferences only
+    turned red - the same mistake looked like two different bugs. Every reason is
+    listed under its own group, and the line disappears once the value is good."""
+    run_gui("""
+        panel = app.open_window("settings")
+        from beantester.gui.prefs import PREFS_BY_KEY
+        err, keys = panel._pref_errors["prefs.group_view"]
+        assert "chart_seconds" in keys and "log_lines" in keys
+
+        panel._pref_vars["chart_seconds"].set("2")          # bounds are (10, 3600)
+        panel._on_pref_number(PREFS_BY_KEY["chart_seconds"])
+        assert err.pack_info is not None, "the reason must be shown, not just the red box"
+        first = err.kw["text"]
+        assert "3600" in first and "10" in first, first
+
+        # a second bad field in the same group adds a reason, it does not replace one
+        panel._pref_vars["log_lines"].set("3")              # bounds are (50, 100000)
+        panel._on_pref_number(PREFS_BY_KEY["log_lines"])
+        both = err.kw["text"]
+        assert first in both and "100000" in both, both
+
+        # fixing one clears only its own reason
+        panel._pref_vars["chart_seconds"].set("120")
+        panel._on_pref_number(PREFS_BY_KEY["chart_seconds"])
+        assert first not in err.kw["text"] and "100000" in err.kw["text"], err.kw["text"]
+
+        # fixing the last one takes the whole line away again
+        panel._pref_vars["log_lines"].set("500")
+        panel._on_pref_number(PREFS_BY_KEY["log_lines"])
+        assert err.kw["text"] == "", err.kw["text"]
+        assert err.pack_info is None
+    """)
+
+
 def test_reset_ui_layout_forgets_window_state():
     run_gui("""
         from beantester.gui import dialogs


### PR DESCRIPTION
Chart history and Log lines kept only got style="Bad.TEntry" on a bad value: _on_pref_number caught the ValueError from parse_number and threw away the message that already names the field and its range. The row limit, one card up in the same window, is rendered by ControlForm and has always shown that sentence - so the same mistake looked like two bugs.

Each PREF_GROUPS group with a NUMBER pref now gets the same Bad.TLabel line ControlForm gives a section: packed only while non-empty, reasons joined with the same separator, kept per pref key so fixing one field clears only its own reason. No new i18n keys (errors.field_range / errors.field_number already exist in both languages) and no registry change; an invalid value still never reaches App.set_pref.
