### PR TITLE
fix(portmap): verify a pid is still the same process before trusting it

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,52 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### portmap: a PID is a number, not an identity (audit item P2)
+
+- **The `pid -> (name, ppid)` cache could not expire, by any route.** `_expire_info` returned
+  early below 512 entries (a normal machine holds 26-343, so it never ran), and `info()` bumped
+  the timestamp on every cache HIT - which made the entry of a busily-read PID immortal, i.e.
+  exactly the entry decisions rest on. Both reproduced against the real table: a target
+  restarting onto a recycled PID was **not impaired**, and an innocent process inheriting the
+  target's old PID **was**. The second is the serious one: this tool breaks networking, and
+  breaking an application the user never named is the worst thing it can do quietly.
+- **Fixed by verifying identity, not by guessing at ages.** Each entry now carries the process
+  START TIME (`create_time`), and every cache hit checks it. The analysis had rejected this as
+  "costs as much as re-resolving" - **that was wrong by three orders of magnitude**, and measuring
+  it is what found the right design:
+
+      create_time() for 2 PIDs : 0.01 ms      full re-resolve: 9.8 ms
+      create_time() for 8 PIDs : 0.03 ms      full re-resolve: 38.9 ms
+
+  `name()` is expensive because it must open the process and read its image path; `create_time()`
+  does not. On this machine it succeeds for **24/24** socket-owning PIDs, including the protected
+  ones that make `name()` fall back to a full `process_iter()`.
+- **"Cannot tell" is not "recycled".** Treating a missing start time as proof of reuse looked like
+  the safe reading and was in fact a way to destroy the cache wholesale on every fallback path:
+  each lookup evicted, re-resolved, failed to stamp, and evicted again, so process names came back
+  empty. Caught by the suite going red on the psutil fake. `_looks_recycled` now returns True only
+  when both stamps are known AND differ; unverifiable environments fall back to the TTL exactly as
+  before. Hardening must not degrade what it cannot harden.
+- Two cheaper mechanisms kept as backstops: the TTL now counts from INSERTION and runs
+  unconditionally (2.2 us a sweep, measured), and a PID that loses every socket is forgotten at
+  once (2.5 us, measured) - a PID can only be reissued after its owner exits, and exiting closes
+  its sockets.
+- **Honest cost:** a warm resolve goes from 1.4 ms to 2.96 ms, because a rebuild verifies every
+  socket-owning PID and every ancestor it walks. At the resolver's measured 17 rebuilds/s that is
+  ~5% of one core - on the RESOLVER thread; the capture thread is untouched, which is what the
+  previous chunk bought. If it ever matters, the cheaper shape is a single batch verification in
+  `PortTable.refresh()` (0.13 ms per rebuild) with ancestors left to the TTL; it was not taken
+  because it splits one mechanism into two for a background thread that is not short of time.
+- Verified beyond the suite: a **real** child process with a **real** socket resolves to
+  `python.exe` while alive and to `""` the moment it exits - no stale name survives. A 10 s live
+  session with targeting: 9020 packets, 171 rebuilds, 23 targeted ports, STOP 18 ms, no thread
+  left behind.
+- New tests in `tests/test_processes.py`, on a controllable `_World` (ports, processes, start
+  times): the restarted target is impaired, the innocent inheritor is not, a living process keeps
+  its entry (verifying must not become re-resolving), an unverifiable environment still resolves
+  names, expiry works below the old 512 threshold and a busily-read entry no longer renews itself,
+  and a PID that loses every socket is forgotten at once.
+
 ### BREAKING
 
 - **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,59 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### BREAKING
+
+- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
+  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
+  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
+  while `--help` advertised "force the GUI". On real WinDivert that meant
+  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
+  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
+  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
+  to stderr and stdout stays clean.
+- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
+  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
+  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
+  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
+  than widening it.
+- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
+  loss and getting zero without being told is the class of quiet lie this project removes), and
+  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
+  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
+  than declined.
+- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
+  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
+- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
+- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
+
+### The capture thread could still reach psutil - and the fix for that broke the process column
+
+Two findings from reviewing the PID-reuse diff, both verified by running them.
+
+- **Identity verification put a psutil call back on the capture thread.** `engine._process_for`
+  reads with `allow_refresh=False`, but that only gated the socket-table rebuild - the NAME lookup
+  underneath it went on to `info()`, which now verifies. Measured with a port table that actually
+  resolves: 12 `create_time()` calls from `Thread-1 (_capture_loop)`. Once per NEW FLOW rather
+  than per packet, so 3/s here - but this tool gets pointed at load generators and port scans,
+  where new flows arrive in thousands per second.
+- **Worse, the same hole predates this branch.** Checked against `master`: on a cache MISS the old
+  `info()` called `_psutil_process_info` from whatever thread asked, so the capture thread could
+  already trigger a resolve (~5 ms) and even a full `process_iter()` (~1.7 s). The previous chunk
+  stopped `process_for_port` from refreshing the socket table and left that path open.
+- Fixed with an explicit `cheap=True` mode on `info()` / `name_of()`, wired from
+  `process_for_port(allow_refresh=False)`: **answer from the cache or not at all.** Resolving a
+  name and verifying an identity are both psutil calls, and gating only one of them is what left
+  the packet path making the other. Re-measured warm and cold: zero psutil calls from the capture
+  thread in both.
+- **That fix then emptied the connection log's process column** - the regression is only visible
+  with no target set, which is most sessions: the capture thread no longer resolves, and the
+  resolver only fills the cache for PIDs it matches, so with no target nothing filled it at all.
+  Measured: 6 rows, 0 names. The column exists precisely because it used to read "?"; shipping
+  that back would have undone a fixed bug. `PortTable.warm_names()` now runs on the WATCHDOG next
+  to the socket-table refresh - cheap in the steady state (one identity check per PID, ~0.13 ms),
+  paying the real resolve once. Re-measured: 6 rows, 6 names, with and without targeting, and
+  still zero psutil from the capture thread.
+
 ### portmap: a PID is a number, not an identity (audit item P2)
 
 - **The `pid -> (name, ppid)` cache could not expire, by any route.** `_expire_info` returned
