### PR TITLE
fix(engine): release the divert before anything that can block

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,59 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### stop() releases the divert before anything that can block
+
+CI caught `test_failsafe.py::test_engine_stops_itself_when_the_duration_elapses` failing on
+master. Not a flake to silence: measured, it failed **10 runs out of 30**, and the cause was a
+real ordering problem in the stop path.
+
+`stop()` sets `_running = False` first, which it must - `_capture_loop` runs `while self._running`
+and that flag is how it ends. But the divert was closed sixteen lines further down, after
+`stop_scenario()`, `_resolver.stop()`, `log_event()` and `notify_all()`. Between those two points
+the capture thread is already gone and the divert is still open, so WinDivert keeps diverting into
+a queue nobody drains - the exact failure FAIL-OPEN exists to prevent (convention 20). It is
+invisible on a synthetic divert, whose `recv()` blocks until close, and real on the live one,
+whose `recv()` returns immediately under traffic.
+
+The window was not theoretical. `_resolver.stop()` joins with a 0.25 s timeout and a resolve in
+flight uses it: an earlier session measured STOP at 252 ms with a scan running against ~100 ms
+idle, and recorded that as STOP latency. It was also a quarter of a second of the user's packets
+queued into a void.
+
+Measured here with a divert whose `recv()` returns immediately and a 200 ms resolver join - time
+the divert stayed OPEN after the capture thread had left:
+
+| | before | after |
+|---|---|---|
+| idle resolver | +0.04 ms | -0.36 ms |
+| resolver mid-scan (200 ms join) | **+200.06 ms** | -0.40 ms |
+
+Negative means the divert was closed before the capture thread finished leaving, which is the
+point - closing it is what ends that thread.
+
+- `engine.stop()`: the `_divert.close()` block moves up, directly after the stop bookkeeping and
+  ahead of `stop_scenario()` / `_resolver.stop()` / `log_event()`.
+- It deliberately does NOT move above `self._running = False`. Checked: `recv()` would then raise
+  while the session still looked live, so `_capture_loop` would take the `_fail_stop` path and
+  report a fault for an ordinary stop - which would also break `test_concurrency_chaos`'s
+  `engine.fault is None`. A microscopic window is unavoidable; the point is that no join sits
+  inside it.
+
+Two changes on the test side:
+
+- `test_engine_stops_itself_when_the_duration_elapses` stopped treating `not is_running()` as
+  "stop() has finished". It is not: the flag drops at the top of `stop()` and every promise (the
+  divert closed, the STOP event logged, the workers joined) lands afterwards, so waiting on the
+  flag and asserting a post-condition in the next statement is a race by construction. The test
+  now waits for the post-conditions themselves. Worth recording: reordering the close alone did
+  NOT make it green - the failure simply MOVED to the STOP-event assertion, which is how the
+  wider problem surfaced.
+- New `test_stop_releases_the_divert_before_anything_that_can_block` asserts the ORDER (close
+  before the resolver join) rather than elapsed time, so it cannot flake. Verified by mutation:
+  with the production change reverted it fails with `['resolver.stop', 'divert.close']`.
+
+Verified: `tests/test_failsafe.py` run 40 times consecutively, 0 failures (10/30 before).
+
 ### Property tests for the decision pipeline (audit item #9)
 
 `BeanCore.decide()` is a twelve-step pipeline over twenty-odd interacting fields, and every test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Ending a session now hands your network back at once, instead of a moment later.** When a run
+  finished - whether you pressed STOP or its time ran out - the tool stopped looking at packets
+  immediately, but kept its grip on your network traffic for a moment longer while it tidied up
+  after itself. In that moment Windows was still handing packets to something that was no longer
+  reading them, so a connection or two could stall right at the end of a run. The moment was
+  usually far too short to notice; if the tool happened to be busy working out which process you
+  were targeting, it stretched to about a quarter of a second. Your traffic is now let go first,
+  and the tidying up happens afterwards.
 - **Targeting could follow a process ID after the process was gone - and Windows hands those
   numbers out again.** Two things went wrong once that happened, both silently. Restart the
   application you are targeting and it could come back with a number the tool still remembered

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -539,6 +539,29 @@ class BeanEngine:
             self._stop_mono = time.monotonic()
             self._stop_wall = time.time()
             self.stop_reason = reason
