### PR TITLE
fix(portmap): stop losing socket-table failures in silence

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,105 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### BREAKING
+
+- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
+  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
+  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
+  while `--help` advertised "force the GUI". On real WinDivert that meant
+  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
+  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
+  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
+  to stderr and stdout stays clean.
+- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
+  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
+  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
+  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
+  than widening it.
+- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
+  loss and getting zero without being told is the class of quiet lie this project removes), and
+  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
+  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
+  than declined.
+- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
+  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
+- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
+- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
+
+### portmap/engine/processes: port-resolution failures stop being invisible
+
+- **`_Native.port_pid_map` accepted a PARTIAL socket table as the truth.** `ok |= self._table(...)`
+  over the four (proto, family) combinations left `ok` True when three of four answered, and
+  `refresh()` cached the result as authoritative. A missing table means sockets the tool cannot
+  see, and an unseen socket is traffic the user asked to impair sailing through untouched -
+  which on screen looks exactly like "the application coped". The failures are now counted and
+  named: all four failing still returns `None` (psutil fallback, unchanged), a partial result is
+  still returned but goes through `crashlog.once("portmap.native.<tables>")`, with the failing
+  tables in the key so a different failure is recorded too.
+- **The stricter option (any failure -> psutil) was rejected on purpose.** Measured on the dev
+  machine, all four tables answer `rc=0` (tcp/v4 103 rows, tcp/v6 10, udp/v4 90, udp/v6 23), so
+  the failure mode is NOT reproducible here. Trading a possible gap for a certain order-of-
+  magnitude slowdown, on a path that cannot be tested, is the wrong bet; when a real machine
+  reports it, `crashes/` will hold the evidence and the decision can be made on data.
+- **`_Native._table` no longer pretends to reuse its buffer.** The comment claimed "grow and KEEP
+  one buffer per table", but a fresh `create_string_buffer` was allocated on every call and the
+  stored buffer was never read back - the cache only pinned memory. `self._buffers` becomes
+  `self._sizes` (the size hint is the part that was doing work). Real reuse was considered and
+  rejected: four allocations a few times a second against aliasing between calls in ctypes code.
+- **`engine._process_for` / `_pid_for` now use `crashlog.once("engine.ports*")`.** They swallowed
+  silently while the same file, 200 lines up, already used `crashlog.once("engine.packet")` for
+  the same class of event on the same thread. `once()` and not `note()` because this is the
+  capture path: a port table that starts failing turns every row's process into "?", which is
+  worth one traceback, not one per packet.
+- **`processes.port_process_map` uses `crashlog.quiet("processes.port_map")`.** Best-effort for
+  the caller (an empty map still just means "?"), recorded for us.
+- New tests in `tests/test_processes.py`: `test_port_process_map_records_a_failure_instead_of_swallowing_it`,
+  `test_a_partial_socket_table_is_reported_not_silently_trusted`,
+  `test_every_socket_table_failing_falls_back_to_psutil`,
+  `test_engine_records_a_broken_port_table_instead_of_going_quiet`. They spy on `crashlog.record`
+  (and reset `_once_seen`) instead of reading the crash directory, so they touch no disk.
+
+### Changelog structure: `### BREAKING` first, now guarded
+
+- Convention 39 requires `### BREAKING` to be the FIRST section of a version in both changelogs.
+  The `--doctor` entry was added ABOVE it in both files, pushing it to second place - the exact
+  drift the convention exists to prevent, committed two chunks after writing the convention down.
+  Nothing caught it: `test_no_em_or_en_dashes` reads changelog TEXT, never its structure.
+- Fixed in both files, and `tests/test_version_and_release.py::test_breaking_sections_come_first`
+  now enforces it: in every version block of either changelog, if a `### BREAKING` heading exists
+  it must be the first `###` under its `##`.
+
+### Hygiene guard: measured, then deliberately NOT tightened
+
+- The audit proposed extending `test_code_hygiene` to catch `except ...: return <default>`, not
+  only `except ...: pass`. A prototype was run across the package first. Result: **66 silent
+  handlers, of which 26 catch a NARROW type** (`OSError`, `(TypeError, ValueError)`) and are
+  idiomatic, and 40 are broad. Of the 40: 7 are `crashlog.py` (already exempt), 12 sit in modules
+  whose docstring states a "never raises" contract (`portmap` 6, `winenv` 4, `matchers.matches()`,
+  `utils.is_local_ip`), 2 in `legal.py` already carry `# noqa: BLE001` with a reason, and 14 are
+  in `gui/` - against roughly 100 correct `crashlog.*` uses in the same directory.
+- **Conclusion: the codebase is disciplined and the guard would mostly encode the status quo**,
+  at the cost of a wide diff and future false positives. Tightening was dropped; the three
+  handlers that were genuinely inconsistent with their own neighbours were fixed above instead.
+  If it is ever revisited, the mechanism to use is the one `legal.py` already established -
+  `# noqa: BLE001 - <reason>` at the handler - not a central allowlist.
+
+### Deferred: PID reuse in the portmap info cache (audit item P2)
+
+- `PortTable._expire_info` returns early below 512 entries, so on a normal machine (50-250
+  socket-owning PIDs) the `pid -> (name, ppid)` cache never expires and a recycled PID keeps the
+  dead process's name. That matters beyond a wrong column: `ProcessTargeting.refresh()` matches on
+  `name_of(pid)`, so the tool can impair a process the user did not target.
+- **The obvious fix does not work.** `info()` refreshes `last_seen` on every cache HIT, so the
+  dangerous case - a recycled PID that is being actively looked up - never expires no matter what
+  the TTL is. Real fixes (TTL from INSERTION, `create_time()` validation, or evicting PIDs that
+  vanish from the socket table) all add work to `PortTable.refresh()`, which today runs **on the
+  capture thread** via `ProcessTargeting.__contains__`. TTL-from-insertion additionally gives a
+  thundering herd: entries created together expire together, so one refresh re-resolves dozens of
+  PIDs at once, in the packet path.
+- Therefore P2 is scheduled straight after the targeting rewrite, when the cost no longer sits on
+  the capture thread. Designing around a constraint that is about to be removed would be wasted work.
+
 ### driver.py: read a service with read rights, not ALL_ACCESS
 
 - **`service_state` opened services with `SERVICE_ALL_ACCESS` (0xF01FF) just to read their