@@ -47,12 +100,26 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   unconditionally (2.2 us a sweep, measured), and a PID that loses every socket is forgotten at
   once (2.5 us, measured) - a PID can only be reissued after its owner exits, and exiting closes
   its sockets.
-- **Honest cost:** a warm resolve goes from 1.4 ms to 2.96 ms, because a rebuild verifies every
-  socket-owning PID and every ancestor it walks. At the resolver's measured 17 rebuilds/s that is
-  ~5% of one core - on the RESOLVER thread; the capture thread is untouched, which is what the
-  previous chunk bought. If it ever matters, the cheaper shape is a single batch verification in
-  `PortTable.refresh()` (0.13 ms per rebuild) with ancestors left to the TTL; it was not taken
-  because it splits one mechanism into two for a background thread that is not short of time.
+- **Cost, measured properly on a second pass.** The first figure recorded here (1.4 -> 2.96 ms,
+  ~5% of a core) was an AVERAGE polluted by a single outlier and roughly double the truth. Isolated
+  by stubbing `_psutil_created` and comparing medians over 40 runs each, with a control run to
+  confirm reproducibility:
+
+      with verification    1.29 ms   (control: 1.28 ms)
+      without              0.93 ms
+      delta                +0.35 ms  (+38%)
+
+  At the resolver's measured 17 rebuilds/s that is **22 ms/s, 2.2% of one core** - and 2.6% of the
+  0.05 s floor it has to fit inside. On the RESOLVER thread; the capture thread is untouched, which
+  is what the previous chunk bought. A batch verification in `PortTable.refresh()` would shave that
+  to ~0.2%, and is deliberately not taken: it splits one mechanism into two and leaves ancestors on
+  the TTL, to save two percent of a background thread that is not short of time.
+- Two more things checked rather than assumed. The 0.001 s tolerance in `_looks_recycled` is never
+  actually needed here - across 342 processes, `process_iter` and `Process.create_time()` agreed to
+  **0.000000000 s**, so there are no false "recycled" verdicts; the tolerance stays as defence on
+  platforms that are less exact. And PIDs that lose every socket and come back do exist (2 of them
+  oscillated 3-4 times in 10 s of observation), costing about 0.8 extra resolves a second - noise
+  against the numbers above.
 - Verified beyond the suite: a **real** child process with a **real** socket resolves to
   `python.exe` while alive and to `""` the moment it exits - no stale name survives. A 10 s live
   session with targeting: 9020 packets, 171 rebuilds, 23 targeted ports, STOP 18 ms, no thread
@@ -62,31 +129,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   its entry (verifying must not become re-resolving), an unverifiable environment still resolves
   names, expiry works below the old 512 threshold and a busily-read entry no longer renews itself,
   and a PID that loses every socket is forgotten at once.
-
-### BREAKING
-
-- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
-  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
-  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
-  while `--help` advertised "force the GUI". On real WinDivert that meant
-  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
-  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
-  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
-  to stderr and stdout stays clean.
-- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
-  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
-  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
-  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
-  than widening it.
-- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
-  loss and getting zero without being told is the class of quiet lie this project removes), and
-  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
-  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
-  than declined.
-- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
-  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
-- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
-- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
 ### STOP no longer waits for a resolve, and the number that explains why
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
+### Fixed
+
+- **Targeting could follow a process ID after the process was gone - and Windows hands those
+  numbers out again.** Two things went wrong once that happened, both silently. Restart the
+  application you are targeting and it could come back with a number the tool still remembered
+  under the old name, so **it was no longer impaired** - the run looked like the app coping when
+  really nothing was being done to it. And in the other direction, a completely different program
+  that happened to inherit the number **was impaired instead**, so an application you never named
+  had its network broken. The tool now checks that the process behind a number is still the same
+  one before it trusts what it remembers, and forgets a process the moment it closes its last
+  connection.
+
 ### BREAKING
 
 - **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
