### PR TITLE
perf(targeting): resolve the port set off the capture thread

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -124,6 +124,21 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   resolver, which matches the child through its ancestor chain. Measured pick-up: ~3 ms without
   the floor, bounded by `min_interval` with it. Grandchildren (two levels) work the same way, and
   `myapp, !myapp-helper` keeps excluding a respawning helper despite its matching parent.
+- **Caught in review, before merge: a target applied MID-SESSION got a frozen port set.** The
+  resolver was started only when a target already existed at `start()`. Press START, watch, then
+  type a process name - an ordinary workflow - and nobody was keeping the port set fresh: it
+  froze at whatever the first resolve produced and sockets opened afterwards were never picked
+  up. Precisely the failure live targeting exists to prevent, reintroduced by the fix for it.
+  The resolver's life is now the SESSION's, unconditionally; with nothing to resolve it blocks on
+  its event and costs nothing. Guarded by
+  `test_a_target_applied_mid_session_still_gets_a_live_port_set`.
+- **The GUI does not resolve on the UI thread while a session runs.** `_refresh_target` resolves
+  inline only when the engine is STOPPED (no resolver to do it, and no session to stall); while
+  running it lets the banner wait for the next 700 ms tick. Four syscalls and a psutil walk on
+  the UI thread would be a frozen window, and a frozen window here is the user unable to press
+  STOP on their own broken network.
+- `TargetResolver.stop()` detaches the old targeting's `on_miss`, so a late packet cannot poke
+  the event of a worker that is no longer listening.
 - New `tests/test_target_resolver.py`: miss wakes the resolver and the new port is picked up
   (long interval, so only the WAKE can explain it), `stop()` joins rather than signals,
   retargeting does not churn threads, an orphaned targeting is detached, a failing table leaves

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -87,6 +87,21 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   doing a full OS scan every 2 s, per fast restart cycle. Not reproduced live (driving the async
   start/stop on the fake-tk harness is awkward); `test_repeated_start_stop_cycles_do_not_stack_resolver_threads`
   is the guard that would have caught it.
+- **A FLOOR under miss-driven rebuilds, found by re-reading the design rather than by a test.**
+  Moving `miss_interval` out of `__contains__` removed the rate limit without putting it back
+  anywhere: targeting narrows traffic to one application, so every packet from every OTHER
+  application is a miss, misses arrive continuously, and the wake-up was re-armed as fast as it
+  was consumed. Measured with a 5 s routine tick: **63 rebuilds a second**, bounded only by the
+  GIL - with a real socket table that is a thread pegged at 100% scanning the OS. The resolver now
+  enforces `min_interval` (`portmap.MISS_REFRESH_S`, the same 0.05 s the old code used), in ONE
+  place instead of on the capture thread. Re-measured: 14 rebuilds/s with the floor, 33/s with it
+  disabled. The cost is the worst-case delay before a brand-new socket starts being impaired -
+  up to 50 ms, exactly the trade the old code made.
+- **Dynamic process trees verified, not assumed.** A child spawned mid-session opens its own
+  socket; the first packet slips through (the documented, unclosable race) and the miss wakes the
+  resolver, which matches the child through its ancestor chain. Measured pick-up: ~3 ms without
+  the floor, bounded by `min_interval` with it. Grandchildren (two levels) work the same way, and
+  `myapp, !myapp-helper` keeps excluding a respawning helper despite its matching parent.
 - New `tests/test_target_resolver.py`: miss wakes the resolver and the new port is picked up
   (long interval, so only the WAKE can explain it), `stop()` joins rather than signals,
   retargeting does not churn threads, an orphaned targeting is detached, a failing table leaves

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,37 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Review pass over the whole targeting diff (four more findings)
+
+Read line by line before merge, on the principle that a green suite had already missed three
+things in this branch. Each one below was verified by running it, not by reasoning about it.
+
+- **The watchdog's new port refresh could cancel the memory work.** `refresh_if_stale()` was put
+  FIRST inside the tick's existing `try`, so a socket-table failure aborted the block and
+  `_trim_conns()` plus `core.drain_retired()` never ran for that tick - the connection log would
+  grow unbounded because a NAME lookup failed. Now its own `try`: cosmetic work and memory safety
+  are different failure domains. Verified with a table that raises on every refresh: `_trim_conns`
+  still ran 6 times in 1.5 s and the row count stayed under the cap.
+- **A failed resolve in `apply_targeting` left the engine and the core disagreeing.** The
+  synchronous announce-path refresh sat inside the `try` whose `except Exception` returns without
+  calling `set_target`, so `engine._targeting` held a new object the core had never been pointed
+  at. Moved out and wrapped in `crashlog.quiet`: a stale announcement is a far smaller problem
+  than two halves disagreeing about what is being impaired, and the resolver corrects it within a
+  tick. Verified with a table that always raises: engine, core and resolver all end up on the
+  same object.
+- **`TargetResolver.stop()` signalled `_stopping` outside its lock**, leaving a window where a
+  concurrent `start()` could clear the flag, spawn a thread, and have the late `set()` kill it on
+  its first check. `BeanEngine` serialises start/stop under `_stop_lock` so it could not happen
+  today, but a threading primitive should not depend on its caller for safety. Verified with 200
+  lifecycle cycles plus 300 start-immediately-after-stop pairs: no thread killed on arrival, no
+  leak, no dangling `on_miss`.
+- **Dead knobs removed from `ProcessTargeting`.** `interval`, `miss_interval` and `_last` were
+  still written but no longer read by anything - pacing lives in `TargetResolver` now. Leaving
+  constructor parameters that control nothing invites somebody to tune them. Also fixed the fake
+  in `test_engine_records_a_broken_port_table_instead_of_going_quiet`, whose `process_for_port`
+  lacked the `allow_refresh` keyword: it was raising `TypeError` instead of the `RuntimeError` the
+  test meant to exercise, and passing for the wrong reason.
+
 ### The connection log was a SECOND socket-table scan on the capture thread
 
 - **Moving targeting off the hot path did nothing for this one, and a green test suite said

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,61 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Targeting resolves off the capture thread (new `target_resolver.py`)
+
+- **`ProcessTargeting.__contains__` used to call `refresh()` inline** - i.e. from
+  `BeanCore.decide()`, on the CAPTURE THREAD, holding `core._lock`. One rebuild is four
+  `iphlpapi` calls, an O(n) dict copy, a `psutil.Process()` per distinct PID and, whenever a
+  protected PID refuses to open, a whole `psutil.process_iter()`. **And it was the normal case,
+  not an edge one:** targeting exists to narrow traffic to one application, so every packet from
+  every OTHER application is a miss, and a miss triggered the rebuild - a steady ~20 Hz of
+  syscalls in the packet path whenever a target was set. A stalled capture thread is precisely
+  what fail-open (convention 20), the watchdog, the eviction move and the table-sort move all
+  exist to prevent: WinDivert keeps diverting into a queue nobody drains, so the user loses
+  connectivity while the UI says "running". Targeting was the last place still doing it.
+- **`__contains__` is now a frozenset lookup and nothing else.** A miss sets a plain bool
+  (atomic under the GIL, free) and, only on the FALSE -> TRUE transition, calls the resolver's
+  wake-up. That guard is the point: `Event.set()` takes a lock, so waking per packet would have
+  moved the problem rather than removed it. `refresh()` stays public and synchronous for
+  one-shot callers (`resolve_ports`, `make_targeting`) and tests.
+- **New `beantester/target_resolver.py`.** Deliberately the same shape as `scenario_runner.py`:
+  a small class owning one thread, lifecycle driven explicitly by `BeanEngine`. Two differences
+  on purpose: `stop()` JOINS (it holds OS handles), and it waits on an `Event` rather than
+  sleeping, so a miss is picked up in milliseconds instead of at the next tick. **One resolver
+  per engine with a swappable target** - retargeting is a reference swap, not a thread restart,
+  because the GUI applies settings repeatedly and `test_concurrency_chaos` does it hundreds of
+  times. Wake ordering is clear-then-refresh-then-wait, so a miss arriving DURING a rebuild
+  re-arms instead of being swallowed by it.
+- **`engine.set_target` is now the single place the resolver is pointed at a target.**
+  `self._targeting` was previously assigned only by `target_for`, so installing a live targeting
+  directly left the engine believing it had none while the core tested against it. `target_for`
+  keeps its memoisation (one live object per expression, so the port and process caches survive)
+  but no longer resolves; `start()` reconciles the two and does one synchronous pass so the first
+  packet meets a populated port set; `stop()` joins the thread.
+- **The resolver's life matches a SESSION's**, not a target's: configuring a target without
+  starting must not leave something scanning the socket table in the background.
+- **`apply_targeting` refreshes only when `announce=True`.** It has to, because the log line
+  reports what was matched and an unresolved target would always read as "matches nothing" - the
+  very message this project made loud on purpose. That is the explicit user-applied path; the
+  periodic path passes `announce=False` and never blocks. Strictly less work than before, where
+  `target_for` refreshed on every call including the GUI's 2 s loop.
+- **Found while re-reading, fixed by removal: the GUI refresher thread leaked on fast restart.**
+  `_finish_start` spawned `_target_thread` unconditionally and nothing ever joined or signalled
+  it, while `_target_refresher` looped on `while self.running` with a 2 s sleep. STOP followed by
+  START inside that sleep left the OLD thread looping as well - one extra permanent scanner, each
+  doing a full OS scan every 2 s, per fast restart cycle. Not reproduced live (driving the async
+  start/stop on the fake-tk harness is awkward); `test_repeated_start_stop_cycles_do_not_stack_resolver_threads`
+  is the guard that would have caught it.
+- New `tests/test_target_resolver.py`: miss wakes the resolver and the new port is picked up
+  (long interval, so only the WAKE can explain it), `stop()` joins rather than signals,
+  retargeting does not churn threads, an orphaned targeting is detached, a failing table leaves
+  the resolver alive, **the capture thread never touches the socket table** (end to end over
+  synthetic traffic, asserting on the THREAD NAMES that made it look), no thread outlives a
+  session, and five start/stop cycles stack nothing.
+  `tests/test_release_fixes.py::test_an_unknown_port_forces_an_early_refresh` is rewritten as
+  `..._asks_for_a_rebuild_without_scanning_inline`: it now asserts the socket table is NOT
+  touched from the packet path and that 50 misses wake the resolver exactly once.
+
 ### AsyncModel: a build returning None no longer wedges the worker for good
 
 - **`poll()` used `None` for two different things** - "no result arrived" and "the result". It

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,28 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### The connection log was a SECOND socket-table scan on the capture thread
+
+- **Moving targeting off the hot path did nothing for this one, and a green test suite said
+  otherwise.** `_log_conn` -> `_process_for` -> `PortTable.process_for_port` calls
+  `refresh_if_stale(miss=True)` whenever the port is unknown - four iphlpapi calls, sometimes a
+  psutil walk - **on the capture thread**, for the connection log's process column. Measured live
+  with a real port table and synthetic traffic: **47 rebuilds in 3 s from
+  `Thread-1 (_capture_loop)`**, alongside the resolver's own 48.
+- **The end-to-end test missed it because it watched the wrong object.** It injected a counting
+  table into the `ProcessTargeting` but left the engine on `portmap.default_table()`, so it
+  asserted on a table the capture thread never used and passed vacuously. The test now sets
+  `engine._ports` to the same table and the fake grew the engine-side surface
+  (`process_for_port`, `pid_for`, `refresh_if_stale`). Found by instrumenting a live run, not by
+  the suite - which is the lesson worth keeping.
+- Fix follows the pattern the project already uses for eviction and flow rotation: `_process_for`
+  reads with `allow_refresh=False` (a pure lookup), and the **watchdog** calls
+  `self._ports.refresh_if_stale()` on its 200 ms tick. Maintenance belongs on the maintenance
+  thread. Cost: a brand-new socket can read as `""` for up to one refresh interval, and
+  `_log_conn` already retries while packets keep coming, so the row fills itself in.
+- Re-measured after the fix: socket-table refreshes come from `bean-target-resolver` (48) and
+  `MainThread` (2). **Zero from the capture thread.**
+
 ### Targeting resolves off the capture thread (new `target_resolver.py`)
 
 - **`ProcessTargeting.__contains__` used to call `refresh()` inline** - i.e. from

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,40 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### STOP no longer waits for a resolve, and the number that explains why
+
+- **Measured, because nobody here knew it: a COLD resolve costs 1.7 SECONDS.** On this desktop
+  25 PIDs own sockets but the process-info cache ends up with 346 entries - the expensive part is
+  one full `psutil.process_iter()`, triggered the moment a protected PID refuses `psutil.Process`.
+  Once warm the same resolve is **1.4 ms**. A thousandfold difference that every fake in the
+  suite hides, because fakes answer instantly.
+- **That made `stop()` slow, and STOP is the control this tool may never make slow.** The
+  resolver joined with a 2 s timeout, so pressing STOP while a cold scan was in flight blocked
+  for **1647 ms** (measured; with an artificially slow table it ate the full 2000 ms and still
+  left the thread running). The old GUI refresher was an unjoined daemon, so this was a
+  regression introduced by the rewrite.
+- Fixed with `TargetResolver.JOIN_S = 0.25`: long enough that an IDLE resolver is always joined
+  (it is parked in `wait()` and exits in microseconds), short enough that a scan in flight can
+  never hold STOP up. Not joining a straggler is safe - `stop()` has already cleared the target
+  and set the stop flag, so it finishes at most one more scan into an object nobody reads and
+  then exits; it is a daemon either way. Re-measured: **252 ms** with a 1.7 s scan in flight,
+  **265 ms** with a 5 s one, **100 ms** idle (and that 100 ms is the engine's other joins).
+- Guards: `test_stop_never_waits_for_a_scan_in_flight` (deliberately slow table, asserts under
+  900 ms) and `test_stop_does_join_an_idle_resolver` (the other half - the common case must be
+  clean, not merely fast).
+- **A full GUI session was driven end to end for the first time** - real engine, real resolver,
+  synthetic traffic, real GUI code - because everything until then had exercised the engine
+  directly and left `_tick`'s new wiring unverified. Verified: resolver up for a targetless
+  session, a non-matching target raises the banner, a matching one takes it down, clearing the
+  field drops targeting, traffic never stalls, STOP stays under 900 ms and leaks no thread.
+  Pinned as `test_gui_state.py::test_a_gui_session_keeps_the_target_banner_honest`, on a fake
+  table so it stays fast and deterministic.
+- Two false alarms during that work, recorded so they are not re-chased: `ProcessTargeting`
+  defines `__len__`, so an object with an empty port set is FALSY - a diagnostic printing
+  `"y" if tg else "N"` reported a live target as missing. And `python` owns no sockets on this
+  machine, so a test using it as a "should match" target was wrong, not the code. Production uses
+  `is None` throughout, which is why neither reached the program.
+
 ### Review pass over the whole targeting diff (four more findings)
 
 Read line by line before merge, on the principle that a green suite had already missed three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   settings from the command line. If a script of yours relied on the old behaviour, delete
   `--gui` from it and it behaves exactly as before.
 
+### Changed
+
+- **Targeting a process no longer competes with the traffic it is measuring.** Working out which
+  connections belong to your target means asking Windows about its sockets, and that used to
+  happen on the same thread that handles your packets - dozens of times a second, because every
+  packet from every *other* application prompted another look. On a busy machine that stole time
+  from the capture itself, which is how a tester ends up measuring the tool instead of their
+  application. The lookup now runs on its own thread. Nothing changes in what you set or see;
+  a freshly opened connection still starts being impaired within tens of milliseconds, and STOP
+  stays immediate even while a lookup is in progress.
+
+### Docs
+
+- **The process field's exclusions are now documented properly.** Writing `!chrome` means "impair
+  everything except chrome" - and "everything" includes any connection whose owning process could
+  not be identified yet, which every brand-new connection passes through. If you want one
+  application left alone, name the one you *do* want broken instead; then anything unidentified
+  passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
+
 ### Fixed
 
 - **`--doctor` could report a WinDivert driver as "not loaded" when it simply was not allowed

--- a/README.md
+++ b/README.md
@@ -928,9 +928,19 @@ seeded).
   explicit exclusion wins: `chrome, !chromedriver` will not pull in `chromedriver` via a parent.
 - **Process targeting is a race with the system (and stays one)** - WinDivert gives a packet, not a
   PID, so we resolve the process from the socket table by **local port**. The table is refreshed
