### PR TITLE
ci: run the test suite once, under coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,24 +66,21 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Test suite (engine + i18n + CLI + fail-safe + tables + GUI smoke)
-        run: python -m pytest tests
-
-      # The two suites that find what example-based tests cannot: the filter
-      # mini-language runs in the packet hot path (it must never raise), and the
-      # CLI is the CI contract (every outcome has an exit code, never a traceback).
-      - name: Property-based tests + CLI fuzzing
-        run: python -m pytest tests/test_matchers_properties.py tests/test_cli_fuzz.py -q
-
-      # Threads are only dangerous together: a "running" engine with a dead capture
-      # thread means WinDivert is queueing the user's packets into a void.
-      - name: Concurrency chaos (fail-open, deadlocks, thread leaks)
-        run: python -m pytest tests/test_concurrency_chaos.py -q
-
+      # ONE run of the whole suite, under coverage. testpaths=["tests"] (pyproject)
+      # means this already includes the suites that used to own separate steps:
+      #   * property-based matchers + CLI fuzzing - the filter mini-language runs in
+      #     the packet hot path (it must never raise), and the CLI is the CI contract
+      #     (every outcome has an exit code, never a traceback);
+      #   * concurrency chaos - threads are only dangerous together: a "running"
+      #     engine with a dead capture thread means WinDivert is queueing the user's
+      #     packets into a void.
+      # Those steps re-ran tests the full run had just executed, on every matrix cell.
+      # pytest names the failing file, so the extra checkmarks bought no diagnosis.
+      #
       # COVERAGE_PROCESS_START is not optional: the GUI tests run in subprocesses,
       # and without it every line they exercise is reported as uncovered (the same
       # suite reads 51% instead of 77%). The gate lives in pyproject (fail_under).
-      - name: Coverage gate
+      - name: Test suite + coverage gate (engine, i18n, CLI, fail-safe, tables, chaos)
         env:
           COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
         run: python -m pytest tests --cov=beantester --cov-report=term --cov-report=xml

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -15,6 +15,27 @@ flags, exit codes, the NDJSON schema, on-disk file formats, or the facade's publ
 a `### BREAKING` section placed FIRST in that version, and each such line is prefixed with
 `**BREAKING:**`. A breaking change also requires a version bump by the owner (convention 34).
 
+## [Unreleased]
+
+### CI: one run of the test suite, under coverage
+
+- **`.github/workflows/ci.yml`: the `tests` job ran the whole suite twice over, plus two
+  overlapping subsets.** Four steps executed: `pytest tests`, then the
+  `test_matchers_properties.py` + `test_cli_fuzz.py` subset, then `test_concurrency_chaos.py`,
+  then `pytest tests --cov` over everything again. `testpaths = ["tests"]` (pyproject) already
+  pulls both subsets into every full run, so the middle steps re-executed tests that had just
+  passed - on ubuntu and windows, on 3.10 and 3.13, four cells deep.
+- **Now a single step:** `pytest tests --cov=beantester` with `COVERAGE_PROCESS_START`, keeping
+  the `fail_under = 77` gate and the `coverage.xml` artifact. Nothing changed about WHICH tests
+  run. The rationale each deleted step carried (why the property/fuzz suites and the chaos suite
+  earn their keep) moved into a comment on the surviving step, so the reasoning outlived the
+  checkmarks it was attached to.
+- **Accepted trade:** a failure now surfaces as one red step instead of a named one (pytest
+  still names the file and test, so diagnosis is unaffected), and the wall-clock assertions
+  (`test_failsafe.py` start/stop under 0.2 s, `test_model_worker.py`, `test_audit_fixes.py`) lose
+  their uninstrumented reference run. They already ran under coverage in the old gate step and
+  passed; if one starts flaking, split the clean run back out.
+
 ## [0.3.0] - 2026-07-20
 
 ### GUI fix: numeric preferences went red without a reason


### PR DESCRIPTION
The tests job ran the whole suite twice over, plus two overlapping subsets: pytest tests, then the property/fuzz subset, then the chaos suite, then pytest tests --cov over everything again. testpaths=["tests"] already pulls both subsets into every full run, so the middle steps re-executed tests that had just passed - on ubuntu and windows, on 3.10 and 3.13.

- .github/workflows/ci.yml: collapse the four pytest steps into one run with --cov, keeping COVERAGE_PROCESS_START and the fail_under=77 gate
- move the rationale the deleted steps carried into a comment on the surviving step, so the reasoning outlives the checkmarks it was attached to
- CHANGELOG-INTERNAL.md: record the change and the accepted trade (one red step instead of a named one; the wall-clock assertions lose their uninstrumented reference run)

No change to which tests execute.
