### PR TITLE
fix(cli)!: reject --gui combined with other options

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### BREAKING
+
+- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
+  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
+  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
+  while `--help` advertised "force the GUI". On real WinDivert that meant
+  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
+  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
+  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
+  to stderr and stdout stays clean.
+- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
+  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
+  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
+  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
+  than widening it.
+- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
+  loss and getting zero without being told is the class of quiet lie this project removes), and
+  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
+  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
+  than declined.
+- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
+  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
+- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
+- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
+
 ### CI: one run of the test suite, under coverage
 
 - **`.github/workflows/ci.yml`: the `tests` job ran the whole suite twice over, plus two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Bean Network Tester.
 The format follows [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
+## [Unreleased]
+
+### BREAKING
+
+- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
+  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
+  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
+  console you may not have been watching. It now stops immediately with a usage error (exit
+  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
+  settings from the command line. If a script of yours relied on the old behaviour, delete
+  `--gui` from it and it behaves exactly as before.
+
 ## [0.3.0] - 2026-07-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ ranges, `!`, `>`, `<`, `>=`, `<=`, wildcards, `re:`, and `--dst-ip` additionally
 | `--log-conns` | print the observed connections at the end |
 | `--repro-out FILE` | save a reproduction report (JSON) |
 | `--simulate` | synthetic traffic instead of WinDivert (test with no Windows, no driver, no admin) |
-| `--gui` | force the GUI |
+| `--gui` | open the GUI. Valid **on its own only** - the GUI has its own controls, so combining it with settings flags is a usage error (exit 2) rather than a silent headless run |
 | `--version` | print the version and exit |
 
 **Output and diagnostics**

--- a/README.pl.md
+++ b/README.pl.md
@@ -500,7 +500,7 @@ BeanNetworkTester.exe --simulate --duration 30 --format json > run.ndjson
 | `--log-conns` | wypisz na końcu zaobserwowane połączenia |
 | `--repro-out PLIK` | zapisz raport reprodukcji (JSON) |
 | `--simulate` | sztuczny ruch zamiast WinDivert (test bez Windows, bez sterownika i bez admina) |
-| `--gui` | wymuś GUI |
+| `--gui` | otwórz GUI. Działa **tylko samodzielnie** - GUI ma własne kontrolki, więc połączenie tej flagi z ustawieniami jest błędem użycia (kod 2), a nie cichym przebiegiem bez okna |
 | `--version` | wersja i koniec |
 
 **Wyjście i diagnostyka**

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -70,7 +70,9 @@ def build_arg_parser():
                    version=f"{APP_NAME} {__version__}")
     p.add_argument("--license", action="store_true",
                    help="print the licence and the third-party notices, then exit")
-    p.add_argument("--gui", action="store_true", help="force the GUI")
+    p.add_argument("--gui", action="store_true",
+                   help="open the GUI (only valid on its own - the GUI has its "
+                        "own controls, so it takes no settings flags)")
     p.add_argument("--config", help="load settings from a JSON file")
     p.add_argument("--save-config", help="save effective settings to a JSON file and exit")
     p.add_argument("--preset", metavar="PRESET",
@@ -536,6 +538,16 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
                  out=out, err=err)
     _install_signal_handlers()
     try:
+        # --gui reaching the CLI runner means it was combined with something else:
+        # main() sends a bare --gui straight to the GUI. It used to be accepted and
+        # then ignored, so `--gui --loss 30 --duration 600` promised a window and
+        # instead ran a headless ten-minute impairment - no window, no STOP button,
+        # on a tool whose whole job is to break the user's own network.
+        if args.gui:
+            _fail(exitcodes.USAGE,
+                  "--gui cannot be combined with other options: it opens the GUI, "
+                  "which has its own controls. Launch the GUI with no arguments, or "
+                  "drop --gui to run these settings from the command line.")
         if args.license:
             return _run_license(log)
         if args.doctor:

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -194,6 +194,21 @@ def test_usage_errors_keep_argparse_exit_code_2():
     check("exit: unknown flag -> USAGE(2)", raised == exitcodes.USAGE, f"({raised})")
 
 
+def test_gui_flag_combined_with_settings_is_a_usage_error():
+    """``--gui --loss 30`` must not quietly become a headless impairment run.
+
+    ``main()`` routes a bare ``--gui`` to the GUI, so the flag only reaches the CLI
+    runner when it was combined with something else. That used to be accepted and
+    then ignored: the flag advertised "force the GUI" and instead started a session
+    with no window and no STOP button - on a tool that breaks the user's network.
+    """
+    code, out, err = cli(["--gui", "--loss", "30", "--duration", "600"])
+    check("--gui + settings -> USAGE(2)", code == exitcodes.USAGE, f"(code={code})")
+    check("--gui: the reason is on stderr", "--gui" in err, f"({err!r})")
+    # a failed run never writes to the data channel (same contract as test_cli_fuzz)
+    check("--gui: stdout stays clean", not out.strip(), f"({out!r})")
+
+
 # --- output channels -------------------------------------------------------- #
 
 


### PR DESCRIPTION
--gui was parsed and then never read. main() routes to the GUI only when argv is empty or exactly ["--gui"], so every other combination fell through to a full CLI session while --help advertised "force the GUI". On real WinDivert that meant `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP button - only Ctrl+C in a console the user may not have been watching.

- cli.py: guard at the top of run_cli's try block, before --license/--doctor/ --cleanup-driver, raising CliError(USAGE) so the reason goes to stderr and stdout stays clean
- cli.py: --gui help text now says the flag is valid on its own
- tests/test_cli_runtime.py: new test asserting USAGE(2), the reason on stderr and an empty data channel
- README.md, README.pl.md: flag tables updated
- both changelogs: ### BREAKING section (convention 39)

Rejected: opening the GUI while silently dropping the other flags (asking for 30% loss and getting zero without being told). Prefilling the GUI form from the flags is nicer and stays open, but it needs gui/app.py, which is due for decomposition.

BREAKING CHANGE: `--gui` with any other option now exits USAGE(2) instead of running a headless CLI session. Scripts relying on the old behaviour should drop --gui. Version bump left to the owner (convention 34).