-  ~3x per second and **additionally at once when an unknown port appears**, so a freshly opened
+  ~3x per second and **additionally as soon as an unknown port appears**, so a freshly opened
   connection starts being impaired within tens of ms. The very first packet of a brand-new
-  connection may slip through - that is a limit of the method, not a bug.
+  connection may slip through - that is a limit of the method, not a bug. The lookup itself runs
+  on its own thread, never on the one handling your packets, so a slow scan can never turn into
+  lost traffic.
+- **An exclusion on its own also covers everything the tool cannot identify.** `!chrome` in the
+  process field means "impair everything except chrome" - and "everything" includes any connection
+  whose owning process could not be determined: the first packets of a brand-new socket, protected
+  system processes, anything the socket table has not caught up with yet. Unidentified is not the
+  rare case here; every new connection passes through it.
+  **So do not use an exclusion to protect an application.** If you want one app left alone, name
+  the app you DO want broken (`--target thatapp`) - then anything unidentified passes through
+  untouched, which is the safe direction. This mirrors `!53` on ports, below.
 - **Targeting that catches nothing breaks nothing** - if no running process matches the expression,
   traffic passes untouched. The program says so explicitly (a red note under the field and a log
   entry), because "a run in which nothing broke" looks identical to "the app held up".

--- a/README.md
+++ b/README.md
@@ -843,7 +843,8 @@ beantester/              the implementation package
                          range, form section, profile scope, CLI flag
   validators.py          number and range validation (shared by GUI, CLI and config file)
   portmap.py             socket table: local port -> PID (iphlpapi/ctypes; psutil fallback)
-  targeting.py           live target port set: refresh on miss + process tree
+  targeting.py           live target port set: process tree, asks for a rebuild on a miss
+  target_resolver.py     rebuilds that port set on its own thread, off the packet path
   jsonfile.py            atomic write + quarantine of corrupted user files
   crashlog.py            crash logger: quiet/note/once, quarantine, background report
   appinfo.py             app identity and version reader (one source: VERSION.txt)

