### PR TITLE
fix(driver): read a service state with read rights, not ALL_ACCESS

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,48 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### driver.py: read a service with read rights, not ALL_ACCESS
+
+- **`service_state` opened services with `SERVICE_ALL_ACCESS` (0xF01FF) just to read their
+  state, and mapped the resulting failure to `None` = "not installed".** Measured on Windows 11
+  from an ELEVATED shell, so this was never a "needs admin" problem:
+
+      OpenServiceW(Schedule, SERVICE_ALL_ACCESS)    -> NULL, error 5 (ACCESS_DENIED)
+      OpenServiceW(Schedule, SERVICE_QUERY_STATUS)  -> handle, QueryServiceStatus = running
+
+  Same for `Dnscache`; `EventLog` grants both, which is why the path looked fine. Any service
+  whose security descriptor withholds full control read back as absent. Now
+  `SC_MANAGER_CONNECT` + `SERVICE_QUERY_STATUS`, which also makes the read work unelevated.
+- **Third return value `NO_ACCESS`**, distinct from a state label and from `None`. "I cannot
+  tell" and "it is not there" lead to opposite conclusions, so they no longer share a value.
+  `installed_drivers()` keeps such a service in the dict (absence from that dict has to keep
+  meaning "not installed"); `doctor()` renders it `warn` with a "re-run as Administrator" hint
+  instead of `ok / not loaded`. Exit codes are untouched: `warn` is not `fail`, and
+  `ok = all(state != "fail")` is unchanged.
+- **`_advapi()` now loads advapi32 with `use_last_error=True`.** `ctypes.get_last_error()` in
+  `stop_and_remove` read a thread-local ctypes never populated, so it was always 0 and both
+  branches of the `if` returned the same string - dead code pretending to discriminate. With the
+  flag it works, so a refusal is reported as `access denied` rather than `not installed`.
+- **`stop_and_remove` deliberately keeps `SERVICE_ALL_ACCESS`.** Narrowing it to
+  `SERVICE_STOP|DELETE|SERVICE_QUERY_STATUS` (0x10024) was measured and does NOT help: a
+  hardened service denies `DELETE` itself. The only honest improvement there is the message.
+- **`_advapi()` and the `SERVICE_STATUS` structure are cached** in module-level slots.
+  `installed_drivers()` asks about three service names, and each call used to rebuild the
+  binding, re-assign six sets of prototypes and define a fresh `ctypes.Structure` subclass.
+  `ctypes.WinDLL(...)` (unlike `ctypes.windll.advapi32`) returns a NEW object per call, so
+  without the cache the `use_last_error` change would have been a small regression. Both stay
+  lazy: `ctypes.wintypes` does not import on Linux and CI runs on ubuntu too.
+- New tests in `tests/test_driver_windows.py`:
+  `test_reading_a_service_state_asks_only_for_the_right_to_read` (the regression guard - probes
+  `Schedule`/`Dnscache`/`EventLog` on Windows and requires a real state back, plus a genuinely
+  absent service still returning `None`), `test_advapi_and_status_type_are_built_once`,
+  `test_doctor_says_it_could_not_look_rather_than_not_loaded` and
+  `test_doctor_still_calls_a_clean_machine_not_loaded` (both directions of the doctor row).
+- Not proven, stated plainly: no WinDivert driver was loaded on the test machine, so this is a
+  correctness and robustness fix rather than a reproduced WinDivert failure. WinDivert's own
+  service descriptor is probably permissive today; the point is that `--doctor` no longer
+  depends on it staying that way.
+
 ### BREAKING
 
 - **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--doctor` could report a WinDivert driver as "not loaded" when it simply was not allowed
+  to look.** Windows refuses full access to some services even for an Administrator, and the
+  check treated that refusal as "the service is not there" - in the one command whose whole job
+  is to tell you the truth about your machine. It now asks only for permission to read the
+  state, which also means the driver line is accurate **without** running as Administrator. If
+  the state genuinely cannot be read, the line now says so and warns, instead of quietly
+  reporting a clean machine.
+- **`--cleanup-driver` explains a refusal instead of calling it "not installed".** Being told
+  "access denied - the service exists but this account may not remove it" points somewhere;
+  being told the service was never there does not.
+
 ### BREAKING
 
 - **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -

--- a/beantester/driver.py
+++ b/beantester/driver.py
@@ -44,6 +44,10 @@ from .winenv import is_admin, is_windows
 # not a test fake): only then is there a driver to unload at exit.
 _DRIVER_USED = [False]
 
+# Lazy, Windows-only singletons (see _advapi / _status_type).
+_ADVAPI = [None]
+_STATUS_TYPE = [None]
+
 
 def mark_driver_used():
     _DRIVER_USED[0] = True
@@ -57,15 +61,37 @@ def driver_used():
 DRIVER_SERVICES = ("WinDivert", "WinDivert1.4", "WinDivert1.1")
 
 # Service control constants (winsvc.h)
+#
+# READING a service state must ask for the RIGHTS TO READ, nothing more. This is
+# not hygiene, it is correctness: a service whose security descriptor does not
+# grant full control reads back as "not installed" if you open it with
+# SERVICE_ALL_ACCESS. Measured on Windows 11, from an ELEVATED shell:
+#
+#     OpenServiceW(Schedule, SERVICE_ALL_ACCESS)    -> NULL, error 5 (access denied)
+#     OpenServiceW(Schedule, SERVICE_QUERY_STATUS)  -> handle, state = running
+#
+# Same for Dnscache; EventLog happens to grant both. So the old mask turned "this
+# service is protected" into "this service does not exist" - in the one command
+# (--doctor) whose entire job is to tell the user the truth about their machine.
+# The ALL_ACCESS pair below is still used by the CLEANUP path, which genuinely
+# needs to stop and delete (and is gated on is_admin()).
 _SC_MANAGER_ALL_ACCESS = 0xF003F
+_SC_MANAGER_CONNECT = 0x0001
 _SERVICE_ALL_ACCESS = 0xF01FF
+_SERVICE_QUERY_STATUS = 0x0004
 _SERVICE_CONTROL_STOP = 0x1
 _SERVICE_STOPPED = 0x1
+_ERROR_ACCESS_DENIED = 5
 _ERROR_SERVICE_DOES_NOT_EXIST = 1060
 
 STATE_LABELS = {1: "stopped", 2: "start pending", 3: "stop pending",
                 4: "running", 5: "continue pending", 6: "pause pending",
                 7: "paused"}
+
+# Third answer, distinct from a state and from None: the service manager refused
+# to let us look. "I cannot tell" and "it is not there" lead the user to opposite
+# conclusions, so they must not share a return value.
+NO_ACCESS = "no access"
 
 
 def _advapi():
@@ -83,11 +109,21 @@ def _advapi():
 
     Declaring argtypes/restype makes ctypes pass real 64-bit handles and marshal
     the return values correctly. This is not optional on Win64; it is the contract.
+
+    Loaded with ``use_last_error=True`` so ``ctypes.get_last_error()`` actually
+    reports the Win32 error. Without it the call site read a thread-local that
+    ctypes never populated, so it always saw 0 and could not tell "not installed"
+    (1060) from "access denied" (5) - both branches returned the same string.
+
+    Cached: ``installed_drivers()`` asks about three service names, and each call
+    used to rebuild the binding and re-assign six sets of prototypes.
     """
+    if _ADVAPI[0] is not None:
+        return _ADVAPI[0]
     import ctypes
     from ctypes import wintypes
 
-    lib = ctypes.windll.advapi32
+    lib = ctypes.WinDLL("advapi32", use_last_error=True)
     # A handle is pointer-sized. wintypes.HANDLE is the right width on 32- and 64-bit.
     H = wintypes.HANDLE
     lib.OpenSCManagerW.argtypes = [wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD]
@@ -102,13 +138,15 @@ def _advapi():
     lib.DeleteService.restype = wintypes.BOOL
     lib.CloseServiceHandle.argtypes = [H]
     lib.CloseServiceHandle.restype = wintypes.BOOL
+    _ADVAPI[0] = lib
     return lib
 
 
-def service_state(name):
-    """Return ``'running'`` / ``'stopped'`` / ... , or ``None`` if not installed."""
-    if not is_windows():
-        return None
+def _status_type():
+    """SERVICE_STATUS, built once. Windows-only: ``ctypes.wintypes`` does not even
+    import on Linux, so this cannot live at module level (CI runs on ubuntu too)."""
+    if _STATUS_TYPE[0] is not None:
+        return _STATUS_TYPE[0]
     import ctypes
     from ctypes import wintypes
 
@@ -121,18 +159,39 @@ def service_state(name):
                     ("dwCheckPoint", wintypes.DWORD),
                     ("dwWaitHint", wintypes.DWORD)]
 
-    api = _advapi()
-    manager = api.OpenSCManagerW(None, None, _SC_MANAGER_ALL_ACCESS)
-    if not manager:
+    _STATUS_TYPE[0] = _STATUS
+    return _STATUS
+
+
+def service_state(name):
+    """State of one service, asking only for the right to READ it.
+
+    Returns a label from ``STATE_LABELS``, ``None`` when the service is genuinely
+    not installed, or ``NO_ACCESS`` when the service manager refused to tell us.
+    That third answer matters: reporting "not installed" for a service we were not
+    allowed to open sends the user looking in the wrong place - see the note on the
+    access masks above, where SERVICE_ALL_ACCESS is denied on real Windows services
+    even to an Administrator.
+    """
+    if not is_windows():
         return None
+    import ctypes
+
+    api = _advapi()
+    manager = api.OpenSCManagerW(None, None, _SC_MANAGER_CONNECT)
+    if not manager:
+        # SC_MANAGER_CONNECT is granted to Authenticated Users, so this failing at
+        # all means something unusual - not an absent service.
+        return NO_ACCESS
     try:
-        handle = api.OpenServiceW(manager, name, _SERVICE_ALL_ACCESS)
+        handle = api.OpenServiceW(manager, name, _SERVICE_QUERY_STATUS)
         if not handle:
-            return None
+            err = ctypes.get_last_error()
+            return None if err == _ERROR_SERVICE_DOES_NOT_EXIST else NO_ACCESS
         try:
-            status = _STATUS()
+            status = _status_type()()
             if not api.QueryServiceStatus(handle, ctypes.byref(status)):
-                return None
+                return NO_ACCESS
             return STATE_LABELS.get(int(status.dwCurrentState), "unknown")
         finally:
             api.CloseServiceHandle(handle)
@@ -141,7 +200,12 @@ def service_state(name):
 
 
 def installed_drivers():
-    """``{service name: state}`` for every WinDivert service present."""
+    """``{service name: state}`` for every WinDivert service present.
+
+    A service we were not allowed to read is present with the state ``NO_ACCESS``
+    rather than being dropped: absent from this dict means "not installed", and
+    that claim has to stay trustworthy.
+    """
     found = {}
     for name in DRIVER_SERVICES:
         state = service_state(name)
@@ -155,30 +219,27 @@ def stop_and_remove(name):
     if not is_windows():
         return f"{name}: not Windows, nothing to do"
     import ctypes
-    from ctypes import wintypes
-
-    class _STATUS(ctypes.Structure):
-        _fields_ = [("dwServiceType", wintypes.DWORD),
-                    ("dwCurrentState", wintypes.DWORD),
-                    ("dwControlsAccepted", wintypes.DWORD),
-                    ("dwWin32ExitCode", wintypes.DWORD),
-                    ("dwServiceSpecificExitCode", wintypes.DWORD),
-                    ("dwCheckPoint", wintypes.DWORD),
-                    ("dwWaitHint", wintypes.DWORD)]
 
     api = _advapi()
     manager = api.OpenSCManagerW(None, None, _SC_MANAGER_ALL_ACCESS)
     if not manager:
         return f"{name}: cannot open the service manager (Administrator required)"
     try:
+        # ALL_ACCESS on purpose here: this path stops and DELETES. Narrowing it to
+        # SERVICE_STOP|DELETE|QUERY_STATUS was measured and does NOT help - a
+        # hardened service denies DELETE itself, so the honest thing left to do is
+        # report WHY rather than pretend the service was never there.
         handle = api.OpenServiceW(manager, name, _SERVICE_ALL_ACCESS)
         if not handle:
-            err = ctypes.get_last_error() if hasattr(ctypes, "get_last_error") else 0
-            if err == _ERROR_SERVICE_DOES_NOT_EXIST:
-                return f"{name}: not installed"
+            err = ctypes.get_last_error()
+            if err == _ERROR_ACCESS_DENIED:
+                return (f"{name}: access denied - the service exists but this "
+                        f"account may not stop or remove it")
+            if err != _ERROR_SERVICE_DOES_NOT_EXIST:
+                return f"{name}: cannot open the service (Windows error {err})"
             return f"{name}: not installed"
         try:
-            status = _STATUS()
+            status = _status_type()()
             api.ControlService(handle, _SERVICE_CONTROL_STOP, ctypes.byref(status))
             deleted = bool(api.DeleteService(handle))
             return (f"{name}: stopped and removed" if deleted
@@ -264,11 +325,17 @@ def doctor():
         drivers = installed_drivers()
         if drivers:
             running = [n for n, s in drivers.items() if s == "running"]
+            blocked = [n for n, s in drivers.items() if s == NO_ACCESS]
+            detail = ", ".join(f"{n}={s}" for n, s in drivers.items())
+            if blocked:
+                # "I could not look" must never be printed as a clean bill of health
+                detail += (" - the service manager would not report the state; "
+                           "re-run as Administrator to be sure")
+            elif running:
+                detail += (" - a session may still be active elsewhere; "
+                           "use --cleanup-driver if not")
             checks.append(("windivert driver",
-                           "warn" if running else "ok",
-                           ", ".join(f"{n}={s}" for n, s in drivers.items())
-                           + (" - a session may still be active elsewhere; "
-                              "use --cleanup-driver if not" if running else "")))
+                           "warn" if (running or blocked) else "ok", detail))
         else:
             checks.append(("windivert driver", "ok", "not loaded"))
         leftovers = stale_temp_dirs()

--- a/tests/test_driver_windows.py
+++ b/tests/test_driver_windows.py
@@ -44,6 +44,63 @@ def test_advapi_declares_pointer_sized_prototypes():
           lib.OpenSCManagerW.restype is handle)
 
 
+def test_reading_a_service_state_asks_only_for_the_right_to_read():
+    """The regression guard for the access-mask bug.
+
+    ``SERVICE_ALL_ACCESS`` is denied on hardened Windows services even to an
+    Administrator, so opening a service with it and treating the failure as
+    "not installed" turned a protected service into a missing one. Measured on
+    Windows 11 from an elevated shell: ``Schedule`` and ``Dnscache`` both returned
+    error 5 with ALL_ACCESS and their real state with ``SERVICE_QUERY_STATUS``.
+
+    Go back to the wide mask and this goes red on the Windows runner.
+    """
+    if not hasattr(ctypes, "windll"):
+        check("service_state is a no-op off Windows", driver.service_state("x") is None)
+        return
+
+    probes = ("Schedule", "Dnscache", "EventLog")     # core services, always present
+    states = {name: driver.service_state(name) for name in probes}
+    readable = [n for n, s in states.items()
+                if s is not None and s != driver.NO_ACCESS]
+    check("a real Windows service reports its state instead of reading as absent",
+          readable, f"({states})")
+    check("a service that truly does not exist is still None",
+          driver.service_state("BeanNetworkTesterNoSuchService") is None)
+
+
+def test_advapi_and_status_type_are_built_once():
+    """``installed_drivers()`` asks about three names; rebuilding the binding and
+    re-assigning six sets of prototypes each time is pure waste."""
+    if not hasattr(ctypes, "windll"):
+        return
+    check("the advapi32 binding is cached", driver._advapi() is driver._advapi())
+    check("the SERVICE_STATUS type is cached",
+          driver._status_type() is driver._status_type())
+
+
+def test_doctor_says_it_could_not_look_rather_than_not_loaded(monkeypatch):
+    """"I was not allowed to check" must never print as a clean bill of health."""
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers",
+                        lambda: {"WinDivert": driver.NO_ACCESS})
+    _, checks = driver.doctor()
+    row = next(c for c in checks if c[0] == "windivert driver")
+    check("doctor: an unreadable service is a warning", row[1] == "warn", f"({row})")
+    check("doctor: it says the state could not be read",
+          "would not report" in row[2], f"({row})")
+
+
+def test_doctor_still_calls_a_clean_machine_not_loaded(monkeypatch):
+    """The other direction: no driver must not start warning people for nothing."""
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers", lambda: {})
+    _, checks = driver.doctor()
+    row = next(c for c in checks if c[0] == "windivert driver")
+    check("doctor: nothing installed stays a clean 'ok'",
+          row[1] == "ok" and "not loaded" in row[2], f"({row})")
+
+
 def test_release_on_exit_never_raises_and_is_a_noop_without_a_driver():
     """release_on_exit must be crash-proof: it runs on the way out of every CLI
     run, and a fault there (the access violation) would take the process down


### PR DESCRIPTION
service_state opened services with SERVICE_ALL_ACCESS just to read their state and mapped the failure to None = "not installed". Measured on Windows 11 from an ELEVATED shell, so this was never a "needs admin" problem:

  OpenServiceW(Schedule, SERVICE_ALL_ACCESS)   -> NULL, error 5 (ACCESS_DENIED)
  OpenServiceW(Schedule, SERVICE_QUERY_STATUS) -> handle, state = running

Same for Dnscache; EventLog grants both, which is why the path looked healthy. Any service whose security descriptor withholds full control read back as absent - in the one command whose whole job is to report the truth.

- service_state: SC_MANAGER_CONNECT + SERVICE_QUERY_STATUS, which also makes the read work without elevation
- new NO_ACCESS return, distinct from a state and from None; doctor() renders it warn + "re-run as Administrator" instead of ok/"not loaded". Exit codes unchanged (warn is not fail)
- _advapi: load advapi32 with use_last_error=True, so the get_last_error branch in stop_and_remove stops being dead code and a refusal reads as "access denied" rather than "not installed"
- cache _advapi and the SERVICE_STATUS type; ctypes.WinDLL returns a new object per call, so without this the use_last_error change would have been a small regression. Both stay lazy (ctypes.wintypes does not import on Linux)
- stop_and_remove keeps ALL_ACCESS on purpose: the narrower stop|delete|query mask was measured and does not help, since DELETE itself is what is denied
- 4 new tests in tests/test_driver_windows.py, including a Windows regression guard that goes red if the wide mask comes back

No WinDivert driver was loaded on the test machine, so this is a correctness and robustness fix, not a reproduced WinDivert failure.