-### Fixed
-
-- **Targeting could follow a process ID after the process was gone - and Windows hands those
-  numbers out again.** Two things went wrong once that happened, both silently. Restart the
-  application you are targeting and it could come back with a number the tool still remembered
-  under the old name, so **it was no longer impaired** - the run looked like the app coping when
-  really nothing was being done to it. And in the other direction, a completely different program
-  that happened to inherit the number **was impaired instead**, so an application you never named
-  had its network broken. The tool now checks that the process behind a number is still the same
-  one before it trusts what it remembers, and forgets a process the moment it closes its last
-  connection.
-
 ### BREAKING
 
 - **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
@@ -48,6 +36,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Targeting could follow a process ID after the process was gone - and Windows hands those
+  numbers out again.** Two things went wrong once that happened, both silently. Restart the
+  application you are targeting and it could come back with a number the tool still remembered
+  under the old name, so **it was no longer impaired** - the run looked like the app coping when
+  really nothing was being done to it. And in the other direction, a completely different program
+  that happened to inherit the number **was impaired instead**, so an application you never named
+  had its network broken. The tool now checks that the process behind a number is still the same
+  one before it trusts what it remembers, and forgets a process the moment it closes its last
+  connection.
 - **`--doctor` could report a WinDivert driver as "not loaded" when it simply was not allowed
   to look.** Windows refuses full access to some services even for an Administrator, and the
   check treated that refusal as "the service is not there" - in the one command whose whole job

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -606,6 +606,12 @@ class BeanEngine:
             # failed. Different jobs, different failure domains.
             try:
                 self._ports.refresh_if_stale()
+                # ...and put the NAMES in the cache too, because the capture thread
+                # is only allowed to read it, never to fill it. Without this the
+                # connection log's process column is empty for every session that
+                # has no target set - which is most of them, and which is the exact
+                # bug the column was added to fix.
+                self._ports.warm_names()
             except Exception as _exc:
                 crashlog.note(_exc, "engine.ports")
             try:

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -245,10 +245,11 @@ def _psutil_created(pid):
     This is what tells a recycled PID from the process that used to own it, and it
     is the reason the cache can be trusted at all. Deliberately its OWN call rather
     than part of the full lookup: measured on Windows, ``create_time()`` costs