--- a/README.pl.md
+++ b/README.pl.md
@@ -834,7 +834,16 @@ wyznaczonym momencie. Wszystkie losowania idą przez jeden generator (opcjonalni
   więc proces ustalamy z tabeli gniazd po **lokalnym porcie**. Tabela jest odświeżana ~3× na sekundę
   i **dodatkowo natychmiast, gdy pojawi się nieznany port**, więc świeżo otwarte połączenie zaczyna
   być psute po kilkudziesięciu ms. Pierwszy pakiet zupełnie nowego połączenia może się prześliznąć -
-  to ograniczenie metody, nie błąd.
+  to ograniczenie metody, nie błąd. Samo wyszukiwanie chodzi na osobnym wątku, nigdy na tym, który
+  obsługuje Twoje pakiety - więc wolny skan nie zamieni się w zgubiony ruch.
+- **Samo wykluczenie obejmuje też wszystko, czego narzędzie nie rozpozna.** `!chrome` w polu procesu
+  znaczy „psuj wszystko oprócz chrome" - a „wszystko" obejmuje każde połączenie, którego właściciela
+  nie udało się ustalić: pierwsze pakiety świeżo otwartego gniazda, procesy chronione, wszystko,
+  za czym tabela gniazd jeszcze nie nadążyła. „Nierozpoznany" nie jest tu przypadkiem rzadkim -
+  przechodzi przez niego **każde** nowe połączenie.
+  **Nie używaj więc wykluczenia do ochrony aplikacji.** Jeśli jedna ma zostać nietknięta, wskaż tę,
+  którą CHCESZ psuć (`--target tamtaaplikacja`) - wtedy wszystko nierozpoznane przechodzi
+  nietknięte, czyli w stronę bezpieczną. To ta sama zasada co `!53` przy portach, niżej.
 - **Celowanie, które nic nie łapie, nic nie psuje** - jeśli żaden działający proces nie pasuje do
   wyrażenia, ruch przechodzi nietknięty. Program mówi o tym wprost (czerwona notka pod polem
   i wpis w logu), bo „przebieg, w którym nic się nie zepsuło” wygląda identycznie jak „aplikacja

--- a/README.pl.md
+++ b/README.pl.md
@@ -749,7 +749,8 @@ beantester/              pakiet z implementacją
                          zakres, sekcja formularza, zakres profilu, flaga CLI
   validators.py          walidacja liczb i zakresów (wspólna dla GUI, CLI i pliku konfiguracji)
   portmap.py             tabela gniazd: lokalny port -> PID (iphlpapi/ctypes; fallback psutil)
-  targeting.py           żywy zbiór portów celu: odświeżanie na chybieniu + drzewo procesów
+  targeting.py           żywy zbiór portów celu: drzewo procesów, prośba o przebudowę na chybieniu
+  target_resolver.py     przebudowuje ten zbiór na własnym wątku, poza ścieżką pakietów
   jsonfile.py            zapis atomowy + kwarantanna uszkodzonych plików użytkownika
   crashlog.py            logger awarii: quiet/note/once, kwarantanna, raport w tle
   appinfo.py             tożsamość aplikacji i odczyt wersji (jedno źródło: VERSION.txt)

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -508,7 +508,14 @@ class BeanEngine:
             # Reconcile: whichever path installed the target (target_for alone, or
             # set_target), the session starts with the resolver pointed at it.
             self._resolver.retarget(targeting)
-            self._resolver.start()
+        # UNCONDITIONALLY, target or no target: the resolver's life is the SESSION's.
+        # Starting it only when a target already exists meant that narrowing down
+        # mid-run - press START, watch, then type a process - left nobody keeping
+        # the port set fresh, so it froze at whatever the first resolve produced and
+        # new sockets were never picked up. That is precisely the failure live
+        # targeting exists to prevent. With no target it blocks on its event and
+        # costs nothing.
+        self._resolver.start()
         self._t_cap = threading.Thread(target=self._capture_loop, daemon=True)
         self._t_inj = threading.Thread(target=self._inject_loop, daemon=True)
         self._t_wd = threading.Thread(target=self._watchdog_loop, daemon=True)

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -593,13 +593,22 @@ class BeanEngine:
                 return
             # bounded memory is this thread's job now, so the capture thread never
             # pays for it (see _trim_conns)
+            # Keeping the socket table fresh is maintenance, so it belongs here for
+            # the same reason eviction does: the capture thread must not pay for it.
+            # _process_for() reads the table without ever rebuilding it, so this
+            # tick is what makes the connection log's process column work at all.
+            #
+            # Its OWN try block, and deliberately after the memory work below would
+            # be wrong too - this is cosmetic (process names) while trimming is
+            # memory safety. Sharing a failure path meant a socket-table hiccup
+            # silently cancelled _trim_conns() and drain_retired() for that tick,
+            # so the connection log would grow unbounded because a NAME lookup
+            # failed. Different jobs, different failure domains.
             try:
-                # Keeping the socket table fresh is maintenance, so it belongs
-                # here for the same reason eviction does: the capture thread must
-                # not pay for it. _process_for() reads the table without ever
-                # rebuilding it, so this tick is what makes the connection log's
-                # process column work at all.
                 self._ports.refresh_if_stale()
+            except Exception as _exc:
+                crashlog.note(_exc, "engine.ports")
+            try:
                 self._trim_conns()
                 # Same principle: freeing a retired 200k flow generation costs
                 # ~7-22 ms (measured). The capture thread must not spend that in a

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -33,6 +33,7 @@ from . import portmap
 from .core import BeanCore
 from .i18n import T
 from .scenario_runner import ScenarioRunner
+from .target_resolver import TargetResolver
 from . import crashlog
 
 WATCHDOG_TICK_S = 0.2      # how often the deadline / worker health is checked
@@ -95,6 +96,10 @@ class BeanEngine:
         self._stop_mono = None      # session clock, frozen at STOP (see now_ref)
         self._stop_wall = None
         self._targeting = None      # live ProcessTargeting, when a target is set
+        self._target_lock = threading.Lock()
+        # Resolves the targeted port set OFF the capture thread (see
+        # target_resolver.py). One per engine, retargeted rather than restarted.
+        self._resolver = TargetResolver()
         self._ports = portmap.default_table()   # local port -> process (capture time)
         self.stop_reason = None     # "user" | "duration" | "fault" | "exit"
         self.fault = None           # last fatal worker error, if any
@@ -152,27 +157,62 @@ class BeanEngine:
         self.core.set_buffer(*a)
 
     def set_target(self, active, ports=None):
-        """Point the engine at a set of local ports (or a live port container)."""
+        """Point the engine at a set of local ports (or a live port container).
+
+        This is the ONE place the resolver is pointed at a target, whichever entry
+        point got here: ``self._targeting`` used to be assigned only by
+        ``target_for``, so installing a live targeting directly left the engine
+        believing it had none while the core happily tested against it.
+
+        Retarget only - the thread itself lives exactly as long as a SESSION does
+        (started in ``start()``, joined in ``stop()``). A configured-but-not-started
+        target must not have something scanning the socket table in the background.
+        """
         if not active:
-            self._targeting = None
+            with self._target_lock:
+                self._targeting = None
+            self._resolver.retarget(None)
+        elif hasattr(ports, "on_miss"):          # a live ProcessTargeting
+            with self._target_lock:
+                self._targeting = ports
+            self._resolver.retarget(ports)
+        else:                                    # a plain set: nothing to refresh
+            with self._target_lock:
+                self._targeting = None
+            self._resolver.retarget(None)
         self.core.set_target(active, ports)
 
     def targeting(self):
         """The live ``ProcessTargeting`` in use, if any."""
         return self._targeting
 
+    def resolver(self):
+        """The background resolver that keeps the port set fresh."""
+        return self._resolver
+
     def target_for(self, matcher):
         """Live targeting for a compiled matcher (reused while the expression holds).
 
-        Rebuilding it on every refresh would throw away the port cache and the
+        Rebuilding it on every apply would throw away the port cache and the
         process-info cache several times a second for nothing.
+
+        No rebuild happens here. Resolving costs syscalls and a psutil walk, and
+        this is called from whichever thread applied the settings - the UI thread
+        among them. The resolver does it (see ``target_resolver``); ``start()``
+        forces one synchronous pass so the very first packet already has a port
+        set to test against.
         """
         from .targeting import ProcessTargeting
-        current = self._targeting
-        if current is None or current.expression != getattr(matcher, "raw", str(matcher)):
-            current = ProcessTargeting(matcher)
-            self._targeting = current
-        current.refresh()
+        # Locked: a GUI apply and a scenario step can both land here, and two
+        # threads racing to build a ProcessTargeting would leave the resolver
+        # pointed at an orphan while the core tested against the other one.
+        with self._target_lock:
+            current = self._targeting
+            if current is None or current.expression != getattr(matcher, "raw", str(matcher)):
+                current = ProcessTargeting(matcher)
+                self._targeting = current
+        # Pointing the RESOLVER at it is set_target's job (one place, one
+        # responsibility) and start() reconciles the two either way.
         return current
 
     def set_flap(self, *a):
@@ -445,6 +485,19 @@ class BeanEngine:
         self._deadline = (self._start_mono + self._duration) if self._duration > 0 else None
         self.stop_reason = None
         self.fault = None
+        # One synchronous resolve before the capture thread exists, so the very
+        # first packet is tested against a populated port set instead of an empty
+        # one. Safe to block here: start() already runs off the UI thread (the GUI
+        # drives it through _begin_transition), and this is the only place the
+        # resolution is allowed to be synchronous.
+        targeting = self._targeting
+        if targeting is not None:
+            with crashlog.quiet("engine.target"):
+                targeting.refresh()
+            # Reconcile: whichever path installed the target (target_for alone, or
+            # set_target), the session starts with the resolver pointed at it.
+            self._resolver.retarget(targeting)
+            self._resolver.start()
         self._t_cap = threading.Thread(target=self._capture_loop, daemon=True)
         self._t_inj = threading.Thread(target=self._inject_loop, daemon=True)
         self._t_wd = threading.Thread(target=self._watchdog_loop, daemon=True)
@@ -469,6 +522,9 @@ class BeanEngine:
             self._stop_wall = time.time()
             self.stop_reason = reason
             self.stop_scenario()
+            # Joins: the resolver holds OS handles and must stop touching them when
+            # the session does, not "eventually".
+            self._resolver.stop()
             self.log_event("STOP", self.EVENT_BY_REASON.get(reason, "events.stopped"))
             with self._cv:
                 self._cv.notify_all()

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -398,7 +398,18 @@ class BeanEngine:
         column was mostly "?" even when running as Administrator.
         """
         try:
-            return self._ports.process_for_port(local_port)
+            # allow_refresh=False is the whole point: process_for_port() otherwise
+            # calls refresh_if_stale(miss=True) when the port is unknown, which is
+            # four iphlpapi calls (and sometimes a psutil walk) ON THE CAPTURE
+            # THREAD - measured at ~16 a second against synthetic traffic. This is
+            # a SECOND path that did what targeting used to do; moving targeting off
+            # the hot path did nothing for it. The watchdog keeps the table fresh
+            # instead, exactly as it already does eviction and flow rotation.
+            #
+            # The cost is that a brand-new socket may read as "" for up to one
+            # refresh interval. _log_conn already retries while packets keep coming,
+            # so the row fills itself in rather than staying "?" for ever.
+            return self._ports.process_for_port(local_port, allow_refresh=False)
         except Exception as _exc:
             # once(), not note(): this is the capture thread. A port table that
             # started failing turns every row's process into "?" - worth one
@@ -576,6 +587,12 @@ class BeanEngine:
             # bounded memory is this thread's job now, so the capture thread never
             # pays for it (see _trim_conns)
             try:
+                # Keeping the socket table fresh is maintenance, so it belongs
+                # here for the same reason eviction does: the capture thread must
+                # not pay for it. _process_for() reads the table without ever
+                # rebuilding it, so this tick is what makes the connection log's
+                # process column work at all.
+                self._ports.refresh_if_stale()
                 self._trim_conns()
                 # Same principle: freeing a retired 200k flow generation costs
                 # ~7-22 ms (measured). The capture thread must not spend that in a

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -119,7 +119,7 @@ class App:
         self._log_lines = []
         self.engine = BeanEngine(self.log)
         self.running = False
-        self._target_thread = None
+        self._applied_target = None     # last expression pushed to the engine
         # Start/stop run their blocking parts (WinDivert driver load ~0.5-1 s, and
         # the worker-thread joins on stop) OFF the UI thread, so the window never
         # freezes. The worker leaves its result in _ui_queue and the main thread
@@ -1264,7 +1264,7 @@ class App:
                 self.engine_warning.pack_forget()
 
     def _drain_target_warning(self):
-        """Apply the refresher thread's verdict to the widget. Main thread only."""
+        """Render the current target verdict. Main thread only."""
         text = self._pending_target_warning
         if text == self._shown_target_warning:
             return                      # nothing changed: no widget work at all
@@ -1272,32 +1272,52 @@ class App:
         self.set_target_warning(text)
 
     def _refresh_target(self, force=False):
-        # One shared implementation (settings.apply_targeting) resolves the
-        # expression, sums the ports of every matching process and logs it, so the
-        # GUI and apply_settings can never drift apart. NO WIDGET IS TOUCHED HERE:
-        # this runs on the refresher thread, so it only reads the main thread's
-        # snapshot of the expression and leaves its verdict in a plain string for
-        # _tick() to render.
+        """Keep the engine's target in step with the field, and report what it caught.
+
+        This used to run on a 2 s background loop (``_target_refresher``, removed).
+        Every pass called ``apply_targeting``, which resolved the port set
+        SYNCHRONOUSLY - four syscalls and a psutil walk - on a thread nobody
+        watched. Worse, the loop was never joined while ``_finish_start`` spawned a
+        new one on every start, so a STOP followed by a START inside its sleep left
+        the old one running as well: one extra permanent scanner per fast restart.
+
+        Keeping the port set fresh is ``target_resolver``'s job now. What is left
+        here is cheap and runs on the main thread from ``_tick``: apply the
+        expression when the USER changed it, then read the verdict.
+
+        NO WIDGET IS TOUCHED HERE - the verdict goes into a plain field and
+        ``_drain_target_warning`` renders it. Deliberately kept that way: it is the
+        shape that stops a Tcl call ever leaving the main thread, whoever calls this
+        next (convention 26).
+        """
         expression = self._target_expr
+        if force or expression != self._applied_target:
+            self._applied_target = expression
+            if not expression:
+                self.engine.set_target(False)
+            else:
+                # One shared implementation (settings.apply_targeting) compiles the
+                # expression and points the engine at it, so the GUI and
+                # apply_settings can never drift apart.
+                apply_targeting(self.engine, expression, self.log, announce=force)
         if not expression:
-            self.engine.set_target(False)
             self._pending_target_warning = ""
             return
-        targeting = apply_targeting(self.engine, expression, self.log, announce=force)
+        targeting = self.engine.targeting()
+        if targeting is None:
+            self._pending_target_warning = T("fields.target_no_match")
+            return
+        if targeting.refreshes == 0:
+            # Just typed, never resolved: the resolver thread only runs during a
+            # session, and reporting "matches nothing" before anybody looked would
+            # be a lie. One resolve here - bounded to once per edit, not per tick.
+            with crashlog.quiet("gui.app"):
+                targeting.refresh()
         # A target that matches nothing impairs nothing - and a run in which
         # nothing broke looks exactly like a run in which everything held up.
         # Say so on the page, not only in the log.
-        if targeting is None or not targeting.matched:
-            self._pending_target_warning = T("fields.target_no_match")
-        else:
-            self._pending_target_warning = ""
-
-    def _target_refresher(self):
-        # Runs for the whole session so unticking "target process" (or clearing the
-        # field) takes effect within one cycle.
-        while self.running:
-            self._refresh_target()
-            time.sleep(2.0)
+        self._pending_target_warning = (
+            "" if targeting.matched else T("fields.target_no_match"))
 
     def toggle(self):
         self._stop() if self.running else self._start()
@@ -1353,8 +1373,9 @@ class App:
             self._scenario.loop = self.loop_var.get()
             self.engine.start_scenario(self._scenario, s, log=self.log)
         self._snapshot_target()
-        self._target_thread = threading.Thread(target=self._target_refresher, daemon=True)
-        self._target_thread.start()
+        # No refresher thread any more: _tick applies a changed expression and the
+        # engine's resolver keeps the port set fresh (see _refresh_target).
+        self._applied_target = None     # re-apply once, now that the engine is up
         self._sync_running_ui()
 
     def _stop(self):
@@ -1665,7 +1686,11 @@ class App:
             self._drain_target_warning()   # worker-thread verdict (main thread only)
             self._drain_engine_warning()   # "the tool itself is dropping packets"
             self._sample()
-            self._snapshot_target()     # main-thread read for the refresher thread
+            self._snapshot_target()     # main-thread read of the target field
+            if self.running:
+                # Cheap now: applies only when the expression changed, and the
+                # resolving happens on the engine's resolver thread.
+                self._refresh_target()
             if self._transition is None and self.running and not self.engine.is_running():
                 self._on_engine_stopped()      # deadline reached / worker fault
             if self._visible():

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -1308,9 +1308,16 @@ class App:
             self._pending_target_warning = T("fields.target_no_match")
             return
         if targeting.refreshes == 0:
-            # Just typed, never resolved: the resolver thread only runs during a
-            # session, and reporting "matches nothing" before anybody looked would
-            # be a lie. One resolve here - bounded to once per edit, not per tick.
+            if self.engine.is_running():
+                # The resolver will have looked by the next tick. Do NOT resolve
+                # here: it is four syscalls and a psutil walk, and this is the UI
+                # thread - a frozen window in this tool is not cosmetic, it is the
+                # user unable to press STOP on their own broken network. The banner
+                # can wait 700 ms; the window cannot wait at all.
+                return
+            # Stopped: there is no resolver running and no session to stall, so
+            # resolve inline rather than report "matches nothing" before anyone
+            # looked - which would be a lie.
             with crashlog.quiet("gui.app"):
                 targeting.refresh()
         # A target that matches nothing impairs nothing - and a run in which

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -1690,7 +1690,7 @@ class App:
         try:
             self._drain_ui_queue()      # finished async start/stop (main thread only)
             self._drain_log()           # worker-thread log lines (main thread only)
-            self._drain_target_warning()   # worker-thread verdict (main thread only)
+            self._drain_target_warning()   # render the target verdict (main thread)
             self._drain_engine_warning()   # "the tool itself is dropping packets"
             self._sample()
             self._snapshot_target()     # main-thread read of the target field

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -154,6 +154,17 @@ def apply_targeting(engine, target, log=lambda *_: None, announce=True):
         return None
     try:
         targeting = engine.target_for(matcher)
+        if announce:
+            # ONE synchronous resolve, and only on the announcing path - which is
+            # the explicit "the user applied settings" one. It is needed because the
+            # log line below reports what was actually matched, and an unresolved
+            # target would always read as "matches nothing" (the very message this
+            # project made loud on purpose).
+            #
+            # The periodic path passes announce=False and never blocks: keeping the
+            # port set fresh from there on is the resolver thread's job, which is
+            # what took this cost off the packet path in the first place.
+            targeting.refresh()
     except ImportError:
         log(T("log.targeting_requires_psutil"))
         engine.set_target(False)

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -6,6 +6,7 @@ settings dict and applies it to an engine.
 """
 import json
 
+from . import crashlog
 from . import fields as F
 from .jsonfile import write_json
 from .fields import FIELD_DEFS, FIELDS
@@ -154,17 +155,6 @@ def apply_targeting(engine, target, log=lambda *_: None, announce=True):
         return None
     try:
         targeting = engine.target_for(matcher)
-        if announce:
-            # ONE synchronous resolve, and only on the announcing path - which is
-            # the explicit "the user applied settings" one. It is needed because the
-            # log line below reports what was actually matched, and an unresolved
-            # target would always read as "matches nothing" (the very message this
-            # project made loud on purpose).
-            #
-            # The periodic path passes announce=False and never blocks: keeping the
-            # port set fresh from there on is the resolver thread's job, which is
-            # what took this cost off the packet path in the first place.
-            targeting.refresh()
     except ImportError:
         log(T("log.targeting_requires_psutil"))
         engine.set_target(False)
@@ -172,6 +162,21 @@ def apply_targeting(engine, target, log=lambda *_: None, announce=True):
     except Exception as e:                                   # pragma: no cover
         log(f"{T('log.targeting_error')}: {e}")
         return None
+    if announce:
+        # ONE synchronous resolve, and only on the announcing path - the explicit
+        # "the user applied settings" one. It is needed because the log line below
+        # reports what was actually matched, and an unresolved target would always
+        # read as "matches nothing" - the very message this project made loud on
+        # purpose. The periodic path passes announce=False and never blocks:
+        # keeping the port set fresh is the resolver thread's job from then on.
+        #
+        # Outside the try above, and swallowed: a failed resolve must NOT abort the
+        # install. Aborting left the engine holding a new targeting object that the
+        # core had never been pointed at - two halves disagreeing about what is
+        # being impaired. A stale announcement is a far smaller problem, and the
+        # resolver corrects it within a tick.
+        with crashlog.quiet("settings.targeting"):
+            targeting.refresh()
     engine.set_target(True, targeting)
     if announce:
         if targeting.matched:

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -80,14 +80,20 @@ class TargetResolver:
         with self._lock:
             thread, self._thread = self._thread, None
             previous, self._targeting = self._targeting, None
+            # Signalled INSIDE the lock, together with taking the thread. Setting
+            # it afterwards left a window where a concurrent start() could clear
+            # _stopping, spawn a fresh thread, and then have this set() kill it on
+            # its first loop check. BeanEngine serialises start/stop under its own
+            # lock so it cannot happen there today, but a threading primitive
+            # should not depend on its caller to be safe.
+            self._stopping.set()
+            self._wake.set()                # unblock an idle wait()
         if previous is not None:
             # Detach, so a packet arriving late cannot poke the event of a resolver
             # that is no longer listening. Harmless either way, but a dangling
             # callback into a dead worker is the kind of thing that becomes a real
             # bug the next time somebody touches this.
             previous.on_miss(None)
-        self._stopping.set()
-        self._wake.set()                    # unblock an idle wait()
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
             thread.join(timeout=timeout)
 

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -79,7 +79,13 @@ class TargetResolver:
         """Stop the thread and WAIT for it: it holds OS handles."""
         with self._lock:
             thread, self._thread = self._thread, None
-            self._targeting = None
+            previous, self._targeting = self._targeting, None
+        if previous is not None:
+            # Detach, so a packet arriving late cannot poke the event of a resolver
+            # that is no longer listening. Harmless either way, but a dangling
+            # callback into a dead worker is the kind of thing that becomes a real
+            # bug the next time somebody touches this.
+            previous.on_miss(None)
         self._stopping.set()
         self._wake.set()                    # unblock an idle wait()
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -42,17 +42,21 @@ every "Apply", and the concurrency tests do hundreds of times - must not churn
 threads.
 """
 import threading
+import time
 
-from . import crashlog
+from . import crashlog, portmap
 
-REFRESH_S = 0.30                # routine rebuild when nothing asks sooner
+REFRESH_S = portmap.REFRESH_S            # routine rebuild when nothing asks sooner
+MIN_INTERVAL_S = portmap.MISS_REFRESH_S  # floor between miss-driven rebuilds
 
 
 class TargetResolver:
     """Rebuilds one ``ProcessTargeting``'s port set on a background thread."""
 
-    def __init__(self, interval=REFRESH_S):
+    def __init__(self, interval=REFRESH_S, min_interval=MIN_INTERVAL_S):
         self.interval = float(interval)
+        self.min_interval = float(min_interval)
+        self._last_rebuild = 0.0
         self._targeting = None
         self._thread = None
         self._wake = threading.Event()
@@ -106,15 +110,36 @@ class TargetResolver:
     # -- the worker ------------------------------------------------------------- #
     def _loop(self):
         while not self._stopping.is_set():
-            # Arm BEFORE reading the target and rebuilding: a miss that arrives
-            # while we are inside refresh() then sets the event again, the wait
-            # below returns at once and the next pass picks it up. Clearing after
-            # the rebuild would swallow exactly that wake-up.
-            self._wake.clear()
             targeting = self._targeting
             if targeting is None:
                 self._wake.wait()           # nothing to resolve: sleep for free
+                self._wake.clear()
                 continue
+
+            # THE FLOOR, and it is not optional. Targeting narrows traffic to one
+            # application, so every packet from every OTHER application is a miss:
+            # misses arrive CONTINUOUSLY, not occasionally. Without a minimum gap
+            # the wake-up is re-armed as fast as it is consumed and this thread
+            # scans the socket table without pause. Measured before this guard
+            # existed: 63 rebuilds a second against a 0.3 s routine tick, bounded
+            # only by the GIL. This is the ``miss_interval`` that used to live in
+            # ``__contains__`` - same 0.05 s, enforced in one place instead of on
+            # the capture thread.
+            #
+            # The cost of the floor is the worst-case delay before a brand-new
+            # socket (a freshly spawned child process, say) starts being impaired:
+            # up to min_interval. That is the trade the old code made too.
+            since = time.monotonic() - self._last_rebuild
+            if since < self.min_interval:
+                self._stopping.wait(timeout=self.min_interval - since)
+                continue
+
+            # Clear BEFORE consuming and rebuilding: a miss arriving while we are
+            # inside refresh() sets the flag again AND re-arms the event, so the
+            # wait below returns at once and the next pass picks it up. The FLAG is
+            # the durable signal; the event is only a doorbell, so losing one to a
+            # race costs nothing.
+            self._wake.clear()
             targeting.consume_miss()
             try:
                 targeting.refresh()
@@ -124,4 +149,5 @@ class TargetResolver:
                 # port set simply goes stale until the next pass. But it stops
                 # being invisible.
                 crashlog.once("targeting.resolver", exc)
+            self._last_rebuild = time.monotonic()
             self._wake.wait(timeout=self.interval)

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -75,8 +75,21 @@ class TargetResolver:
                                             daemon=True)
             self._thread.start()
 
