### PR TITLE
fix(gui): stop a None model result wedging the table worker

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,30 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### AsyncModel: a build returning None no longer wedges the worker for good
+
+- **`poll()` used `None` for two different things** - "no result arrived" and "the result". It
+  started with `rows = None` and returned early on `rows is None`, so a build that genuinely
+  produced `None` looked identical to an empty queue and **`_pending` was never cleared**. From
+  that moment `request()` coalesced into `_latest` for ever and nothing ran again: the table
+  stopped rebuilding for the rest of the session, and `busy()` stayed True, which leaves
+  `conns._poll_soon()` rescheduling its 40 ms catch-up timer indefinitely on the UI thread.
+- Fixed with a module-level `_NOTHING` sentinel. The caller's contract is unchanged (`poll()`
+  still returns `None` for "nothing new to show"); what changed is that a result for the request
+  in flight now clears `_pending` whatever its value.
+- Latent, not live: `conns._build_model` always returns a dict. But convention 29 makes
+  `AsyncModel` the mechanism every future heavy table is meant to use, so the contract had to
+  hold before something is built on it.
+- **Deliberately NOT fixed in the same pass:** the exception path in `_run` clears `_pending` but
+  drops a request that queued into `_latest` while the build was failing. It self-heals - the page
+  calls `request()` on every tick, so a newer payload starts within about a second - and
+  re-submitting would mean calling `request()` (documented UI-thread only) from the worker thread,
+  outside the lock to avoid deadlocking on it. Threading complexity for a case that already
+  recovers is the wrong trade in a tool whose STOP button has to keep working.
+- New test: `tests/test_model_worker.py::test_a_build_returning_none_does_not_wedge_the_worker`.
+  Verified non-vacuous by restoring the old collision (`_NOTHING = None`) and confirming the
+  worker wedges.
+
 ### portmap/engine/processes: port-resolution failures stop being invisible
 
 - **`_Native.port_pid_map` accepted a PARTIAL socket table as the truth.** `ok |= self._table(...)`

--- a/beantester/gui/model_worker.py
+++ b/beantester/gui/model_worker.py
@@ -44,6 +44,14 @@ import threading
 from .. import crashlog
 
 
+# "no result arrived", which is NOT the same as "the build returned None". Sharing
+# one value between those two meanings wedged the worker permanently: poll() bailed
+# out before clearing _pending, so request() coalesced into _latest for ever, the
+# table stopped rebuilding for the rest of the session, and busy() stayed True -
+# which leaves the page's 40 ms catch-up poll rescheduling itself indefinitely.
+_NOTHING = object()
+
+
 class AsyncModel:
     """A model rebuilt off-thread, delivered to the UI thread whole.
 
@@ -73,8 +81,14 @@ class AsyncModel:
         self._spawn(token, payload)
 
     def poll(self):
-        """Main thread: the finished model, or None. Never blocks."""
-        rows = None
+        """Main thread: the finished model, or None. Never blocks.
+
+        ``None`` back means "nothing new to show" - either no result arrived, or the
+        build genuinely produced ``None``. The difference matters INSIDE: whatever
+        the value, a result for the request in flight clears ``_pending``, or the
+        model never rebuilds again (see ``_NOTHING``).
+        """
+        rows = _NOTHING
         while True:
             try:
                 token, result = self._results.get_nowait()
@@ -84,7 +98,7 @@ class AsyncModel:
                 current = self._pending
             if token == current:
                 rows = result               # a newer request supersedes an older result
-        if rows is None:
+        if rows is _NOTHING:
             return None
 
         with self._lock:
@@ -114,5 +128,12 @@ class AsyncModel:
             with self._lock:
                 if self._pending == token:
                     self._pending = None
+            # A request that queued into _latest while this build was failing is
+            # dropped here rather than re-submitted. Deliberate: the page calls
+            # request() on every tick, so a newer payload starts within ~1 s anyway,
+            # and re-submitting would mean calling request() from the WORKER thread
+            # (documented UI-thread only) and doing it outside this lock to avoid
+            # deadlocking on it. Threading complexity for a case that self-heals is
+            # a bad trade in a tool whose STOP button must keep working.
             return
         self._results.put((token, rows))

--- a/tests/test_model_worker.py
+++ b/tests/test_model_worker.py
@@ -145,6 +145,48 @@ def test_a_worker_that_raises_keeps_the_old_model_on_screen():
     assert _wait(lambda: ok.poll() is not None, timeout=5)
 
 
+def test_a_build_returning_none_does_not_wedge_the_worker():
+    """``None`` used to mean two things at once, and the collision was permanent.
+
+    ``poll()`` started with ``rows = None`` and bailed out early on ``rows is None``,
+    so a build that genuinely returned ``None`` looked like "nothing arrived" - and
+    ``_pending`` was never cleared. From then on every ``request()`` coalesced into
+    ``_latest`` and nothing ever ran again: the table stopped rebuilding for the rest
+    of the session, and ``busy()`` stayed True, leaving the page's 40 ms catch-up
+    poll rescheduling itself for ever.
+
+    Latent today (the connections page always returns a dict), but ``AsyncModel`` is
+    the mechanism every future heavy table is meant to use, so the contract has to
+    hold before somebody builds on it.
+    """
+    model = AsyncModel(lambda payload: None)
+    model.request("first")
+
+    # poll the way the page does - busy() only clears once a result is COLLECTED
+    def polled_until_idle(timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            assert model.poll() is None, "there is no model to show, and that is fine"
+            if not model.busy():
+                return True
+            time.sleep(0.005)
+        return False
+
+    assert polled_until_idle(), \
+        "a build returning None never released the worker"
+
+    # the point of the fix: the worker is still usable afterwards
+    delivered = AsyncModel(lambda payload: [payload])
+    delivered.request("later")
+    assert _collect(delivered, timeout=5) == ["later"]
+
+    # and the SAME instance recovers too, once its build starts producing rows
+    model._build = lambda payload: [payload]
+    model.request("second")
+    assert _collect(model, timeout=5) == ["second"], \
+        "the worker never accepted another request"
+
+
 def test_no_thread_is_left_behind():
     """Twenty rebuilds must not leave twenty threads.
 


### PR DESCRIPTION
AsyncModel.poll() used None for two different things - "no result arrived" and "the result". It started with rows = None and returned early on `rows is None`, so a build that genuinely produced None was indistinguishable from an empty queue and _pending was never cleared.

From that point every request() coalesced into _latest and nothing ran again: the table stopped rebuilding for the rest of the session, and busy() stayed True, leaving conns._poll_soon() rescheduling its 40 ms catch-up timer indefinitely on the UI thread.

- gui/model_worker.py: module-level _NOTHING sentinel; a result for the request in flight now clears _pending whatever its value. The caller's contract is unchanged - poll() still returns None for "nothing new".
- tests/test_model_worker.py: new regression test, verified non-vacuous by restoring the old collision (_NOTHING = None) and confirming the wedge

Latent rather than live: the connections page always returns a dict. But convention 29 makes AsyncModel the mechanism every future heavy table uses, so the contract has to hold before something is built on it.

The exception path in _run still drops a request queued into _latest while a build was failing. Left alone on purpose: it self-heals within a tick, and re-submitting would mean calling request() from the worker thread, outside the lock to avoid deadlocking on it.