-    0.005 ms per PID (0.13 ms for every socket-owning PID on the machine, 0.2% of a
-    core at the resolver's rate), while ``name()`` costs 5 ms because it has to open
-    the process and read its image path. Verifying is a thousand times cheaper than
-    re-resolving, which is what makes checking on EVERY cache hit affordable.
+    ~0.005 ms per PID while ``name()`` costs ~5 ms, because only the latter has to
+    open the process and read its image path. Verifying is a thousand times cheaper
+    than re-resolving, which is what makes checking on EVERY cache hit affordable:
+    it adds 0.35 ms to a resolve that took 0.93 ms, i.e. 2.2% of a core at the
+    resolver's measured rate.
     """
     try:
         import psutil
@@ -283,7 +284,7 @@ class PortTable:
         self.clock = clock
         self._lock = threading.RLock()
         self._ports = {}                 # port -> pid
-        self._info = {}                  # pid -> (name, ppid, last_seen)
+        self._info = {}                  # pid -> (name, ppid, created, written_at)
         self._bulk_at = 0.0              # last full process_iter (fallback path)
         self._last = 0.0                 # last successful refresh
         self._native = _make_native()
@@ -370,8 +371,18 @@ class PortTable:
         self._info = {pid: entry for pid, entry in self._info.items()
                       if entry[3] > cutoff}
 
-    def info(self, pid):
+    def info(self, pid, cheap=False):
         """``(name, ppid)`` for a pid - cached, verified, never raises.
+
+        ``cheap=True`` means **never touch the OS from here**: answer from the cache
+        or not at all. That is the mode the CAPTURE THREAD uses, and it is not an
+        optimisation - it is the boundary the previous chunk established. Both the
+        identity check and the fall-back resolve are psutil calls, so leaving either
+        reachable from the packet path puts back exactly what was taken out of it.
+        The cost of being cheap is a connection-log row that may show a stale or
+        empty process name; ``_log_conn`` retries while packets keep coming, and the
+        name is display, not a decision. Targeting - which IS a decision - always
+        runs on the resolver thread and always verifies.
 
         Every cache hit is checked against the process's START TIME. A PID is only
         a number the OS hands out; the same number can belong to a different
@@ -392,7 +403,7 @@ class PortTable:
         with self._lock:
             entry = self._info.get(pid)
         if entry is not None:
-            if not _looks_recycled(_psutil_created(pid), entry[2]):
+            if cheap or not _looks_recycled(_psutil_created(pid), entry[2]):
                 # The timestamp is NOT bumped here. It marks when the entry was
                 # written, so the TTL means "this answer is at most N seconds old"
                 # rather than "nobody has asked lately". Bumping it made the entry
@@ -404,6 +415,11 @@ class PortTable:
             with self._lock:
                 if self._info.get(pid) is entry:
                     del self._info[pid]
+        if cheap:
+            # Nothing cached (or what was cached is provably wrong) and we may not
+            # ask the OS. "" is the honest answer; the resolver will have filled the
+            # cache by the time this row is looked at again.
+            return ("", None)
         resolved = _psutil_process_info(pid)
         if resolved is None:
             # psutil.Process is unavailable (or denied): fall back to one bulk
@@ -425,8 +441,25 @@ class PortTable:
             self._info[pid] = (resolved[0], resolved[1], resolved[2], now)
         return (resolved[0], resolved[1])
 
-    def name_of(self, pid):
-        return self.info(pid)[0]
+    def name_of(self, pid, cheap=False):
+        return self.info(pid, cheap=cheap)[0]
+
+    def warm_names(self):
+        """Resolve (and verify) the name of every PID that currently owns a socket.
+
+        Somebody on a background thread has to do this, because the capture thread
+        reads names CHEAPLY - cache or nothing - and would otherwise show an empty
+        process column. The resolver fills the cache for the PIDs it matches, but
+        only while a target is set; most sessions have none, and the connection
+        log's process column exists precisely so a tester can see who the traffic
+        belongs to before deciding what to target.
+
+        Cheap in the steady state: the names are already cached, so this is one
+        identity check per PID (~0.13 ms for the 25-odd PIDs a desktop has). The
+        first pass pays the real resolve (~124 ms) once.
+        """
+        for pid in set(self.snapshot().values()):
+            self.info(pid)
 
     def ancestors(self, pid, depth=8):
         """``[(pid, name), ...]`` from the parent upwards (bounded, cycle-safe)."""
@@ -448,7 +481,11 @@ class PortTable:
         if pid is None and allow_refresh:
             self.refresh_if_stale(now, miss=True)
             pid = self.pid_for(port)
-        return self.name_of(pid) if pid else ""
+        # allow_refresh=False means "do not touch the OS", and that has to cover the
+        # NAME lookup too - not just the socket-table rebuild. Resolving a name and
+        # verifying an identity are both psutil calls; gating only one of them left
+        # the packet path making the other.
+        return self.name_of(pid, cheap=not allow_refresh) if pid else ""
 
 
 _DEFAULT = None

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -200,30 +200,69 @@ def _psutil_port_pid_map():
 
 
 def _psutil_process_table():
-    """``{pid: (name, ppid)}`` for every process (the slow, portable path)."""
+    """``{pid: (name, ppid, created)}`` for every process (the slow, portable path)."""
     try:
         import psutil
     except Exception:
         return {}
     try:
         table = {}
-        for proc in psutil.process_iter(["pid", "name", "ppid"]):
+        for proc in psutil.process_iter(["pid", "name", "ppid", "create_time"]):
             info = getattr(proc, "info", None) or {}
             pid = info.get("pid")
             if pid is None:
                 continue
-            table[int(pid)] = (str(info.get("name") or ""), info.get("ppid"))
+            table[int(pid)] = (str(info.get("name") or ""), info.get("ppid"),
+                               info.get("create_time"))
         return table
     except Exception:
         return {}
 
 
+def _looks_recycled(current, cached):
+    """True only when we can PROVE the PID now belongs to a different process.
+
+    "Cannot tell" is not "recycled". If either start time is missing - psutil has
+    no ``Process`` here, the platform will not say, a bulk scan wrote the entry
+    without one - the honest answer is that the entry is unverifiable, and the
+    cache falls back to its TTL exactly as it did before. Treating unverifiable as
+    recycled looked tempting ("fail safe") and was in fact a way to destroy the
+    cache wholesale on every fallback path: every lookup would evict, re-resolve,
+    fail to stamp, and evict again, so process names came back empty. Hardening
+    must not degrade the environments it cannot harden.
+
+    The tolerance absorbs the last-bit difference between ``process_iter`` and
+    ``Process.create_time`` for the same process.
+    """
+    if current is None or cached is None:
+        return False
+    return abs(current - cached) >= 0.001
+
+
+def _psutil_created(pid):
+    """Start time of ``pid`` right now - the identity stamp. ``None`` if unknown.
+
+    This is what tells a recycled PID from the process that used to own it, and it
+    is the reason the cache can be trusted at all. Deliberately its OWN call rather
+    than part of the full lookup: measured on Windows, ``create_time()`` costs
+    0.005 ms per PID (0.13 ms for every socket-owning PID on the machine, 0.2% of a
+    core at the resolver's rate), while ``name()`` costs 5 ms because it has to open
+    the process and read its image path. Verifying is a thousand times cheaper than
+    re-resolving, which is what makes checking on EVERY cache hit affordable.
+    """
+    try:
+        import psutil
+        return psutil.Process(int(pid)).create_time()
+    except Exception:
+        return None
+
+
 def _psutil_process_info(pid):
-    """``(name, ppid)`` for one pid, or ``None`` when it cannot be resolved."""
+    """``(name, ppid, created)`` for one pid, or ``None`` when it cannot be resolved."""
     try:
         import psutil
         process = psutil.Process(int(pid))
-        return str(process.name() or ""), process.ppid()
+        return str(process.name() or ""), process.ppid(), process.create_time()
     except Exception:
         return None
 
@@ -271,8 +310,21 @@ class PortTable:
             if ports is None:
                 self._last = now                         # do not hammer a broken lookup
                 return False
+            # A PID that has just lost every socket is a PID whose process is
+            # probably gone - and a PID can only be handed to somebody else AFTER
+            # its owner exits. So this is the moment to forget its name, before the
+            # OS can hand the number to a process with a different one. It closes
+            # the dangerous window (impairing a process the user never targeted)
+            # from "the rest of the session" down to one refresh interval.
+            #
+            # Costs 2.5 us (measured): two set builds and a difference. The TTL
+            # above still backstops PIDs that never owned a socket - ancestors,
+            # and whatever a bulk scan swept in - which cannot be caught this way.
+            departed = set(self._ports.values()) - set(ports.values())
             self._ports = ports
             self._last = now
+            for pid in departed:
+                self._info.pop(pid, None)
             self._expire_info(now)
             return True
 
@@ -298,23 +350,60 @@ class PortTable:
 
     # -- process info ----------------------------------------------------------- #
     def _expire_info(self, now):
-        if len(self._info) < 512:
-            return
+        """Drop entries older than ``INFO_TTL_S``, counted from when they were WRITTEN.
+
+        There used to be a ``len(self._info) < 512`` early return, and on a normal
+        machine the cache holds 26-343 entries - so this never ran at all. Combined
+        with ``info()`` bumping the timestamp on every cache HIT, an entry that was
+        being read constantly could not expire by any route. A PID whose process had
+        died therefore kept the dead process's name for the life of the session.
+
+        That is not a cosmetic problem. Windows reuses PIDs, and the name is what
+        targeting matches on, so a stale entry means either the target restarting
+        onto a recycled PID is NOT impaired, or an innocent process that inherits
+        the target's old PID IS. Both were reproduced against the real table.
+
+        Measured cost of sweeping unconditionally: 2.2 us. There was never anything
+        to buy with that threshold.
+        """
         cutoff = now - INFO_TTL_S
         self._info = {pid: entry for pid, entry in self._info.items()
-                      if entry[2] > cutoff}
+                      if entry[3] > cutoff}
 
     def info(self, pid):