-    def stop(self, timeout=2.0):
-        """Stop the thread and WAIT for it: it holds OS handles."""
+    # Long enough that an IDLE resolver is always joined (it is parked in wait(),
+    # so it exits in microseconds), short enough that a scan in flight can never
+    # hold STOP up. Measured on a normal desktop: a cold resolve is 1.7 SECONDS
+    # (25 PIDs own sockets but the info cache holds 346 - the expensive part is one
+    # full psutil.process_iter()), against 1.4 ms once warm. Joining that would have
+    # meant a 1.6 s STOP, and STOP is the control this tool may never make slow: it
+    # is how the user undoes the damage they just did to their own network.
+    #
+    # Not joining is safe. stop() has already cleared _targeting and set _stopping,
+    # so a straggler finishes at most one more scan - into an object nobody reads
+    # any more - and then exits at its next loop check. It is a daemon either way.
+    JOIN_S = 0.25
+
+    def stop(self, timeout=JOIN_S):
+        """Stop the thread, waiting only briefly - never for a scan in flight."""
         with self._lock:
             thread, self._thread = self._thread, None
             previous, self._targeting = self._targeting, None

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -1,0 +1,127 @@
+"""Keeps the targeted port set fresh - on its own thread, never on the capture one.
+
+Why this module exists
+----------------------
+``ProcessTargeting`` answers "does this local port belong to the targeted
+process?". Answering it means reading the OS socket table and resolving PIDs to
+process names, which costs four ``iphlpapi`` calls, an O(n) dict copy, a
+``psutil.Process()`` per distinct PID and - whenever a protected PID refuses to
+open - a whole ``psutil.process_iter()``.
+
+All of that used to happen inside ``ProcessTargeting.__contains__``, i.e. inside
+``BeanCore.decide()``, i.e. on the CAPTURE THREAD, while holding ``core._lock``.
+And it was the normal case rather than an edge one: targeting exists to narrow
+traffic to a single application, so every packet from every *other* application
+is a miss, and a miss is what triggered the rebuild. With a target set, that was
+a steady ~20 Hz of syscalls in the packet path.
+
+A stalled capture thread is the one failure this tool must not have. WinDivert
+keeps diverting packets into a queue nobody is draining, so the user quietly
+loses connectivity - while the UI cheerfully reports "running". The whole
+fail-open design (convention 20), the watchdog, and moving eviction and table
+sorting off the hot path all exist to prevent exactly that. Targeting was the
+last place still doing it.
+
+Shape
+-----
+Deliberately the same shape as :mod:`beantester.scenario_runner`: a small class
+that owns one background thread, with its lifecycle driven explicitly by
+``BeanEngine`` (``start`` / ``stop``), rather than a leaf object that
+self-starts a hidden daemon. Two differences, both on purpose:
+
+* **``stop()`` joins.** The resolver holds OS handles; it must stop touching them
+  the moment the session ends, not "eventually". (``ScenarioRunner.stop()`` only
+  sets a flag.)
+* **It waits on an ``Event``, not a ``sleep``.** A packet for an unknown port
+  wakes it immediately, so a brand-new connection starts being impaired within
+  tens of milliseconds instead of at the next tick.
+
+ONE resolver per engine, with a swappable target: retargeting is a reference
+swap, not a thread restart. Applying settings repeatedly - which the GUI does on
+every "Apply", and the concurrency tests do hundreds of times - must not churn
+threads.
+"""
+import threading
+
+from . import crashlog
+
+REFRESH_S = 0.30                # routine rebuild when nothing asks sooner
+
+
+class TargetResolver:
+    """Rebuilds one ``ProcessTargeting``'s port set on a background thread."""
+
+    def __init__(self, interval=REFRESH_S):
+        self.interval = float(interval)
+        self._targeting = None
+        self._thread = None
+        self._wake = threading.Event()
+        self._stopping = threading.Event()
+        self._lock = threading.Lock()
+        self._rebuilds = 0
+
+    # -- lifecycle (driven by BeanEngine) -------------------------------------- #
+    def start(self):
+        """Start the thread if it is not already running. Idempotent."""
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stopping.clear()
+            self._thread = threading.Thread(target=self._loop, name="bean-target-resolver",
+                                            daemon=True)
+            self._thread.start()
+
+    def stop(self, timeout=2.0):
+        """Stop the thread and WAIT for it: it holds OS handles."""
+        with self._lock:
+            thread, self._thread = self._thread, None
+            self._targeting = None
+        self._stopping.set()
+        self._wake.set()                    # unblock an idle wait()
+        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+
+    def retarget(self, targeting):
+        """Point the resolver at a new targeting (``None`` = nothing to resolve).
+
+        A reference swap, not a thread restart - see the module docstring.
+        """
+        with self._lock:
+            previous, self._targeting = self._targeting, targeting
+        if previous is not None and previous is not targeting:
+            previous.on_miss(None)          # an orphan must not keep waking us
+        if targeting is not None:
+            targeting.on_miss(self._wake.set)
+        self._wake.set()
+
+    # -- introspection (tests, diagnostics) ------------------------------------ #
+    def is_running(self):
+        thread = self._thread
+        return thread is not None and thread.is_alive()
+
+    @property
+    def rebuilds(self):
+        return self._rebuilds
+
+    # -- the worker ------------------------------------------------------------- #
+    def _loop(self):
+        while not self._stopping.is_set():
+            # Arm BEFORE reading the target and rebuilding: a miss that arrives
+            # while we are inside refresh() then sets the event again, the wait
+            # below returns at once and the next pass picks it up. Clearing after
+            # the rebuild would swallow exactly that wake-up.
+            self._wake.clear()
+            targeting = self._targeting
+            if targeting is None:
+                self._wake.wait()           # nothing to resolve: sleep for free
+                continue
+            targeting.consume_miss()
+            try:
+                targeting.refresh()
+                self._rebuilds += 1
+            except Exception as exc:
+                # The session must not die because a socket table hiccupped; the
+                # port set simply goes stale until the next pass. But it stops
+                # being invisible.
+                crashlog.once("targeting.resolver", exc)
+            self._wake.wait(timeout=self.interval)

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -18,9 +18,8 @@ So targeting is a live object instead:
 
 * it rebuilds its port set every ``interval`` (300 ms by default, cheap thanks
   to :mod:`beantester.portmap`),
