### PR TITLE
chore(release): date the 0.3.0 changelog headings

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -15,7 +15,7 @@ flags, exit codes, the NDJSON schema, on-disk file formats, or the facade's publ
 a `### BREAKING` section placed FIRST in that version, and each such line is prefixed with
 `**BREAKING:**`. A breaking change also requires a version bump by the owner (convention 34).
 
-## [0.3.0]
+## [0.3.0] - 2026-07-20
 
 ### GUI fix: numeric preferences went red without a reason
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Bean Network Tester.
 The format follows [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
-## [0.3.0]
+## [0.3.0] - 2026-07-20
 
 ### Changed
 


### PR DESCRIPTION
VERSION.txt has read 0.3.0 for a while; closing the version means the changelogs should say when. Same shape as the 0.2.0 heading below them.