-        """``(name, ppid)`` for a pid - cached, never raises."""
+        """``(name, ppid)`` for a pid - cached, verified, never raises.
+
+        Every cache hit is checked against the process's START TIME. A PID is only
+        a number the OS hands out; the same number can belong to a different
+        process a second later, and targeting matches on the NAME, so trusting a
+        cached name means either the target restarting onto a recycled PID is not
+        impaired, or an innocent process that inherits the old PID is. Both were
+        reproduced against the real table before this check existed.
+
+        Checking is affordable because verifying is not resolving: ``create_time()``
+        costs 0.005 ms per PID, ``name()`` costs 5 ms (it must open the process and
+        read its image path). Verifying every socket-owning PID on this machine is
+        0.13 ms per rebuild - 0.2% of a core at the resolver's rate.
+        """
         if pid is None:
             return ("", None)
         pid = int(pid)
         now = self.clock()
         with self._lock:
             entry = self._info.get(pid)
-            if entry is not None:
-                self._info[pid] = (entry[0], entry[1], now)
+        if entry is not None:
+            if not _looks_recycled(_psutil_created(pid), entry[2]):
+                # The timestamp is NOT bumped here. It marks when the entry was
+                # written, so the TTL means "this answer is at most N seconds old"
+                # rather than "nobody has asked lately". Bumping it made the entry
+                # of a busily-read PID immortal - which is exactly the entry most
+                # worth re-checking, because it is the one decisions rest on.
                 return (entry[0], entry[1])
+            # Same number, PROVABLY a different process: the cached name is about
+            # somebody else. Drop it and resolve afresh.
+            with self._lock:
+                if self._info.get(pid) is entry:
+                    del self._info[pid]
         resolved = _psutil_process_info(pid)
         if resolved is None:
             # psutil.Process is unavailable (or denied): fall back to one bulk
@@ -325,16 +414,16 @@ class PortTable:
                 table = _psutil_process_table()
                 with self._lock:
                     self._bulk_at = now
-                    for other, (name, ppid) in table.items():
-                        self._info[other] = (name, ppid, now)
+                    for other, (name, ppid, created) in table.items():
+                        self._info[other] = (name, ppid, created, now)
                     entry = self._info.get(pid)
                 return (entry[0], entry[1]) if entry else ("", None)
             with self._lock:
                 entry = self._info.get(pid)
             return (entry[0], entry[1]) if entry else ("", None)
         with self._lock:
-            self._info[pid] = (resolved[0], resolved[1], now)
-        return resolved
+            self._info[pid] = (resolved[0], resolved[1], resolved[2], now)
+        return (resolved[0], resolved[1])
 
     def name_of(self, pid):
         return self.info(pid)[0]

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -472,3 +472,65 @@ def test_a_pid_that_loses_every_socket_is_forgotten_at_once(monkeypatch):
     table.refresh(force=True)
     check("the departed pid was forgotten", 8001 not in table._info)
     check("the surviving pid kept its entry", 8000 in table._info)