-* an **unknown port forces an early rebuild** (rate limited to ``miss_interval``),
-  which shrinks the "new socket slips through" window from seconds to tens of
-  milliseconds,
+* an **unknown port asks for an early rebuild**, which shrinks the "new socket
+  slips through" window from seconds to tens of milliseconds,
 * a socket belongs to the target when its owning process **or any of its
   ancestors** matches the expression - so a PID (or a name) covers the whole
   process tree. An explicitly EXCLUDED process (``!chromedriver``) is never
@@ -28,6 +27,27 @@ So targeting is a live object instead:
 
 ``BeanCore.decide()`` keeps its ``local_port not in target_ports`` test: this
 class simply *is* the container it tests against (``__contains__``).
+
+Who does the rebuilding, and where
+----------------------------------
+``__contains__`` runs in the PACKET PATH, inside ``BeanCore._lock``, at up to
+150 000 calls a second. It therefore does no work beyond a frozenset lookup.
+
+It used to call ``refresh()`` itself, which meant the capture thread paid for
+four ``iphlpapi`` calls, an O(n) dict copy and a ``psutil.Process()`` per distinct
+PID - occasionally a whole ``process_iter()`` - while holding the core lock. And
+that was not a rare path: targeting exists to narrow traffic to one application,
+so every packet from every OTHER application is a MISS, which made the rebuild a
+steady 20 Hz whenever a target was set. A stalled capture thread is exactly the
+failure WinDivert punishes: it keeps diverting into a queue nobody drains, so the
+user loses connectivity while the UI still says "running".
+
+Now a miss only sets a flag and wakes :class:`~beantester.target_resolver.TargetResolver`,
+which rebuilds on its own thread. The flag is the reason the wake-up is free:
+``Event.set()` takes a lock, so it is called only on the FALSE -> TRUE transition,
+at most once per resolver cycle, while the flag itself is a plain bool (atomic
+under the GIL). ``refresh()`` stays public and synchronous for one-shot callers
+(``resolve_ports``, ``make_targeting``) and for tests.
 
 Hard limit, documented on purpose: WinDivert hands us a packet, not a PID, so
 the port -> process mapping is inherently a race. It cannot be closed, only made
@@ -56,6 +76,11 @@ class ProcessTargeting:
         self._pids = frozenset()
         self._last = 0.0
         self._refreshes = 0
+        # Set by the packet path when it is asked about a port it does not know;
+        # cleared by the resolver before each rebuild. A plain bool on purpose -
+        # reads and writes are atomic under the GIL, so the hot path pays nothing.
+        self._miss = False
+        self._on_miss = None        # the resolver's wake-up, when one is attached
 
     # -- resolution ----------------------------------------------------------- #
     def _matches(self, pid, name):
@@ -95,21 +120,44 @@ class ProcessTargeting:
 
     # -- the container BeanCore tests against ---------------------------------- #
     def __contains__(self, port):
+        """A frozenset lookup and nothing else. See "Who does the rebuilding".
+
+        THE PACKET PATH CALLS THIS, inside ``BeanCore._lock``. It must not touch
+        the socket table, psutil, or any lock of its own.
+        """
         if port is None:
             return False
-        now = self.clock()
-        if (now - self._last) >= self.interval:
-            self.refresh(now)
         if port in self._ports:
             return True
-        # An unknown port is the interesting case: it is either traffic we do not
-        # care about, or a connection the target opened microseconds ago. Only a
-        # fresh look can tell - rate limited, so a busy link cannot turn this into
-        # a rebuild per packet.
-        if (now - self._last) >= self.miss_interval:
-            self.refresh(now)
-            return port in self._ports
+        # An unknown port is the interesting case: either traffic we do not care
+        # about, or a connection the target opened microseconds ago. Only a fresh
+        # scan can tell - so ask for one and get out of the way. The guard keeps
+        # Event.set() (which takes a lock) to one call per resolver cycle instead
+        # of one per packet.
+        if not self._miss:
+            self._miss = True
+            wake = self._on_miss
+            if wake is not None:
+                wake()
         return False
+
+    # -- resolver handshake ----------------------------------------------------- #
+    def on_miss(self, callback):
+        """Attach the resolver's wake-up (``None`` detaches it)."""
+        self._on_miss = callback
+
+    def consume_miss(self):
+        """Take and clear the "somebody asked about an unknown port" flag.
+
+        Called by the resolver BEFORE it rebuilds, so a miss that happens *during*
+        the rebuild re-arms instead of being swallowed by it.
+        """
+        missed, self._miss = self._miss, False
+        return missed
+
+    @property
+    def missed(self):
+        return self._miss
 
     def __iter__(self):
         return iter(self._ports)

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -16,8 +16,9 @@ the field ("I target chrome and the browser keeps working"):
 
 So targeting is a live object instead:
 
-* it rebuilds its port set every ``interval`` (300 ms by default, cheap thanks
-  to :mod:`beantester.portmap`),
+* its port set is rebuilt on a routine tick (300 ms by default, cheap thanks to
+  :mod:`beantester.portmap`) by :class:`~beantester.target_resolver.TargetResolver`,
+  which also owns the pacing - this class holds no timing knobs of its own,
 * an **unknown port asks for an early rebuild**, which shrinks the "new socket
   slips through" window from seconds to tens of milliseconds,
 * a socket belongs to the target when its owning process **or any of its
@@ -44,7 +45,7 @@ user loses connectivity while the UI still says "running".
 
 Now a miss only sets a flag and wakes :class:`~beantester.target_resolver.TargetResolver`,
 which rebuilds on its own thread. The flag is the reason the wake-up is free:
-``Event.set()` takes a lock, so it is called only on the FALSE -> TRUE transition,
+``Event.set()`` takes a lock, so it is called only on the FALSE -> TRUE transition,
 at most once per resolver cycle, while the flag itself is a plain bool (atomic
 under the GIL). ``refresh()`` stays public and synchronous for one-shot callers
 (``resolve_ports``, ``make_targeting``) and for tests.
@@ -62,19 +63,19 @@ from . import portmap
 class ProcessTargeting:
     """The set of local ports owned by the processes matching an expression."""
 
-    def __init__(self, matcher, table=None, interval=portmap.REFRESH_S,
-                 miss_interval=portmap.MISS_REFRESH_S, clock=time.monotonic):
+    def __init__(self, matcher, table=None, clock=time.monotonic):
+        # No interval/miss_interval here any more. They used to drive the rate
+        # limiting inside __contains__; the pacing now lives entirely in
+        # TargetResolver, and leaving dead knobs on the constructor would invite
+        # somebody to tune something that controls nothing.
         self.matcher = matcher
         self.expression = getattr(matcher, "raw", str(matcher))
         self.table = table if table is not None else portmap.default_table()
-        self.interval = float(interval)
-        self.miss_interval = float(miss_interval)
         self.clock = clock
         self._lock = threading.RLock()
         self._ports = frozenset()
         self._names = ()
         self._pids = frozenset()
-        self._last = 0.0
         self._refreshes = 0
         # Set by the packet path when it is asked about a port it does not know;
         # cleared by the resolver before each rebuild. A plain bool on purpose -
@@ -114,7 +115,6 @@ class ProcessTargeting:
             self._ports = frozenset(port for port, pid in port_pid.items()
                                     if pid in pids)
             self._names = tuple(sorted(n for n in names if n))