+            # FIRST, before anything that can block. Closing the divert unblocks a
+            # capture thread stuck in recv() AND releases the WinDivert driver
+            # (which otherwise keeps its .sys file locked - see driver.py).
+            #
+            # The order matters because ``_capture_loop`` runs ``while self._running``:
+            # the line above has already ended it, so from this point NOTHING is
+            # draining the divert while WinDivert keeps diverting into it. Every step
+            # that used to sit in between can block - ``_resolver.stop()`` joins with
+            # a 0.25 s timeout and a resolve in flight really does use it (measured:
+            # STOP took 252 ms with a scan running, against ~100 ms idle). That was up
+            # to a quarter of a second of the user's packets queued into a void, which
+            # is the exact failure FAIL-OPEN exists to prevent (convention 20). It is
+            # invisible on a synthetic divert, whose recv() blocks, and shows up on the
+            # real one, whose recv() returns immediately under traffic.
+            #
+            # It must NOT move above ``self._running = False``: recv() would then raise
+            # while the session still looked live, so ``_capture_loop`` would take the
+            # ``_fail_stop`` path and report a fault for an ordinary stop.
+            if self._divert is not None:
+                try:
+                    self._divert.close()
+                except Exception as _exc:
+                    crashlog.note(_exc, "engine")
             self.stop_scenario()
             # Joins: the resolver holds OS handles and must stop touching them when
             # the session does, not "eventually".
@@ -546,14 +569,6 @@ class BeanEngine:
             self.log_event("STOP", self.EVENT_BY_REASON.get(reason, "events.stopped"))
             with self._cv:
                 self._cv.notify_all()
-            # closing the divert unblocks a capture thread stuck in recv() AND
-            # releases the WinDivert driver (which otherwise keeps its .sys file
-            # locked - see beantester/driver.py)
-            if self._divert is not None:
-                try:
-                    self._divert.close()
-                except Exception as _exc:
-                    crashlog.note(_exc, "engine")
             # join the worker threads before releasing self._divert: they read the
             # attribute live, so a quick stop->start would otherwise leave an old
             # capture thread consuming packets from the NEW session's divert

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -97,13 +97,73 @@ def test_engine_stops_itself_when_the_duration_elapses():
     check("duration: time_left counts down", 0 < eng.time_left() <= 0.3 + 0.05,
           f"({eng.time_left()})")
 
-    check("duration: the engine stops itself", _wait_until(lambda: not eng.is_running()))
+    # ``is_running()`` goes False at the TOP of stop(), because ``_capture_loop``
+    # runs ``while self._running`` and has to end there. Everything stop()
+    # PROMISES - the divert closed, the STOP event logged, the workers joined -
+    # happens after it. So waiting on the flag and asserting a post-condition in
+    # the next statement is a race, and not a rare one: measured at 10 failures in
+    # 30 runs, which is what CI caught. Wait for the promise, not for the flag.
+    def stopped_completely():
+        kinds = [(e[2], e[3]) for e in eng.events_snapshot()]
+        return (not eng.is_running() and divert.closed
+                and ("STOP", "events.duration_reached") in kinds)
+
+    check("duration: the engine stops itself", _wait_until(stopped_completely),
+          f"(running={eng.is_running()}, closed={divert.closed}, "
+          f"events={[(e[2], e[3]) for e in eng.events_snapshot()]})")
     check("duration: the reason is recorded", eng.stop_reason == "duration",
           f"({eng.stop_reason})")
     check("duration: the divert is released", divert.closed is True)
     kinds = [(e[2], e[3]) for e in eng.events_snapshot()]
     check("duration: the event log says why",
           ("STOP", "events.duration_reached") in kinds, f"({kinds})")