+
+
+def test_the_capture_thread_never_reaches_psutil_for_a_name(monkeypatch):
+    """`allow_refresh=False` must mean "do not touch the OS", NAME lookup included.
+
+    Two separate leaks lived here. Verifying an identity is a psutil call, so
+    adding the reuse check put one back on the packet path (12 of them across a
+    short run, once per new flow - and this tool gets pointed at load generators,
+    where new flows arrive in thousands per second). And on a cache MISS the older
+    code resolved from whatever thread asked, so the capture thread could trigger a
+    5 ms lookup or even a 1.7 s `process_iter()`. Gating the socket-table rebuild
+    alone left both open.
+    """
+    from beantester import portmap
+    touched = []
+    monkeypatch.setattr(portmap, "_psutil_created",
+                        lambda pid: touched.append("verify"))
+    monkeypatch.setattr(portmap, "_psutil_process_info",
+                        lambda pid: touched.append("resolve"))
+    monkeypatch.setattr(portmap, "_psutil_process_table",
+                        lambda: touched.append("bulk") or {})
+
+    table = portmap.PortTable()
+    table._native = None
+    table._info = {4242: ("app.exe", 1, 1000.0, time.monotonic())}
+    table._ports = {5555: 4242}
+
+    check("a cached name comes back", table.name_of(4242, cheap=True) == "app.exe")
+    check("...without asking the OS", touched == [], f"({touched})")
+
+    table._info.clear()
+    check("an uncached name is blank rather than resolved",
+          table.name_of(4242, cheap=True) == "")
+    check("...still without asking the OS", touched == [], f"({touched})")
+
+    # and the verified path, which runs on the resolver, DOES ask
+    table._info = {4242: ("app.exe", 1, 1000.0, time.monotonic())}
+    table.name_of(4242)
+    check("the verified path checks identity", touched == ["verify"], f"({touched})")
+
+
+def test_names_are_warmed_for_the_connection_log_without_a_target(monkeypatch):
+    """The capture thread may only READ the name cache, so somebody must fill it.
+
+    The resolver fills it for the PIDs it matches - but only while a target is set,
+    and most sessions have none. Without this the connection log's process column
+    came back empty, which is the exact bug the column was added to fix.
+    """
+    world = _World()
+    table = world.install(monkeypatch)
+    world.procs[8100] = ("app.exe", 1); world.created[8100] = 1000.0
+    world.ports[9100] = 8100
+    table.refresh(force=True)
+
+    check("nothing is cached until somebody warms it", 8100 not in table._info)
+    check("and a cheap read is honest about that",
+          table.name_of(8100, cheap=True) == "")
+
+    table.warm_names()
+    check("warming resolves every socket-owning pid", table._info.get(8100) is not None)
+    check("so the capture thread's cheap read now answers",
+          table.name_of(8100, cheap=True) == "app.exe")

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -3,6 +3,7 @@
 psutil is faked, so the tests run anywhere (the real lookup needs a live system).
 """
 import sys
+import time
 import types
 
 import pytest
@@ -308,3 +309,166 @@ def test_engine_records_a_broken_port_table_instead_of_going_quiet(monkeypatch):
     check("both failures were recorded", len(recorded) == 2, f"({recorded})")
     check("recorded as hot-path, so they cost one traceback each",
           all(kw.get("source") == "hot-path" for kw in recorded), f"({recorded})")
+
+
+# -- PID reuse: a pid is a number the OS hands out, not an identity ---------- #
+#
+# Windows recycles PIDs, and targeting matches on the process NAME, so a cached
+# name that outlives its process is not a cosmetic problem. Both directions were
+# reproduced against the real port table before these guards existed:
+#   * the target restarts onto a recycled pid  -> it is NOT impaired
+#   * an innocent process inherits the old pid -> it IS impaired
+# The second one matters most: this tool breaks networking, and breaking an
+# application the user never named is the worst thing it can do quietly.
+
+
+class _World:
+    """A controllable OS: ports, processes, and each process's start time."""
+
+    def __init__(self):
+        self.ports = {}          # port -> pid
+        self.procs = {}          # pid  -> (name, ppid)
+        self.created = {}        # pid  -> start time (absent = "cannot tell")
+
+    def install(self, monkeypatch):
+        from beantester import portmap
+        monkeypatch.setattr(portmap, "_psutil_port_pid_map", lambda: dict(self.ports))
+        monkeypatch.setattr(portmap, "_psutil_created",
+                            lambda pid: self.created.get(int(pid)))
+        monkeypatch.setattr(portmap, "_psutil_process_info", lambda pid: (
+            (self.procs[int(pid)][0], self.procs[int(pid)][1], self.created.get(int(pid)))
+            if int(pid) in self.procs else None))
+        monkeypatch.setattr(portmap, "_psutil_process_table", lambda: {
+            p: (n, pp, self.created.get(p)) for p, (n, pp) in self.procs.items()})
+        table = portmap.PortTable()
+        table._native = None
+        return table
+
+
+def _targeting_on(table, expr="myapp"):
+    from beantester.targeting import ProcessTargeting
+    return ProcessTargeting(parse_target(expr), table=table)
+
+
+def test_a_target_restarting_onto_a_recycled_pid_is_still_impaired(monkeypatch):
+    world = _World()
+    table = world.install(monkeypatch)
+    targeting = _targeting_on(table)
+
+    world.procs[5000] = ("oldapp.exe", 1); world.created[5000] = 1000.0
+    world.ports[9001] = 5000
+    targeting.refresh()
+    check("an unrelated process is not targeted", targeting.ports() == set(),
+          f"({targeting.ports()})")
+
+    # same pid number, different process: the target has restarted into it
+    world.procs[5000] = ("myapp.exe", 1); world.created[5000] = 2000.0
+    world.ports.clear(); world.ports[9002] = 5000
+    targeting.refresh()
+    check("the tool sees the new name", table.name_of(5000) == "myapp.exe",
+          f"({table.name_of(5000)!r})")
+    check("the restarted target IS impaired", 9002 in targeting.ports(),
+          f"({sorted(targeting.ports())})")
+
+
+def test_an_innocent_process_inheriting_the_pid_is_not_impaired(monkeypatch):
+    world = _World()
+    table = world.install(monkeypatch)
+    targeting = _targeting_on(table)
+
+    world.procs[6000] = ("myapp.exe", 1); world.created[6000] = 1000.0
+    world.ports[9003] = 6000
+    targeting.refresh()
+    check("the target is impaired while it lives", 9003 in targeting.ports())
+
+    world.procs[6000] = ("innocent.exe", 1); world.created[6000] = 2000.0
+    world.ports.clear(); world.ports[9004] = 6000
+    targeting.refresh()
+    check("the tool sees the new name", table.name_of(6000) == "innocent.exe",
+          f"({table.name_of(6000)!r})")
+    check("a process the user never named is NOT impaired",
+          9004 not in targeting.ports(), f"({sorted(targeting.ports())})")
+
+
+def test_a_living_process_keeps_its_cached_entry(monkeypatch):
+    """The other direction: verifying must not turn into re-resolving."""
+    world = _World()
+    table = world.install(monkeypatch)
+    targeting = _targeting_on(table)
+    world.procs[7000] = ("myapp.exe", 1); world.created[7000] = 1000.0
+    world.ports[9005] = 7000
+    targeting.refresh()
+
+    entries = len(table._info)
+    for _ in range(30):
+        table.name_of(7000)
+    check("the entry survives repeated reads", table._info.get(7000) is not None)
+    check("and the cache does not churn", len(table._info) == entries,
+          f"({len(table._info)} vs {entries})")
+
+
+def test_an_unverifiable_environment_still_resolves_names(monkeypatch):
+    """No start times available (the psutil fallback) must DEGRADE, not break.
+
+    Treating "cannot tell" as "recycled" looked like the safe reading and was in
+    fact a way to destroy the cache wholesale: every lookup would evict,
+    re-resolve, fail to stamp, and evict again, so process names came back empty.
+    Hardening must not degrade the environments it cannot harden - there, the TTL
+    remains the only bound, exactly as before.
+    """
+    world = _World()
+    table = world.install(monkeypatch)
+    targeting = _targeting_on(table)
+    world.procs[7100] = ("myapp.exe", 1)          # note: no start time at all
+    world.ports[9006] = 7100
+    targeting.refresh()
+
+    check("names still resolve", table.name_of(7100) == "myapp.exe",
+          f"({table.name_of(7100)!r})")
+    check("the target is still impaired", 9006 in targeting.ports())
+    for _ in range(50):
+        table.name_of(7100)
+    check("an unverifiable entry is kept, not evicted on every read",
+          table._info.get(7100) is not None)
+
+
+def test_the_info_cache_expires_below_the_old_512_threshold(monkeypatch):
+    """`_expire_info` used to bail out under 512 entries - so on a normal machine
+    (26-343) it never ran at all, and `info()` bumped the timestamp on every HIT,
+    which made a busily-read entry immortal."""
+    from beantester import portmap
+    world = _World()
+    table = world.install(monkeypatch)
+    world.procs[7200] = ("myapp.exe", 1); world.created[7200] = 1000.0
+    world.ports[9007] = 7200
+    table.refresh(force=True)
+    table.name_of(7200)
+    stamp = table._info[7200][3]
+    for _ in range(20):
+        table.name_of(7200)
+    check("a busily-read entry does not renew its own timestamp",
+          table._info[7200][3] == stamp)
+
+    monkeypatch.setattr(portmap, "INFO_TTL_S", 0.05)
+    time.sleep(0.08)
+    table.refresh(force=True)
+    check("stale entries are swept even with a tiny cache",
+          7200 not in table._info, f"({len(table._info)} entries)")
+
+
+def test_a_pid_that_loses_every_socket_is_forgotten_at_once(monkeypatch):
+    """A pid can only be handed to somebody else after its owner exits, and exiting
+    closes its sockets - so this is the moment to forget the name, before the OS
+    can reissue the number."""
+    world = _World()
+    table = world.install(monkeypatch)
+    world.procs[8000] = ("myapp.exe", 1); world.created[8000] = 1000.0
+    world.procs[8001] = ("other.exe", 1); world.created[8001] = 1000.0
+    world.ports[9008] = 8000; world.ports[9009] = 8001
+    table.refresh(force=True)
+    table.name_of(8000); table.name_of(8001)
+
+    del world.ports[9009]                      # 8001 exits; 8000 keeps its socket
+    table.refresh(force=True)
+    check("the departed pid was forgotten", 8001 not in table._info)
+    check("the surviving pid kept its entry", 8000 in table._info)