@@ -58,31 +157,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   correctness and robustness fix rather than a reproduced WinDivert failure. WinDivert's own
   service descriptor is probably permissive today; the point is that `--doctor` no longer
   depends on it staying that way.
-
-### BREAKING
-
-- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
-  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
-  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
-  while `--help` advertised "force the GUI". On real WinDivert that meant
-  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
-  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
-  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
-  to stderr and stdout stays clean.
-- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
-  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
-  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
-  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
-  than widening it.
-- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
-  loss and getting zero without being told is the class of quiet lie this project removes), and
-  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
-  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
-  than declined.
-- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
-  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
-- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
-- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
 ### CI: one run of the test suite, under coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
+### BREAKING
+
+- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
+  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
+  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
+  console you may not have been watching. It now stops immediately with a usage error (exit
+  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
+  settings from the command line. If a script of yours relied on the old behaviour, delete
+  `--gui` from it and it behaves exactly as before.
+
 ### Fixed
 
 - **`--doctor` could report a WinDivert driver as "not loaded" when it simply was not allowed
@@ -17,16 +27,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 - **`--cleanup-driver` explains a refusal instead of calling it "not installed".** Being told
   "access denied - the service exists but this account may not remove it" points somewhere;
   being told the service was never there does not.
-
-### BREAKING
-
-- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
-  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
-  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
-  console you may not have been watching. It now stops immediately with a usage error (exit
-  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
-  settings from the command line. If a script of yours relied on the old behaviour, delete
-  `--gui` from it and it behaves exactly as before.
 
 ## [0.3.0] - 2026-07-20
 

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -359,7 +359,11 @@ class BeanEngine:
         """
         try:
             return self._ports.process_for_port(local_port)
-        except Exception:
+        except Exception as _exc:
+            # once(), not note(): this is the capture thread. A port table that
+            # started failing turns every row's process into "?" - worth one
+            # traceback, not one per packet.
+            crashlog.once("engine.ports", _exc)
             return ""
 
     def _pid_for(self, local_port):
@@ -370,7 +374,8 @@ class BeanEngine:
         """
         try:
             return self._ports.pid_for(local_port)
-        except Exception:
+        except Exception as _exc:
+            crashlog.once("engine.ports.pid", _exc)
             return None
 
     def stats_snapshot(self):

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -27,6 +27,8 @@ import sys
 import threading
 import time
 
+from . import crashlog
+
 REFRESH_S = 0.30          # a routine rebuild of the port table
 MISS_REFRESH_S = 0.05     # a rebuild forced by an unknown port (rate limited)
 INFO_TTL_S = 30.0         # how long a pid -> (name, ppid) entry survives unused
@@ -89,7 +91,7 @@ class _Native:
             ("udp", _AF_INET): MIB_UDPROW_OWNER_PID,
             ("udp", _AF_INET6): MIB_UDP6ROW_OWNER_PID,
         }
-        self._buffers = {}
+        self._sizes = {}            # (proto, family) -> bytes the table needed last time
 
     def _table(self, proto, family, out):
         """Append ``(port, pid)`` pairs of one table to ``out``."""
@@ -102,15 +104,22 @@ class _Native:
         table_class = (_TCP_TABLE_OWNER_PID_ALL if proto == "tcp"
                        else _UDP_TABLE_OWNER_PID)
 
-        # Grow (and keep) one buffer per table: the socket table is queried
-        # several times per second, so reallocating it every time would be pure
-        # garbage for the allocator.
-        size = wintypes.DWORD(self._buffers.get((proto, family), (None, 0))[1] or 8192)
+        # Start from the size this table needed last time. The socket table is
+        # queried several times per second and its size barely moves, so the first
+        # attempt normally fits and we skip the grow-and-retry round trip.
+        #
+        # The BUFFER is deliberately not reused. A previous version stored it and
+        # claimed to reuse it, but allocated a fresh one on every call anyway and
+        # never read the stored one back - so the cache only pinned memory. Real
+        # reuse was considered and rejected: it saves four allocations a few times
+        # a second and buys aliasing between calls in ctypes code, which is a poor
+        # trade in the module the packet path leans on.
+        size = wintypes.DWORD(self._sizes.get((proto, family)) or 8192)
         for _ in range(6):                       # the table can grow between calls
             buffer = ctypes.create_string_buffer(size.value)
             rc = call(buffer, ctypes.byref(size), False, family, table_class, 0)
             if rc == 0:
-                self._buffers[(proto, family)] = (buffer, size.value)
+                self._sizes[(proto, family)] = size.value
                 break
             if rc != _ERROR_INSUFFICIENT_BUFFER:
                 return False
@@ -130,13 +139,35 @@ class _Native:
                 out[port] = pid
         return True
 
+    FAMILY_NAMES = {_AF_INET: "v4", _AF_INET6: "v6"}
+
     def port_pid_map(self):
+        """``{local port: pid}`` from all four socket tables, or ``None``.
+
+        A PARTIAL result is still returned. Dropping to psutil because one table
+        of four stopped answering would trade a possible gap for a certain
+        slowdown, and the native path is what makes live targeting affordable at
+        all - so the gap is the better risk.
+
+        What it must not be is SILENT. A table that stops answering means sockets
+        this tool can no longer see, and a socket it cannot see is traffic the user
+        asked to impair sailing through untouched - which looks exactly like "the
+        application coped". ``once()`` keeps that free in the hot path, and the key
+        carries WHICH tables failed, so a different failure still gets recorded.
+        """
         out = {}
-        ok = False
+        failed = []
         for proto in ("tcp", "udp"):
             for family in (_AF_INET, _AF_INET6):
-                ok |= self._table(proto, family, out)
-        return out if ok else None
+                if not self._table(proto, family, out):
+                    failed.append(f"{proto}/{self.FAMILY_NAMES[family]}")
+        if len(failed) == 4:
+            return None                  # nothing answered at all: let psutil try
+        if failed:
+            crashlog.once("portmap.native." + ".".join(failed), RuntimeError(
+                "socket table(s) unavailable, the port map may be incomplete: "
+                + ", ".join(failed)))
+        return out
 
 
 def _make_native():

--- a/beantester/processes.py
+++ b/beantester/processes.py
@@ -9,7 +9,7 @@ that refreshes itself and follows process trees) on top of
 :mod:`beantester.portmap` (the fast socket table). This module keeps the small,
 stable API the GUI, the CLI and the settings layer have always used.
 """
-from . import portmap
+from . import crashlog, portmap
 from .matchers import KIND_PROCESS, Matcher, parse_matcher
 from .targeting import NO_PROCESS, ProcessTargeting, resolve_ports
 
@@ -57,9 +57,11 @@ def find_process_ports(target):
 def port_process_map():
     """Best-effort map of local port -> process name (empty when unavailable)."""
     table = portmap.default_table()
-    try:
+    # Best-effort stays best-effort for the CALLER (an empty map just means the
+    # process column shows "?"), but the failure itself is recorded: a lookup that
+    # silently stops working looked identical to a machine with nothing to report.
+    with crashlog.quiet("processes.port_map"):
         table.refresh_if_stale()
         return {port: (table.name_of(pid) or str(pid))
                 for port, pid in table.snapshot().items()}
-    except Exception:
-        return {}
+    return {}

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -204,3 +204,103 @@ def test_port_process_map_maps_ports_to_names(fake_psutil):
           mapping.get(5001) == "chrome.exe", f"(got {mapping.get(5001)!r})")
     check("firefox port resolves to its process name",
           mapping.get(6001) == "firefox.exe", f"(got {mapping.get(6001)!r})")
+
+
+# -- port resolution fails LOUDLY (for us), quietly (for the user) ---------- #
+#
+# All three of these used to swallow. An empty map, a blank process name and a
+# partial socket table are all legitimate answers on a quiet machine, so a lookup
+# that had STOPPED WORKING was indistinguishable from one with nothing to report.
+# That is how "the process column is all ?" becomes a bug report nobody can act on.
+
+
+def _spy_on_crashlog(monkeypatch):
+    """Capture what would be recorded, without touching the crash directory."""
+    from beantester import crashlog
+    recorded = []
+    monkeypatch.setattr(crashlog, "_once_seen", set())   # once() dedupes per process
+    monkeypatch.setattr(crashlog, "record",
+                        lambda exc, **kw: recorded.append(kw))
+    return recorded
+
+
+def test_port_process_map_records_a_failure_instead_of_swallowing_it(monkeypatch):
+    from beantester import portmap
+    from beantester.processes import port_process_map
+
+    class _Broken:
+        def refresh_if_stale(self, *a, **k):
+            raise RuntimeError("socket table exploded")
+
+    recorded = _spy_on_crashlog(monkeypatch)
+    monkeypatch.setattr(portmap, "default_table", lambda: _Broken())
+
+    mapping = port_process_map()
+    check("the caller still gets a usable empty map", mapping == {}, f"({mapping!r})")
+    check("the failure was recorded, not swallowed", len(recorded) == 1, f"({recorded})")
+    check("it is attributed to its subsystem",
+          recorded[0].get("subsystem") == "processes.port_map", f"({recorded})")
+
+
+def test_a_partial_socket_table_is_reported_not_silently_trusted(monkeypatch):
+    """One table of four failing used to leave `ok` True and cache a map with holes.
+
+    A hole means sockets the tool cannot see, and traffic the user asked to impair
+    sailing through untouched - which looks exactly like "the application coped".
+    """
+    from beantester.portmap import _AF_INET6, _Native
+
+    native = _Native.__new__(_Native)        # no Windows needed: _table is faked
+    native._sizes = {}
+    recorded = _spy_on_crashlog(monkeypatch)
+    seen = []
+
+    def fake_table(proto, family, out):
+        seen.append((proto, family))
+        if proto == "udp" and family == _AF_INET6:
+            return False                     # this one stops answering
+        out[1000 + len(seen)] = 4000 + len(seen)
+        return True
+
+    monkeypatch.setattr(native, "_table", fake_table)
+    result = native.port_pid_map()
+
+    check("all four tables are attempted", len(seen) == 4, f"({seen})")
+    check("a partial map is still returned (psutil is an order slower)", result)
+    check("the gap was recorded", len(recorded) == 1, f"({recorded})")
+    check("the record names the table that failed",
+          "udp/v6" in str(recorded[0].get("subsystem", "")), f"({recorded})")
+
+
+def test_every_socket_table_failing_falls_back_to_psutil(monkeypatch):
+    """Nothing answered at all: return None so refresh() tries psutil instead."""
+    from beantester.portmap import _Native
+
+    native = _Native.__new__(_Native)
+    native._sizes = {}
+    _spy_on_crashlog(monkeypatch)
+    monkeypatch.setattr(native, "_table", lambda *a: False)
+
+    check("no usable map -> None, so the psutil fallback runs",
+          native.port_pid_map() is None)
+
+
+def test_engine_records_a_broken_port_table_instead_of_going_quiet(monkeypatch):
+    """The capture thread keeps going (a blank name beats a dead session), but the
+    reason no longer disappears. ``once()``, not ``note()``: this is the hot path."""
+    class _Broken:
+        def process_for_port(self, port):
+            raise RuntimeError("boom")
+
+        def pid_for(self, port):
+            raise RuntimeError("boom")
+
+    recorded = _spy_on_crashlog(monkeypatch)
+    engine = BeanEngine()
+    engine._ports = _Broken()
+
+    check("a failed name lookup still yields a blank", engine._process_for(1234) == "")
+    check("a failed pid lookup still yields None", engine._pid_for(1234) is None)
+    check("both failures were recorded", len(recorded) == 2, f"({recorded})")
+    check("recorded as hot-path, so they cost one traceback each",
+          all(kw.get("source") == "hot-path" for kw in recorded), f"({recorded})")

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -101,3 +101,34 @@ def test_no_stale_license_references_in_metadata():
     if os.path.exists(spec_path):
         spec = open(spec_path, encoding="utf-8").read()
         check("the exe metadata no longer says MIT", "MIT License" not in spec)
+
+
+def test_breaking_sections_come_first():
+    """Convention 39: `### BREAKING` must be the FIRST section of its version.
+
+    The point of the rule is that a reader scanning a release sees the contract
+    breakage before anything else. This guard exists because the rule was broken two
+    chunks after it was written down: a `Fixed` entry was inserted above `BREAKING`
+    in both changelogs and nothing noticed - the em/en-dash guard reads changelog
+    TEXT, never its structure.
+    """
+    for name in ("CHANGELOG.md", "CHANGELOG-INTERNAL.md"):
+        lines = open(os.path.join(ROOT, name), encoding="utf-8").read().splitlines()
+        version, sections = None, []
+        problems = []
+
+        def close(version, sections):
+            if version and "### BREAKING" in sections and sections[0] != "### BREAKING":
+                problems.append(f"{name} {version}: BREAKING is #{sections.index('### BREAKING') + 1}"
+                                f" of {len(sections)} (first is {sections[0]!r})")
+
+        for line in lines:
+            if line.startswith("## "):
+                close(version, sections)
+                version, sections = line.strip(), []
+            elif line.startswith("### ") and version:
+                sections.append(line.strip())
+        close(version, sections)
+
+        check(f"{name}: every BREAKING section comes first in its version",
+              not problems, f"({problems})")


### PR DESCRIPTION
Port resolution had three ways to fail without leaving a trace, which matters because a socket the tool cannot see is traffic the user asked to impair sailing through untouched - on screen that looks exactly like "the application coped".

- portmap: port_pid_map() counted `ok |= ...` across four socket tables, so three of four answering cached a map with holes as authoritative. All four failing still returns None (psutil fallback, unchanged); a partial result is still returned, but now via crashlog.once() with the failing tables in the key. The stricter "any failure -> psutil" was rejected: all four tables answer rc=0 on the dev machine, so that path cannot be tested, and it trades a possible gap for a certain order-of-magnitude slowdown
- portmap: _Native._table claimed to keep one buffer per table but allocated a fresh one every call and never read the stored one back, so the cache only pinned memory. _buffers becomes _sizes - the size hint was the part doing work. Real reuse rejected: aliasing risk for four allocations a second
- engine: _process_for/_pid_for use crashlog.once("engine.ports*"), matching what the same file already does 200 lines up for the same class of event on the same thread
- processes: port_process_map uses crashlog.quiet("processes.port_map")
- 4 new tests in tests/test_processes.py, spying on crashlog.record instead of reading the crash directory

Also fixes a self-inflicted regression: the --doctor entry from the previous chunk was added ABOVE ### BREAKING in both changelogs, pushing it out of first place (convention 39). Nothing caught it, because the dash guard reads changelog text and never its structure - so
test_version_and_release.py::test_breaking_sections_come_first now does.

The hygiene-guard tightening was measured and dropped, and the PID-reuse fix deferred until targeting moves off the capture thread; both are written up in CHANGELOG-INTERNAL.md so the analysis is not re-derived.