-            self._last = now
             self._refreshes += 1
             return self._ports
 

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -199,8 +199,14 @@ def test_the_ui_notices_when_the_engine_stops_itself():
     """)
 
 
-def test_the_target_refresher_never_touches_tkinter():
-    """Tcl is not thread-safe: the worker thread may only see a main-thread snapshot."""
+def test_target_syncing_reads_only_the_main_thread_snapshot():
+    """``_refresh_target`` works off ``_target_expr``, never off the tk variable.
+
+    The background refresher that used to call this is gone (resolving moved to
+    ``target_resolver``), but the separation it forced is worth keeping: the
+    snapshot is taken on the main thread, and everything downstream consumes the
+    plain string. That is what makes it safe to call this from anywhere later.
+    """
     run_gui("""
         app.vars["target"].set("chrome.exe")
         assert app._snapshot_target() == "chrome.exe"
@@ -209,16 +215,16 @@ def test_the_target_refresher_never_touches_tkinter():
         app.vars["target"].set("   ")
         assert app._snapshot_target() == ""
 
-        # from now on every tk variable explodes if the worker thread touches it
+        # from now on the tk variable explodes if anything downstream reads it
         class Exploding:
             def get(self):
-                raise AssertionError("tk variable read from the refresher thread")
+                raise AssertionError("_refresh_target read the tk variable")
             def set(self, *a):
-                raise AssertionError("tk variable written from the refresher thread")
+                raise AssertionError("_refresh_target wrote the tk variable")
 
         app.vars["target"] = Exploding()
         app._target_expr = "chrome.exe"
-        app._refresh_target()          # this is what the worker thread runs
+        app._refresh_target()          # consumes the snapshot only
     """)
 
 

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -318,3 +318,97 @@ def test_target_verdict_is_recorded_not_rendered_off_the_main_thread():
         app._drain_target_warning()
         assert len(touched) == before, "an unchanged banner must cost no widget work"
     """)