### PR DESCRIPTION
A PID is a number the operating system hands out, not an identity. Targeting matches on the
process **name**, and the `pid -> (name, ppid)` cache could not expire by any route - so a name
could outlive the process it belonged to for the rest of the session.

## The defect, reproduced against the real port table

`_expire_info` returned early below 512 entries (a normal machine holds 26-343, so it never ran),
and `info()` bumped the timestamp on every cache **hit** - which made the entry of a busily-read
PID immortal. That is exactly the entry decisions rest on.

Both directions were reproduced, not theorised:

| scenario | before |
|---|---|
| The target restarts and lands on a recycled PID | **not impaired** - the run looks like the application coping when nothing is being done to it |
| An innocent process inherits the PID the target used | **impaired** - a program the user never named has its network broken |

The second one is the serious one. This tool breaks networking, and breaking an application
nobody asked it to break is the worst thing it can do quietly.

## The fix, and the measurement that found it

The analysis for this branch rejected `create_time()` verification as "costs as much as
re-resolving". **That was wrong by three orders of magnitude**, and measuring is what found the
right design:

```
create_time() for 2 pids : 0.01 ms      full re-resolve: 9.8 ms
create_time() for 8 pids : 0.03 ms      full re-resolve: 38.9 ms
```

`name()` is expensive because it must open the process and read its image path. `create_time()`
does not, and it succeeds for **24/24** socket-owning PIDs here - including the protected ones
that make `name()` fall back to a full `process_iter()`.