+
+
+def test_stop_releases_the_divert_before_anything_that_can_block():
+    """Nothing drains the divert between ``_running = False`` and ``close()``.
+
+    ``_capture_loop`` runs ``while self._running``, so the flag going down IS the
+    end of draining: under a real WinDivert, whose ``recv()`` returns immediately
+    under traffic, the thread is gone within microseconds. Everything stop() does
+    after that leaves the divert OPEN while WinDivert keeps diverting into it -
+    and the steps in between can block. ``_resolver.stop()`` joins with a 0.25 s
+    timeout and a resolve in flight really uses it (measured in an earlier
+    session: STOP took 252 ms with a scan running, against ~100 ms idle).
+
+    Measured with a divert whose ``recv()`` returns immediately and a 200 ms
+    resolver join: the divert used to stay open and undrained for 200.06 ms after
+    the capture thread had left. It now closes BEFORE that thread finishes
+    leaving, which is the point - closing is what ends it.
+
+    Asserted as ORDER rather than as elapsed time, so it cannot flake.
+    """
+    eng = BeanEngine()
+    divert = QuietDivert()
+    order = []
+
+    real_close = divert.close
+
+    def close():
+        order.append("divert.close")
+        real_close()
+
+    divert.close = close
+
+    real_resolver_stop = eng._resolver.stop
+
+    def resolver_stop(*a, **kw):
+        order.append("resolver.stop")
+        return real_resolver_stop(*a, **kw)
+
+    eng._resolver.stop = resolver_stop
+
+    eng.start("test", divert=divert)
+    eng.stop()
+
+    check("stop() closed the divert", "divert.close" in order, f"({order})")
+    check("stop() stopped the resolver", "resolver.stop" in order, f"({order})")
+    check("the divert is released BEFORE the blocking joins",
+          order.index("divert.close") < order.index("resolver.stop"), f"({order})")
 
 
 def test_no_duration_means_no_deadline():


### PR DESCRIPTION
stop() sets _running = False first, which it must: _capture_loop runs `while self._running` and that flag is how it ends. But the divert was closed sixteen lines later, after stop_scenario(), _resolver.stop(), log_event() and notify_all(). Between those two points the capture thread is already gone and the divert is still open, so WinDivert keeps diverting into a queue nobody drains - the exact failure FAIL-OPEN exists to prevent (convention 20).

The window was not theoretical. _resolver.stop() joins with a 0.25 s timeout and a resolve in flight uses it; an earlier session measured STOP at 252 ms with a scan running against ~100 ms idle, and recorded that as STOP latency. It was also a quarter of a second of the user's packets queued into a void.

Measured with a divert whose recv() returns immediately, and a 200 ms resolver join - time the divert stayed OPEN after the capture thread had left:

  idle resolver                 +0.04 ms   ->  -0.36 ms
  resolver mid-scan (200 ms)  +200.06 ms   ->  -0.40 ms

Negative means it was closed before the capture thread finished leaving, which is the point: closing it is what ends that thread.

The close deliberately does NOT move above `self._running = False`. recv() would then raise while the session still looked live, so _capture_loop would take the _fail_stop path and report a fault for an ordinary stop.

Found by CI, which failed test_engine_stops_itself_when_the_duration_elapses on master. Measured at 10 failures in 30 runs, so not a flake to silence. That test also stopped treating a False is_running() as "stop() has finished" - it is not, and reordering the close alone did not make it green: the failure MOVED to the STOP-event assertion, which is how the wider problem surfaced. The new test_stop_releases_the_divert_before_anything_that_can_block asserts the ORDER rather than elapsed time, so it cannot flake, and was verified by reverting the production change.

Verified: tests/test_failsafe.py 40 consecutive runs plus 12 more under coverage, 0 failures. Full suite green.