+
+
+def test_a_gui_session_keeps_the_target_banner_honest():
+    """The tick loop end to end: apply on change, and report what was matched.
+
+    The GUI no longer runs a refresher thread - `_tick` applies a changed target
+    expression and the engine's resolver keeps the port set fresh. That rewiring
+    was verified against a real session (real engine, real resolver, synthetic
+    traffic) and this pins the behaviour it must keep:
+
+      * a target that matches nothing raises the banner - a run in which nothing
+        broke looks exactly like a run in which everything held up;
+      * a target that DOES match takes it back down;
+      * clearing the field drops targeting altogether;
+      * none of it stalls the capture.
+
+    The socket table is faked so the test is deterministic and fast. Against the
+    real one the first resolve costs about 1.7 s on a normal desktop, which is a
+    measurement worth knowing but not worth spending in every suite run.
+    """
+    run_gui("""
+        import time
+        from beantester import portmap
+        from beantester.synthetic import SyntheticDivert
+
+        class FakeTable:
+            def __init__(self):
+                self.ports = {5001: 200}
+                self.info = {200: ("realapp.exe", 1)}
+            def refresh(self, now=None, force=False): return True
+            def snapshot(self): return dict(self.ports)
+            def name_of(self, pid): return self.info.get(pid, ("", None))[0]
+            def ancestors(self, pid, depth=8): return []
+            def refresh_if_stale(self, now=None, miss=False): return True
+            def process_for_port(self, port, now=None, allow_refresh=True): return ""
+            def pid_for(self, port): return self.ports.get(port)
+
+        table = FakeTable()
+        portmap.default_table = lambda: table
+
+        real_start = app.engine.start
+        app.engine.start = (lambda filt, divert=None, duration=0:
+                            real_start(filt, divert=SyntheticDivert(seed=21),
+                                       duration=duration))
+
+        def settle(seconds=1.0):
+            end = time.monotonic() + seconds
+            while time.monotonic() < end:
+                app._tick()
+                time.sleep(0.02)
+
+        app._start(); app._settle_transition()
+        assert app.running is True, "the GUI did not start"
+        settle(0.3)
+        assert app.engine.resolver().is_running(), "no resolver for the session"
+        assert app._pending_target_warning == "", repr(app._pending_target_warning)
+        seen1 = app.engine.stats_snapshot()["seen"]
+        assert seen1 > 0, "no traffic"
+
+        # a target nothing matches: the banner must shout
+        app.vars["target"].set("no_such_process_xyz")
+        settle(1.0)
+        tg = app.engine.targeting()
+        assert app._applied_target == "no_such_process_xyz", app._applied_target
+        assert tg is not None and tg.refreshes > 0, "the resolver never resolved it"
+        assert app._pending_target_warning == bnt.T("fields.target_no_match"), \
+            "banner should shout: %r" % app._pending_target_warning
+        assert app._shown_target_warning == app._pending_target_warning, "not rendered"
+
+        # a target that DOES own a socket: the banner must come back down
+        app.vars["target"].set("realapp")
+        settle(1.0)
+        tg = app.engine.targeting()
+        assert tg.expression == "realapp", tg.expression
+        assert tg.matched is True and len(tg.ports()) > 0, sorted(tg.ports())
+        assert app._pending_target_warning == "", \
+            "a matching target must clear the banner: %r" % app._pending_target_warning
+        assert app._shown_target_warning == "", "the banner was not taken down"
+
+        # clearing the field drops targeting entirely
+        app.vars["target"].set("")
+        settle(0.4)
+        assert app.engine.targeting() is None, "clearing must drop targeting"
+        assert app._pending_target_warning == "", "no target, no banner"
+
+        assert app.engine.stats_snapshot()["seen"] > seen1, "traffic stalled"
+
+        t0 = time.monotonic()
+        app._stop(); app._settle_transition()
+        stop_ms = (time.monotonic() - t0) * 1000
+        assert app.running is False, "the GUI did not stop"
+        assert stop_ms < 900, "STOP took %.0f ms" % stop_ms
+        assert not app.engine.resolver().is_running(), "resolver outlived the session"
+    """)

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -260,8 +260,8 @@ def test_dialogs_are_in_app_and_translated():
     """)
 
 
-def test_target_refresher_never_touches_widgets_from_its_thread():
-    """The refresher thread must not make Tcl calls (convention: Tk = main thread).
+def test_target_verdict_is_recorded_not_rendered_off_the_main_thread():
+    """``_refresh_target`` must leave its verdict in a field, never draw it itself.
 
     ``_refresh_target`` used to call ``set_target_warning`` directly, so
     ``.config()`` / ``.winfo_ismapped()`` / ``.pack()`` ran on a worker thread.
@@ -269,6 +269,12 @@ def test_target_refresher_never_touches_widgets_from_its_thread():
     open, which is the one thing FAIL-OPEN exists to prevent - or raises
     ``RuntimeError: main thread is not in main loop`` into a bare ``except``,
     silently swallowing the very banner that is supposed to shout.
+
+    The background refresher that made this urgent is gone (resolving moved to
+    ``target_resolver``), but the SHAPE is the guard: as long as the verdict goes
+    into ``_pending_target_warning`` and only ``_drain_target_warning`` renders it,
+    calling this from a thread again can never put a Tcl call on one. The test
+    still runs it on a worker thread, which is the hostile case.
     """
     run_gui("""
         import threading

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -289,7 +289,11 @@ def test_engine_records_a_broken_port_table_instead_of_going_quiet(monkeypatch):
     """The capture thread keeps going (a blank name beats a dead session), but the
     reason no longer disappears. ``once()``, not ``note()``: this is the hot path."""
     class _Broken:
-        def process_for_port(self, port):
+        # the signature MATTERS: the engine reads with allow_refresh=False (it must
+        # never make the capture thread rebuild the table). A fake missing the
+        # keyword would raise TypeError instead, and the test would pass while
+        # exercising the wrong failure entirely.
+        def process_for_port(self, port, now=None, allow_refresh=True):
             raise RuntimeError("boom")
 
         def pid_for(self, port):

--- a/tests/test_release_fixes.py
+++ b/tests/test_release_fixes.py
@@ -176,28 +176,38 @@ def test_an_explicit_exclusion_beats_an_inherited_match():
           targeting.ports() == {5001}, f"({targeting.ports()})")
 
 
-def test_an_unknown_port_forces_an_early_refresh():
-    """A brand-new connection must not run unimpaired until the next scan."""
-    clock = [100.0]
+def test_an_unknown_port_asks_for_a_rebuild_without_scanning_inline():
+    """A brand-new connection must not run unimpaired until the next scan - and the
+    scan must not happen on the packet path either.
+
+    This used to call ``refresh()`` straight from ``__contains__``, i.e. from
+    ``BeanCore.decide()``, i.e. on the CAPTURE THREAD holding the core lock: four
+    iphlpapi calls, an O(n) copy and a psutil walk per rebuild. And it was the
+    normal case, not an edge one - targeting narrows traffic to one application, so
+    every packet from every OTHER application is a miss.
+    """
     table = _FakeTable(ports={5001: 200}, info={200: ("chrome.exe", 1)})
-    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table,
-                                 clock=lambda: clock[0])
-    targeting.refresh(now=clock[0])
-    before = targeting.refreshes
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
+    targeting.refresh()
+    before = table.refreshes
 
     # the app opens a socket right now; the cached set knows nothing about it
     table.ports[5002] = 200
-    clock[0] += 0.06                    # less than the routine interval (0.30 s)
-    check("the new port is picked up on the miss", 5002 in targeting)
-    check("which cost exactly one extra refresh",
-          targeting.refreshes == before + 1, f"({targeting.refreshes})")
+    check("the packet path answers without scanning", 5002 not in targeting)
+    check("it did NOT touch the socket table", table.refreshes == before,
+          f"({table.refreshes} vs {before})")
+    check("but it did ask for a rebuild", targeting.missed)
 
-    # ...but a miss storm cannot turn into a rebuild per packet
-    refreshes = targeting.refreshes
+    # ...and a miss storm asks ONCE, not once per packet: Event.set() takes a lock,
+    # so the flag transition is what guards the hot path
+    targeting.consume_miss()
+    wakes = []
+    targeting.on_miss(lambda: wakes.append(1))
     for _ in range(50):
         assert 9999 not in targeting
-    check("misses are rate limited", targeting.refreshes == refreshes,
-          f"({targeting.refreshes} vs {refreshes})")
+    check("50 misses wake the resolver exactly once", len(wakes) == 1, f"({len(wakes)})")
+    check("still no socket-table access from the packet path",
+          table.refreshes == before, f"({table.refreshes} vs {before})")
 
 
 def test_targeting_reports_when_it_matches_nothing():

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -1,0 +1,217 @@
+"""The targeted port set is resolved on its own thread, never on the packet path.
+
+The invariant this file exists for: ``ProcessTargeting.__contains__`` runs inside
+``BeanCore.decide()``, on the capture thread, holding the core lock, at up to
+150 000 calls a second. It may look things up. It may not go and ASK the operating
+system, which is what it used to do - four iphlpapi calls, an O(n) dict copy and a
+``psutil.Process()`` per PID, at a steady ~20 Hz whenever a target was set (every
+packet from every non-targeted application is a miss, and a miss triggered the
+rebuild).
+
+A stalled capture thread is the failure the whole fail-open design exists to
+prevent: WinDivert keeps diverting into a queue nobody drains, so the user loses
+connectivity while the UI still says "running".
+"""
+import threading
+import time
+
+import bean_network_tester as bnt
+from beantester.engine import BeanEngine
+from beantester.synthetic import SyntheticDivert
+from beantester.target_resolver import TargetResolver
+from beantester.targeting import ProcessTargeting
+from fakes import check
+
+
+class _CountingTable:
+    """A socket table that records every time somebody makes it look."""
+
+    def __init__(self, ports=None, info=None):
+        self.ports = dict(ports or {})
+        self._info = dict(info or {})
+        self.refreshes = 0
+        self.threads = set()
+
+    def refresh(self, now=None, force=False):
+        self.refreshes += 1
+        self.threads.add(threading.current_thread().name)
+        return True
+
+    def snapshot(self):
+        return dict(self.ports)
+
+    def name_of(self, pid):
+        return self._info.get(pid, ("", None))[0]
+
+    def ancestors(self, pid, depth=8):
+        return []
+
+
+def _targeting(expr="chrome", table=None):
+    table = table if table is not None else _CountingTable(
+        ports={5001: 200}, info={200: ("chrome.exe", 1)})
+    return ProcessTargeting(bnt.parse_target(expr), table=table), table
+
+
+def _wait(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+# -- the resolver itself ------------------------------------------------------ #
+def test_a_miss_wakes_the_resolver_and_the_new_port_is_picked_up():
+    """The wake-up, not the timer, is what closes the race on a new connection."""
+    targeting, table = _targeting()
+    targeting.refresh()
+
+    # A long interval on purpose: if the port appears, it is because the MISS woke
+    # the resolver, not because a routine tick happened to come round.
+    resolver = TargetResolver(interval=5.0)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver did its first pass", _wait(lambda: resolver.rebuilds >= 1))
+        settled = resolver.rebuilds
+
+        table.ports[5002] = 200                 # the app opens a socket right now
+        check("the packet path says 'not mine' for now", 5002 not in targeting)
+        check("the miss woke the resolver",
+              _wait(lambda: resolver.rebuilds > settled))
+        check("and the new port is now targeted", _wait(lambda: 5002 in targeting))
+    finally:
+        resolver.stop()
+
+
+def test_stop_joins_the_thread_because_it_holds_os_handles():
+    targeting, _ = _targeting()
+    resolver = TargetResolver(interval=0.02)
+    resolver.retarget(targeting)
+    resolver.start()
+    check("the resolver is running", _wait(resolver.is_running))
+
+    resolver.stop()
+    check("stop() joined, it did not merely signal", not resolver.is_running())
+
+
+def test_retargeting_swaps_a_reference_instead_of_churning_threads():
+    """Applying settings repeatedly must not start and stop a thread each time."""
+    first, _ = _targeting("chrome")
+    second, _ = _targeting("firefox")
+    resolver = TargetResolver(interval=0.02)
+    resolver.start()
+    try:
+        thread = resolver._thread
+        for _ in range(20):
+            resolver.retarget(first)
+            resolver.retarget(second)
+            resolver.retarget(None)
+        check("forty retargets, still the same thread", resolver._thread is thread)
+        check("and it is still alive", resolver.is_running())
+    finally:
+        resolver.stop()
+
+
+def test_an_orphaned_targeting_stops_waking_the_resolver():
+    """A target that has been replaced must not keep poking the thread awake."""
+    old, _ = _targeting("chrome")
+    new, _ = _targeting("firefox")
+    resolver = TargetResolver(interval=5.0)
+    resolver.retarget(old)
+    resolver.retarget(new)
+
+    check("the replaced targeting was detached", old._on_miss is None)
+    check("the current one is attached", new._on_miss is not None)
+
+
+def test_a_failing_refresh_does_not_kill_the_resolver():
+    """A socket table that hiccups leaves the port set stale, not the session dead."""
+    class _Broken:
+        def refresh(self, *a, **k):
+            raise RuntimeError("socket table exploded")
+
+        def snapshot(self):
+            return {}
+
+        def name_of(self, pid):
+            return ""
+
+        def ancestors(self, pid, depth=8):
+            return []
+
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=_Broken())
+    resolver = TargetResolver(interval=0.02)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        time.sleep(0.15)
+        check("the resolver survived a broken table", resolver.is_running())
+    finally:
+        resolver.stop()
+
+
+# -- wired into the engine ----------------------------------------------------- #
+def test_the_capture_thread_never_touches_the_socket_table():
+    """The whole point, asserted end to end.
+
+    Runs a real session over synthetic traffic with targeting active, then checks
+    WHICH threads made the socket table look. The capture thread must not be
+    among them.
+    """
+    table = _CountingTable(ports={5001: 200}, info={200: ("chrome.exe", 1)})
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
+
+    engine = BeanEngine()
+    engine.set_target(True, targeting)
+    engine.start("true", divert=SyntheticDivert(seed=7))
+    try:
+        check("traffic flowed", _wait(lambda: engine.stats_snapshot()["seen"] > 200))
+        check("the resolver was doing the looking", table.refreshes > 0)
+    finally:
+        engine.stop()
+
+    capture_threads = {name for name in table.threads if "capture" in name.lower()}
+    check("no socket-table access from a capture thread",
+          not capture_threads, f"({sorted(table.threads)})")
+    check("the resolver thread stopped with the engine",
+          not engine.resolver().is_running())
+
+
+def test_stopping_the_engine_leaves_no_resolver_thread_behind():
+    before = {t.name for t in threading.enumerate()}
+    targeting, _ = _targeting()
+
+    engine = BeanEngine()
+    engine.set_target(True, targeting)
+    engine.start("true", divert=SyntheticDivert(seed=3))
+    time.sleep(0.05)
+    engine.stop()
+    time.sleep(0.2)
+
+    leaked = {t.name for t in threading.enumerate()} - before
+    check("no thread outlives the session", not leaked, f"({leaked})")
+
+
+def test_repeated_start_stop_cycles_do_not_stack_resolver_threads():
+    """The regression this rewrite also removes.
+
+    The GUI used to spawn a refresher thread on every start and never join it, so a
+    STOP followed by a START inside its 2 s sleep left the OLD thread looping as
+    well - one extra permanent scanner per fast restart cycle.
+    """
+    before = {t.name for t in threading.enumerate()}
+    targeting, _ = _targeting()
+    engine = BeanEngine()
+    engine.set_target(True, targeting)
+
+    for cycle in range(5):
+        engine.start("true", divert=SyntheticDivert(seed=cycle))
+        time.sleep(0.02)
+        engine.stop()
+
+    time.sleep(0.2)
+    leaked = {t.name for t in threading.enumerate()} - before
+    check("five start/stop cycles leave no thread behind", not leaked, f"({leaked})")

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -332,6 +332,44 @@ def test_the_capture_thread_never_touches_the_socket_table():
           not engine.resolver().is_running())
 
 
+def test_a_target_applied_mid_session_still_gets_a_live_port_set():
+    """Start broad, then narrow it down - and the port set must not freeze.
+
+    A regression this rewrite introduced and very nearly shipped: the resolver was
+    started only when a target already existed at ``start()``. Press START, watch
+    for a while, then type a process name - a completely ordinary workflow - and
+    nobody was left keeping the port set fresh. It froze at whatever the first
+    resolve produced, so sockets the target opened afterwards were never picked up.
+    That is exactly the failure live targeting was built to prevent.
+
+    The resolver's life is the SESSION's now, target or no target; with nothing to
+    resolve it blocks on its event and costs nothing.
+    """
+    table = _CountingTable(ports={5001: 200}, info={200: ("chrome.exe", 1),
+                                                    201: ("chrome.exe", 1)})
+    engine = BeanEngine()
+    engine._ports = table
+
+    engine.start("true", divert=SyntheticDivert(seed=13))       # no target yet
+    try:
+        check("the resolver runs even with nothing to resolve",
+              engine.resolver().is_running())
+
+        # the user narrows it down while the session is running
+        targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
+        engine.set_target(True, targeting)
+        targeting.refresh()                    # what apply_targeting(announce) does
+        check("the resolver is still up", engine.resolver().is_running())
+
+        # ...and the app opens a new socket, which is the whole point of a LIVE set
+        table.ports[6001] = 201
+        check("the new socket misses at first", 6001 not in targeting)
+        check("but the resolver picks it up", _wait(lambda: 6001 in targeting))
+    finally:
+        engine.stop()
+    check("and it stops with the session", not engine.resolver().is_running())
+
+
 def test_stopping_the_engine_leaves_no_resolver_thread_behind():
     before = {t.name for t in threading.enumerate()}
     targeting, _ = _targeting()

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -110,6 +110,69 @@ def test_stop_joins_the_thread_because_it_holds_os_handles():
     check("stop() joined, it did not merely signal", not resolver.is_running())
 
 
+def test_stop_never_waits_for_a_scan_in_flight():
+    """STOP is the control this tool may never make slow.
+
+    A resolve is not always cheap. Measured on a normal desktop: **1.7 seconds**
+    the first time (25 PIDs own sockets but the process-info cache holds 346 - the
+    expensive part is one full ``psutil.process_iter()``), against 1.4 ms once
+    warm. An earlier version of this joined with a 2 s timeout, so pressing STOP
+    while that scan was in flight blocked for 1.6 s - on the button the user
+    reaches for precisely because they have just broken their own network.
+
+    Not joining that is safe: ``stop()`` has already cleared the target and set the
+    stop flag, so a straggler finishes at most one more scan into an object nobody
+    reads any more, then exits. It is a daemon either way.
+    """
+    class _SlowTable:
+        def __init__(self, delay):
+            self.delay = delay
+            self.inside = threading.Event()
+
+        def refresh(self, now=None, force=False):
+            self.inside.set()
+            time.sleep(self.delay)
+            return True
+
+        def snapshot(self):
+            return {}
+
+        def name_of(self, pid):
+            return ""
+
+        def ancestors(self, pid, depth=8):
+            return []
+
+    slow = _SlowTable(3.0)               # far longer than any sane join timeout
+    targeting = ProcessTargeting(bnt.parse_target("app"), table=slow)
+    resolver = TargetResolver(interval=0.02, min_interval=0.0)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver is inside a scan", slow.inside.wait(timeout=5))
+
+        t0 = time.monotonic()
+        resolver.stop()
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        check("stop() did not wait for the scan", elapsed_ms < 900,
+              f"({elapsed_ms:.0f} ms)")
+    finally:
+        resolver.stop()
+        time.sleep(3.1)                  # let the straggler retire before we leave
+
+
+def test_stop_does_join_an_idle_resolver():
+    """The other half: the common case must still be clean, not merely fast."""
+    targeting, _ = _targeting()
+    resolver = TargetResolver(interval=5.0)
+    resolver.retarget(targeting)
+    resolver.start()
+    check("the resolver settled", _wait(lambda: resolver.rebuilds >= 1))
+
+    resolver.stop()
+    check("an idle resolver is joined, not abandoned", not resolver.is_running())
+
+
 def test_retargeting_swaps_a_reference_instead_of_churning_threads():
     """Applying settings repeatedly must not start and stop a thread each time."""
     first, _ = _targeting("chrome")

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -46,6 +46,19 @@ class _CountingTable:
     def ancestors(self, pid, depth=8):
         return []
 
+    # the engine's side of the PortTable surface (see _process_for / _pid_for)
+    def refresh_if_stale(self, now=None, miss=False):
+        return self.refresh(now=now, force=True)
+
+    def process_for_port(self, port, now=None, allow_refresh=True):
+        if allow_refresh:
+            self.refresh_if_stale(now, miss=True)
+        pid = self.ports.get(port)
+        return self.name_of(pid) if pid else ""
+
+    def pid_for(self, port):
+        return self.ports.get(port)
+
 
 def _targeting(expr="chrome", table=None):
     table = table if table is not None else _CountingTable(
@@ -290,11 +303,20 @@ def test_the_capture_thread_never_touches_the_socket_table():
     Runs a real session over synthetic traffic with targeting active, then checks
     WHICH threads made the socket table look. The capture thread must not be
     among them.
+
+    The table is injected into BOTH the targeting AND the engine on purpose. An
+    earlier version of this test gave the counting table only to the targeting and
+    left the engine on ``portmap.default_table()`` - so it watched an object the
+    capture thread never used, passed, and missed the fact that ``_log_conn`` ->
+    ``_process_for`` -> ``process_for_port`` was still rebuilding the real table
+    about sixteen times a second on that very thread. A live run caught what the
+    test could not; the test now watches what the engine actually uses.
     """
     table = _CountingTable(ports={5001: 200}, info={200: ("chrome.exe", 1)})
     targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
 
     engine = BeanEngine()
+    engine._ports = table                       # the table the capture thread reads
     engine.set_target(True, targeting)
     engine.start("true", divert=SyntheticDivert(seed=7))
     try:

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -153,6 +153,136 @@ def test_a_failing_refresh_does_not_kill_the_resolver():
         resolver.stop()
 
 
+def test_constant_misses_cannot_turn_into_a_continuous_scan():
+    """The floor, and why it is not optional.
+
+    Targeting narrows traffic to ONE application, so every packet from every other
+    application is a miss - misses arrive continuously, not occasionally. If a miss
+    simply woke the resolver, the wake would be re-armed as fast as it was consumed
+    and the socket table would be scanned without pause. Measured while this guard
+    was missing: 63 rebuilds a second against a 0.3 s routine tick, bounded only by
+    the GIL.
+    """
+    targeting, _ = _targeting()
+    targeting.refresh()
+
+    # routine tick far away, so anything that happens is miss-driven
+    resolver = TargetResolver(interval=5.0, min_interval=0.05)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver settled", _wait(lambda: resolver.rebuilds >= 1))
+        base = resolver.rebuilds
+
+        stop = threading.Event()
+
+        def storm():                      # unrelated traffic: a miss every time
+            while not stop.is_set():
+                9999 in targeting
+
+        noise = threading.Thread(target=storm, daemon=True)
+        noise.start()
+        time.sleep(0.6)
+        stop.set()
+        noise.join(timeout=2)
+
+        did = resolver.rebuilds - base
+        # 0.6 s at a 0.05 s floor allows about 12; anything approaching "continuous"
+        # is in the dozens-to-hundreds. The margin is deliberately generous - this
+        # asserts the ORDER of magnitude, not a stopwatch.
+        check("the rebuild rate stayed bounded by the floor", did <= 25,
+              f"({did} rebuilds in 0.6 s of constant misses)")
+    finally:
+        resolver.stop()
+
+
+# -- dynamic process trees ----------------------------------------------------- #
+class _TreeTable:
+    """A socket table whose process TREE can grow while the test runs."""
+
+    def __init__(self):
+        self.ports = {5001: 100}                    # the parent's own socket
+        self.info = {100: ("myapp.exe", 1)}         # pid -> (name, ppid)
+        self.refreshes = 0
+
+    def refresh(self, now=None, force=False):
+        self.refreshes += 1
+        return True
+
+    def snapshot(self):
+        return dict(self.ports)
+
+    def name_of(self, pid):
+        return self.info.get(pid, ("", None))[0]
+
+    def ancestors(self, pid, depth=8):
+        chain, current = [], self.info.get(pid, ("", None))[1]
+        while current and len(chain) < depth:
+            name, parent = self.info.get(current, ("", None))
+            chain.append((current, name))
+            current = parent
+        return chain
+
+
+def test_a_child_spawned_mid_session_starts_being_impaired():
+    """The targeted app spawns workers while the session runs - that is the norm.
+
+    A browser opens a network-service child; a game launcher spawns a downloader; a
+    test harness forks per case. Their sockets belong to the target as much as the
+    parent's, and they appear at a moment nobody can schedule for.
+    """
+    table = _TreeTable()
+    targeting = ProcessTargeting(bnt.parse_target("myapp"), table=table)
+    targeting.refresh()
+    check("only the parent's socket is targeted at first",
+          targeting.ports() == {5001}, f"({targeting.ports()})")
+
+    resolver = TargetResolver(interval=5.0, min_interval=0.02)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver settled", _wait(lambda: resolver.rebuilds >= 1))
+
+        # the app spawns a worker, which opens its own socket
+        table.info[200] = ("myapp-helper.exe", 100)
+        table.ports[7001] = 200
+        check("the child's FIRST packet slips through (the documented race)",
+              7001 not in targeting)
+        check("but the child is targeted moments later", _wait(lambda: 7001 in targeting))
+
+        # ...and a grandchild, two levels down
+        table.info[300] = ("renderer.exe", 200)
+        table.ports[7002] = 300
+        9999 in targeting                            # any packet re-arms the miss
+        check("a grandchild is targeted too", _wait(lambda: 7002 in targeting))
+
+        check("the whole tree is in scope", targeting.ports() == {5001, 7001, 7002},
+              f"({targeting.ports()})")
+    finally:
+        resolver.stop()
+
+
+def test_an_excluded_child_is_not_pulled_back_in_by_its_parent():
+    """`myapp, !myapp-helper` must keep excluding the helper as it respawns."""
+    table = _TreeTable()
+    targeting = ProcessTargeting(bnt.parse_target("myapp, !myapp-helper"), table=table)
+    resolver = TargetResolver(interval=5.0, min_interval=0.02)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver settled", _wait(lambda: resolver.rebuilds >= 1))
+        table.info[200] = ("myapp-helper.exe", 100)
+        table.ports[7001] = 200
+        9999 in targeting
+        check("a rebuild happened", _wait(lambda: resolver.rebuilds >= 2))
+        time.sleep(0.05)
+        check("the excluded child stays out despite its matching parent",
+              7001 not in targeting, f"({targeting.ports()})")
+        check("the parent itself is still targeted", 5001 in targeting)
+    finally:
+        resolver.stop()
+
+
 # -- wired into the engine ----------------------------------------------------- #
 def test_the_capture_thread_never_touches_the_socket_table():
     """The whole point, asserted end to end.


### PR DESCRIPTION
Resolving *which connections belong to the targeted process* used to happen **on the capture
thread, inside the core lock**. This branch moves it onto its own thread and closes everything
that turned up while proving it.

## The original problem

```
BeanCore.decide()                      <- capture thread, holds core._lock
 └ local_port not in target_ports
    └ ProcessTargeting.__contains__
       └ refresh()                     <- 4 iphlpapi calls + O(n) copy
          └ psutil.Process() per PID
             └ psutil.process_iter()   <- the expensive one
```

And it was the **normal** case, not an edge one: targeting exists to narrow traffic to one
application, so every packet from every *other* application is a miss - and a miss triggered the
rebuild. A steady ~20 Hz of syscalls in the packet path whenever a target was set.

A stalled capture thread is exactly what fail-open, the watchdog, the eviction move and the
table-sort move all exist to prevent: WinDivert keeps diverting into a queue nobody drains, so the
user loses connectivity while the UI still says "running". Targeting was the last place doing it.

CLI had it worse: it has no refresher at all, so `--target` relied **entirely** on the hot path.

## The shape

New `beantester/target_resolver.py`, deliberately the same shape as `scenario_runner.py`: a small
class owning one thread, lifecycle driven by `BeanEngine`. Two differences on purpose - it waits on
an `Event` (a miss lands in milliseconds, not at the next tick) and its life is the **session's**.

`__contains__` is now a frozenset lookup plus a plain bool. `Event.set()` takes a lock, so the
wake-up fires only on the FALSE->TRUE transition - waking per packet would have moved the problem,
not removed it.

The GUI's 2 s refresher thread is gone; `_tick` applies a changed expression and reads the verdict.

## Everything found while proving it

A green suite missed most of this. Each was found by reading the code or running it, and each is
now guarded.

| # | Finding | Evidence |
|---|---|---|
| 1 | **No floor under miss-driven rebuilds.** Removing `miss_interval` from `__contains__` put it nowhere. Misses arrive continuously, so the wake re-armed as fast as it was consumed | 63 rebuilds/s against a 0.3 s tick, bounded only by the GIL. Now 14/s |
| 2 | **A second scan path on the capture thread**: `_log_conn` -> `_process_for` -> `process_for_port` -> `refresh_if_stale`, for the connection log's process column | 47 rebuilds in 3 s from `Thread-1 (_capture_loop)`. Now 0 |
| 3 | **The end-to-end test watched the wrong object** - it gave a counting table to the targeting but left the engine on `default_table()`, so it passed vacuously | fixed; the fake grew the engine-side surface |
| 4 | **A target applied mid-session got a frozen port set.** The resolver started only if a target existed at `start()`. Press START, watch, then type a process - nobody kept the set fresh | the exact failure live targeting exists to prevent, reintroduced by the fix for it |
| 5 | **The watchdog's new refresh could cancel the memory work** - it sat first in the shared `try`, so a socket-table failure skipped `_trim_conns()` and `drain_retired()` | verified: `_trim_conns` still runs 6x in 1.5 s with an always-raising table |
| 6 | **A failed resolve left engine and core disagreeing** about what is being impaired | verified: all three now end on the same object |
| 7 | **`TargetResolver.stop()` signalled outside its lock** - a concurrent `start()` could have its thread killed on arrival | 200 lifecycle cycles + 300 start-after-stop pairs, clean |
| 8 | **Dead knobs** (`interval`, `miss_interval`, `_last`) still on `ProcessTargeting`, and a fake whose signature made a test exercise the wrong exception | removed / fixed |
| 9 | **STOP waited for a resolve.** A cold resolve is **1.7 seconds**; the join timeout was 2 s | STOP was 1647 ms. Now 252 ms with a 1.7 s scan in flight, 100 ms idle |

**The number worth keeping:** a cold resolve costs **1713 ms** (one full `process_iter()`; 25 PIDs
own sockets but the info cache ends up with 346), against **1.4 ms** warm. A thousandfold
difference that every fake in the suite hides, because fakes answer instantly.

## Verification

Beyond the suite - the suite is what missed most of the above:

- **A full GUI session, driven for the first time** (real engine, real resolver, synthetic traffic,
  real GUI code): resolver up for a targetless session, a non-matching target raises the banner, a
  matching one takes it down, clearing the field drops targeting, traffic never stalls, STOP under
  900 ms, no thread left behind. Pinned as
  `test_gui_state.py::test_a_gui_session_keeps_the_target_banner_honest`.
- **Process dynamics**, since a target is not a static thing: the process exits mid-session; it
  restarts under a new PID; a parent dies and its child is orphaned; a four-generation tree; 300
  short-lived children. All behave, and the port set stays bounded.
- **10 s live against the real socket table**: 9419 packets, 24 targeted ports, 159 rebuilds,
  STOP 98 ms, socket-table refreshes from `bean-target-resolver` (159) and `MainThread` (2) -
  **zero from a capture thread**.
- `pytest tests` 575 passed, `smoke_gui.py` OK, CLI exit codes 0 / 3 / 4 / 6.

## Docs

The rule that an exclusion-only expression also covers values it cannot evaluate was documented
for **ports** (`!53` catching ICMP) but never for **processes** - where it matters more.
"Unidentified" is rare for ports; for processes it is what every brand-new connection passes
through. So `!chrome` does not protect chrome's neighbours - it impairs them, and everything the
tool cannot name yet. Both READMEs now say to name the app you *do* want broken instead.

## Known, and next

**PID reuse (audit item P2) is confirmed and NOT fixed here.** Verified against the real port
table: a target that restarts onto a recycled PID is **not impaired**, and an innocent process that
inherits a PID the target used **is impaired**. It predates this branch, so nothing here makes it
worse - but it is the immediate next branch, and the reason it was deferred (the cost sat on the
capture thread) is exactly what this PR removes. Re-resolving all 25 socket-owning PIDs measures
124 ms, on the resolver thread, against a 300 ms tick.