So every cache hit now verifies the process start time. Two cheaper mechanisms back it up: the
TTL counts from **insertion** and runs unconditionally (2.2 us a sweep), and a PID that loses
every socket is forgotten at once (2.5 us) - a PID can only be reissued after its owner exits,
and exiting closes its sockets.

## "Cannot tell" is not "recycled"

Treating a missing start time as proof of reuse looked like the safe reading. It was in fact a way
to destroy the cache wholesale on every fallback path: each lookup evicted, re-resolved, failed to
stamp, and evicted again, so process names came back empty. **The suite caught this** by going red
on the psutil fake.

`_looks_recycled` now returns True only when both stamps are known **and** differ. Environments
that cannot be verified fall back to the TTL exactly as before: hardening must not degrade what it
cannot harden.

## Two more found by reviewing the diff

Both verified by running them.

**Verification put a psutil call back on the capture thread.** `engine._process_for` reads with
`allow_refresh=False`, but that only gated the socket-table rebuild - the name lookup underneath
went on to `info()`, which now verifies. Measured with a port table that actually resolves: 12
`create_time()` calls from `Thread-1 (_capture_loop)`. Once per **new flow**, so 3/s in that test,
but this tool gets pointed at load generators and port scans where new flows arrive in thousands
per second.

**And the same hole predates this branch.** Checked against `master`: on a cache **miss** the old
`info()` resolved from whatever thread asked, so the capture thread could already trigger a 5 ms
lookup or a 1.7 s `process_iter()`. The previous PR stopped `process_for_port` from refreshing the
socket table and left that path open. Fixed with an explicit `cheap=True` mode - answer from the
cache or not at all - because resolving a name and verifying an identity are both psutil calls,
and gating only one of them is what left the packet path making the other.

**That fix then emptied the connection log's process column**, visible only with no target set -
which is most sessions. The capture thread no longer resolves, and the resolver fills the cache
only for the PIDs it matches. Measured: 6 rows, 0 names. That column exists precisely because it
used to read "?". `PortTable.warm_names()` now runs on the **watchdog** next to the socket-table
refresh: cheap in the steady state (one identity check per PID, ~0.13 ms), paying the real resolve
once. Re-measured: 6 rows, 6 names with and without targeting, and still zero psutil from the
capture thread.

## Cost, and a correction

An earlier commit in this branch recorded "1.4 -> 2.96 ms, ~5% of a core". That was an average
polluted by a single outlier and roughly double the truth. Isolated by stubbing `_psutil_created`
and comparing medians over 40 runs each, with a control run:

```
with verification    1.29 ms   (control: 1.28 ms)
without              0.93 ms
delta                +0.35 ms  (+38%)
```

At the resolver's measured 17 rebuilds/s that is **22 ms/s, 2.2% of one core** - and 2.6% of the
0.05 s floor it has to fit inside. On the resolver thread; the capture thread is untouched, which
is what the previous PR bought. A batch verification in `PortTable.refresh()` would shave it to
~0.2% and is deliberately not taken: it splits one mechanism into two and leaves ancestors on the
TTL, to save two percent of a background thread that is not short of time.

Two more things checked rather than assumed. The 0.001 s tolerance in `_looks_recycled` is never
actually needed here - across 342 processes, `process_iter` and `Process.create_time()` agreed to
**0.000000000 s** - so it stays only as defence on platforms that are less exact. And PIDs that
lose every socket and come back do exist (2 of them oscillated 3-4 times in 10 s), costing about
0.8 extra resolves a second: noise.

## Verification

- A **real** child process with a **real** socket resolves to `python.exe` while alive and to `""`
  the moment it exits. No stale name survives.
- A 10 s live session with targeting: 9020 packets, 171 rebuilds