### PR TITLE
test(chaos): full-stack concurrency - engine, model worker and the UI tick

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,49 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### The model worker meets a live engine (audit item #11, part 1)
+
+`test_concurrency_chaos.py` was engine-only, and the seven `AsyncModel` tests all feed the worker
+a fake `build`. Nothing put the two together - which matters because `ConnectionsPage.refresh()`
+hands the worker **the engine itself**, not a snapshot of it (a snapshot is ~70 ms at half a
+million rows, most of what moving the sort off the UI thread bought back). So `_build_model` calls
+`connections_snapshot()` on the worker thread, and that returns `list(self._conns.values())`:
+the outer list is a copy taken under the lock, but every row in it is the live dict the capture
+thread keeps updating. `model_worker.py` asserts in prose that this is safe. Nothing checked it.
+
+New `test_the_model_worker_survives_a_live_connection_table` runs the real pipeline - snapshot,
+filter, sort, totals, scope - on the real `AsyncModel` against a real engine under load, while
+settings and targeting churn underneath.
+
+**The traffic had to be built for it, and the reason is measured.** `SyntheticDivert` sleeps once
+per packet, and Windows timer granularity turns that into a ceiling: it delivers **~1900
+packets/s whatever `gen_kbps` says** (2000 kbps and 1 Gbps both land there), over a flow space of
+three local ports against three hard-coded remote addresses - so the connection table stops at
+**12 rows** however long a test runs. A model-worker test on that table sorts twelve rows and
+proves nothing. `FastDivert` (test-local, unthrottled) measures **~126 000 packets/s and ~125 000
+connection rows in three seconds**. It stays in the test file on purpose: production has no use
+for an unthrottled generator, and widening `SyntheticDivert` to make a test look better would be
+changing the tool to suit the test.
+
+Verified by mutation, and the negatives are recorded in the test docstring so nobody re-derives
+them:
+
+- **caught:** `connections_snapshot` returning the live `dict.values()` view instead of a copy
+  under the lock - the tempting optimisation here, and the one that turns every rebuild into a
+  race with flow creation.
+- **not caught:** taking the copy without the lock (window too narrow to hit in a few seconds);
+  iterating a row (`dict(c)`, `**c`, `.items()`). The second is harmless only because `_log_conn`
+  builds each row with its full key set and never adds one later, so a row never changes size -
+  if that ever stops being true, this test will not warn anybody.
+
+The test watches `crashlog.note` as well as the thread excepthook. `AsyncModel._run` catches
+everything, records it and keeps the previous table on screen, so a worker raising on every build
+would otherwise leave a green test and a quietly frozen table. It also asserts it ran in the
+regime it claims (builds completed, table over 1000 rows, over 10 000 packets seen): a green run
+that never got there would be decorative.
+
+Stability: the file was run 10 times consecutively, 0 failures.
+
 ### stop() releases the divert before anything that can block
 
 CI caught `test_failsafe.py::test_engine_stops_itself_when_the_duration_elapses` failing on

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,41 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Chaos through the whole stack (audit item #11, part 2)
+
+New `tests/test_gui_stack_chaos.py`: the real `App` on the fake tkinter, a real engine on
+synthetic traffic, the real connections page and its `AsyncModel`, and the `_tick` loop running
+throughout - while a simulated user switches pages, types in the search box, flips sort columns,
+toggles "freeze", and stops and restarts the session mid-rebuild.
+
+The combination is what matters. The off-main-thread Tk call in the old target refresher survived
+every test precisely because nothing ran the pieces together, and the fake tkinter is single
+threaded so it could not have seen it.
+
+Three choices worth recording:
+
+- **The off-main-thread check watches the fake's widget base class**, not a handful of named
+  widgets. A named spy only catches the widget somebody already suspected; patching `W.configure`,
+  `W.pack`, `W.after` and friends covers every widget in the app, including ones added later.
+  Note `config = configure` in the fake binds the ORIGINAL function at class creation, so both
+  names need patching - patching one silently misses half the calls.
+- **A failed tick is detected through the LOG, not through the loop surviving.** `_tick` catches
+  everything by design (the loop must outlive a broken tick) and reports `log.ui_error`, so
+  "the loop kept running" is true even when every single tick failed. The test takes the literal
+  part of the translated template, ahead of the `{e}` placeholder, and asserts no line carries it.
+- **Scope is stated in the docstring:** this is about thread boundaries, not volume. The traffic
+  is `SyntheticDivert` on a twelve-row table; making the sort big enough to matter is part 1's
+  job. Saying so keeps the next session from reading it as a load test.
+
+Every assertion was verified by injecting the failure it exists for, and confirming the run goes
+red: a widget touched from a worker thread, a tick that raises (injected into `_sample`, which
+only `_tick` calls - the first attempt broke `conns.refresh`, which the test body also calls
+directly, so it blew up on the wrong line and proved nothing), and a wedged model worker whose
+`busy()` never clears.
+
+Stability, which is the risk with a test like this: run 10 times consecutively, 0 failures,
+median 3.4 s. Suite 591 -> 593 tests, +5.2 s (157.6 s -> 162.8 s).
+
 ### The model worker meets a live engine (audit item #11, part 1)
 
 `test_concurrency_chaos.py` was engine-only, and the seven `AsyncModel` tests all feed the worker

--- a/tests/test_concurrency_chaos.py
+++ b/tests/test_concurrency_chaos.py
@@ -18,6 +18,16 @@ annoying:
   job is not being done.
 
 Kept deliberately short (a few seconds); it is a smoke alarm, not a soak test.
+
+A note on the traffic these tests run on. ``SyntheticDivert`` sleeps once per
+packet, and on Windows the timer granularity turns that into a ceiling: measured,
+it delivers **~1900 packets/s no matter what ``gen_kbps`` says** (2000 kbps and
+1 Gbps both land there). Its flow space is just as small - three local ports
+against three hard-coded remote addresses, so the connection table stops at
+**12 rows** however long the test runs. That is fine for the engine tests below,
+which are about threads rather than volume, but it is nowhere near a load: a
+model-worker test on that table would sort twelve rows and prove nothing.
+``FastDivert`` exists for that one test, and only there.
 """
 import threading
 import time
@@ -25,7 +35,8 @@ import time
 from beantester.engine import BeanEngine
 from beantester.matchers import KIND_PROCESS, parse_matcher
 from beantester.settings import DEFAULT_SETTINGS, apply_settings
-from beantester.synthetic import SyntheticDivert
+from beantester.synthetic import SyntheticDivert, _SyntheticPacket, _SyntheticTCP
+from beantester.views import filter_sort_connections, traffic_totals
 from fakes import check
 
 STRESS_SECONDS = 3.0
@@ -161,6 +172,192 @@ def test_engine_survives_concurrent_writers():
     check("no unhandled thread exception", not errors, f"({errors[:3]})")
     check("traffic actually flowed while all this happened", seen > 0, f"({seen})")
     check("the engine did not fault", engine.fault is None, f"({engine.fault})")
+
+
+class FastDivert:
+    """A divert that does not pace itself, so the connection table actually grows.
+
+    ``SyntheticDivert`` sleeps per packet and tops out at ~1900 packets/s over 12
+    flows (see the module docstring). This one measures **~126 000 packets/s and
+    ~125 000 connection rows in three seconds**, which is the regime the model
+    worker was built for - a filter+sort big enough to take real time while the
+    capture thread keeps writing to the very rows it is reading.
+
+    It lives here rather than in ``beantester``: production has no use for an
+    unthrottled generator, and widening ``SyntheticDivert`` to make a test look
+    better would be changing the tool to suit the test.
+    """
+
+    def __init__(self, ports=range(3000, 3500)):
+        self._ports = list(ports)
+        self._i = 0
+        self.closed = False
+
+    def open(self):
+        pass
+
+    def recv(self):
+        if self.closed:
+            raise OSError("closed")
+        self._i += 1
+        i = self._i
+        return _SyntheticPacket(b"\x00" * 200, i % 2 == 0,
+                                self._ports[i % len(self._ports)], "10.0.0.2",
+                                f"93.184.{i % 200}.{i % 251}",
+                                tcp=_SyntheticTCP(ack=True))
+
+    def send(self, packet):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+def test_the_model_worker_survives_a_live_connection_table():
+    """The connections page hands the ENGINE to its worker, not a snapshot of it.
+
+    ``conns.refresh()`` puts ``app.engine`` in the request payload on purpose - a
+    snapshot costs ~70 ms at half a million rows, which is most of what moving the
+    sort off the UI thread just bought back. So ``_build_model`` calls
+    ``connections_snapshot()`` on the WORKER, and that returns
+    ``list(self._conns.values())``: the outer list is a copy taken under the lock,
+    but every row in it is the live dict the capture thread keeps updating.
+
+    ``model_worker.py`` states in its docstring that this is safe, because it reads
+    individual keys (atomic under the GIL) and never iterates a dict the capture
+    thread could resize. Nothing tested that claim: all seven ``AsyncModel`` tests
+    feed it a fake ``build``, and the engine chaos tests never involve the worker.
+    This runs the real pipeline - snapshot, filter, sort, totals, scope - on the
+    real ``AsyncModel``, against a real engine under real load, while settings and
+    targeting change underneath.
+
+    What it was MEASURED to catch (each mutation applied, test confirmed red):
+
+    * ``connections_snapshot`` handing back the live ``dict.values()`` view instead
+      of a copy taken under the lock. That is the tempting optimisation here - the
+      copy is O(n) - and it turns every rebuild into a race with the capture thread
+      creating a flow.
+
+    What it does NOT catch, measured rather than assumed, so nobody re-derives it:
+
+    * taking the snapshot copy WITHOUT the lock. The window is real but too narrow
+      to hit reliably in a few seconds; it stayed green.
+    * iterating a row (``dict(c)``, ``**c``, ``.items()``). Harmless TODAY only
+      because ``_log_conn`` builds each row with its full key set and never adds
+      one afterwards, so a row never changes size. If a row ever gains a key
+      conditionally, that stops being true and this test will not warn you.
+
+    The crashlog watch matters more than it looks: ``AsyncModel._run`` catches
+    everything, records it and keeps the previous table on screen, so a worker that
+    raises on every single build still leaves a green test and a quietly frozen
+    table.
+    """
+    from beantester import crashlog
+    from beantester.gui.model_worker import AsyncModel
+
+    errors, restore_hook = _watch_worker_exceptions()
+    swallowed = []
+    real_note = crashlog.note
+    crashlog.note = lambda exc, where="": swallowed.append(f"{where}: {exc!r}")
+
+    engine = BeanEngine()
+    apply_settings(engine, DEFAULT_SETTINGS, lambda *_: None)
+    engine.start("true", divert=FastDivert())
+
+    queries = ["", "93.184", "443", "tcp", "zzz-matches-nothing"]
+    columns = ["bytes", "last", "remote_ip", "remote_port", "local_port",
+               "packets", "dur", "idle", "proto"]
+    builds = {"n": 0, "rows": 0}
+
+    def build(request):
+        """What ConnectionsPage._build_model does, minus the widgets."""
+        conns = request["engine"].connections_snapshot(limit=None)
+        shown = filter_sort_connections(
+            conns, request["query"], request["sort"], request["reverse"],
+            now=request["now"], proc_map=request["proc_map"],
+            limit=request["limit"])
+        totals = traffic_totals(conns, request["query"], request["proc_map"])
+        scope_active = request["engine"].targeting_active()
+        return {"rows": shown, "total": len(conns), "totals": totals,
+                "scope_active": scope_active}
+
+    model = AsyncModel(build, name="conns-model")
+    stop = threading.Event()
+    problems = []
+
+    def churn():
+        """Settings and targeting move under the worker, as they do in the GUI."""
+        i = 0
+        while not stop.is_set():
+            try:
+                i += 1
+                s = dict(DEFAULT_SETTINGS)
+                s.update(loss=i % 40, latency=i % 150, dup=i % 6, down=i % 400,
+                         dst_port="80,443,!8080" if i % 2 else "")
+                apply_settings(engine, s, lambda *_: None)
+                if i % 3 == 0:
+                    matcher = parse_matcher("python,!nonexistent_xyz", KIND_PROCESS)
+                    engine.set_target(True, engine.target_for(matcher))
+                else:
+                    engine.set_target(False)
+            except Exception as exc:                   # pragma: no cover - the bug
+                problems.append(f"churn: {type(exc).__name__}: {exc}")
+                return
+            time.sleep(0.01)
+
+    churner = threading.Thread(target=churn, name="applier", daemon=True)
+    churner.start()
+
+    # The "UI thread": ask, pick up, ask again - exactly the request/poll cycle
+    # ConnectionsPage drives from _tick and _poll_soon.
+    deadline = time.monotonic() + STRESS_SECONDS
+    i = 0
+    try:
+        while time.monotonic() < deadline:
+            i += 1
+            model.request({"engine": engine, "query": queries[i % len(queries)],
+                           "sort": columns[i % len(columns)],
+                           "reverse": i % 2 == 0, "limit": (0, 400, 50_000)[i % 3],
+                           "now": time.monotonic(), "proc_map": {}})
+            result = model.poll()
+            if result is not None:
+                builds["n"] += 1
+                builds["rows"] = max(builds["rows"], result["total"])
+                if not isinstance(result["rows"], list):
+                    problems.append(f"rows is {type(result['rows'])}")
+                if not isinstance(result["totals"], dict):
+                    problems.append(f"totals is {type(result['totals'])}")
+            time.sleep(0.005)
+
+        # let whatever is in flight land, so busy() means something below
+        for _ in range(200):
+            if model.poll() is not None:
+                builds["n"] += 1
+            if not model.busy():
+                break
+            time.sleep(0.02)
+    finally:
+        stop.set()
+        churner.join(timeout=10)
+        seen = engine.stats_snapshot()["seen"]
+        engine.stop()
+        crashlog.note = real_note
+        restore_hook()
+
+    # Diagnostics first: a swallowed build explains every other symptom below.
+    check("no build raised into crashlog", not swallowed, f"({swallowed[:3]})")
+    check("no thread raised", not errors, f"({errors[:3]})")
+    # Then the conclusiveness checks. A green run over twelve rows at 900 packets/s
+    # would prove nothing, so the test asserts it ran in the regime it claims.
+    check("the worker was actually exercised", builds["n"] > 10, f"({builds['n']})")
+    check("the table was big enough for the sort to mean something",
+          builds["rows"] > 1000, f"({builds['rows']} rows - the point is a real sort)")
+    check("traffic really flowed while it did", seen > 10_000, f"({seen})")
+    check("nothing went wrong on the driving side", not problems, f"({problems[:3]})")
+    check("the worker did not wedge", model.busy() is False)
+    check("the engine did not fault", engine.fault is None, f"({engine.fault})")
+    leaked = [t.name for t in threading.enumerate() if t.name == "conns-model"]
+    check("no model-worker thread outlived the test", not leaked, f"({leaked})")
 
 
 def test_stopping_joins_every_worker_thread():

--- a/tests/test_gui_stack_chaos.py
+++ b/tests/test_gui_stack_chaos.py
@@ -1,0 +1,149 @@
+"""Chaos through the whole stack: engine threads, model worker and the UI tick.
+
+``test_concurrency_chaos.py`` covers the engine's own threads, and one of its
+tests now drives the model worker against a live engine. What neither reaches is
+the GUI on top of both: the 700 ms ``_tick``, the start/stop transitions that run
+off the UI thread, and a user doing things to the connections table while a
+rebuild is in flight.
+
+That combination is not hypothetical. The off-main-thread Tk call in the old
+target refresher survived every test precisely because nothing ran the pieces
+together, and the fake tkinter is single threaded, so it could not see it. The
+failure it caused is the dangerous one: Tk called from a worker either hangs the
+GUI - and a hung GUI keeps the WinDivert handle open, which is what FAIL-OPEN
+exists to prevent - or raises ``RuntimeError: main thread is not in main loop``
+into a bare ``except``, silently swallowing the thing it was told to show.
+
+Scope, so nobody expects more than is here: this is about THREAD BOUNDARIES, not
+volume. The traffic is ``SyntheticDivert``, which tops out around 1900 packets/s
+over a twelve-row connection table (measured; see the note in
+``test_concurrency_chaos.py``). Making the sort big enough to matter is that
+file's job. Here the table just has to be alive while the UI pokes it.
+
+The invariants:
+
+* **no widget is touched off the main thread** - checked globally, by watching the
+  fake widget base class rather than a handful of named widgets, so it also covers
+  code nobody thought to spy on;
+* **``_tick`` never swallows an exception** - it catches everything by design (the
+  loop must survive a broken tick), and logs ``log.ui_error``. A test that only
+  checked "the loop kept running" would pass while every tick failed;
+* **the model worker never wedges** - ``busy()`` stuck at True is how the
+  connections table stops rebuilding for the rest of the session;
+* **nothing is left behind** - no leaked worker threads, no engine fault, the
+  divert released.
+"""
+from gui_harness import run_gui
+
+
+def test_the_whole_stack_survives_a_user_being_a_nuisance():
+    """Start, stop, restart, switch pages, search, sort and freeze - all under
+    live traffic, with the tick running throughout."""
+    run_gui("""
+        import threading
+        import time
+
+        import fake_tk
+        from beantester.synthetic import SyntheticDivert
+
+        # --- 1) watch for ANY widget call from a thread that is not the main one.
+        # Named-widget spies only catch the widget somebody suspected; this covers
+        # every widget in the app, including ones added later.
+        offenders = []
+        main = threading.main_thread()
+
+        def watch(cls, name):
+            original = getattr(cls, name, None)
+            if original is None:
+                return
+            def spy(self, *a, **kw):
+                if threading.current_thread() is not main:
+                    offenders.append((name, threading.current_thread().name))
+                return original(self, *a, **kw)
+            setattr(cls, name, spy)
+
+        # `config = configure` in the fake binds the ORIGINAL function at class
+        # creation, so patching one does not patch the other. Both, explicitly.
+        for _name in ("configure", "config", "pack", "pack_forget", "grid",
+                      "grid_forget", "insert", "delete", "winfo_ismapped",
+                      "after", "after_cancel"):
+            watch(fake_tk.W, _name)
+
+        # --- 2) a real session on synthetic traffic
+        real_start = app.engine.start
+        app.engine.start = (lambda filt, divert=None, duration=0:
+                            real_start(filt, divert=SyntheticDivert(seed=5),
+                                       duration=duration))
+
+        def tick(times=1, pause=0.01):
+            for _ in range(times):
+                app._tick()
+                time.sleep(pause)
+
+        app._start(); app._settle_transition()
+        assert app.running is True, "the GUI did not start"
+        tick(10)
+        assert app.engine.stats_snapshot()["seen"] > 0, "no traffic flowed"
+
+        conns = app.pages["connections"]
+        page_ids = list(app.pages)
+
+        # --- 3) be a nuisance: switch pages, search, sort and freeze while the
+        # worker is mid-rebuild, and restart the session underneath all of it.
+        for i in range(60):
+            app.select_page(page_ids[i % len(page_ids)])
+            if i % 5 == 0:
+                conns.search_var.set(["", "93.184", "443", "zzz"][(i // 5) % 4])
+                conns._schedule_search()
+            if i % 7 == 0:
+                col = ["bytes", "last", "remote_ip", "local_port"][(i // 7) % 4]
+                conns.table.sort["col"] = col
+                conns.table.sort["reverse"] = not conns.table.sort["reverse"]
+                conns.refresh(force=True)
+            if i % 11 == 0:
+                conns.pause_var.set(not conns.pause_var.get())
+            if i == 25:
+                app._stop(); app._settle_transition()
+                assert app.running is False, "the GUI did not stop"
+            if i == 32:
+                app._start(); app._settle_transition()
+                assert app.running is True, "the GUI did not restart"
+            app._tick()
+            time.sleep(0.005)
+
+        conns.pause_var.set(False)
+        tick(20)
+
+        # let anything in flight land, so busy() below means something
+        for _ in range(100):
+            if not conns._model.busy():
+                break
+            app._tick()
+            time.sleep(0.02)
+
+        before_stop = {t.name for t in threading.enumerate()}
+        app._stop(); app._settle_transition()
+        tick(5)
+        time.sleep(0.3)
+
+        # --- 4) the invariants
+        assert not offenders, f"widget touched off the main thread: {offenders[:5]}"
+
+        # _tick catches everything on purpose - the loop has to survive a broken
+        # tick - and reports it as log.ui_error. So "the loop kept running" proves
+        # nothing; the log is the only place a failed tick shows up. Take the
+        # literal part of the translated template, ahead of the {e} placeholder.
+        marker = bnt.T("log.ui_error", e="\\x00").split("\\x00")[0].strip()
+        assert marker, "log.ui_error starts with its placeholder; pick another marker"
+        ui_errors = [l for l in app._log_lines if marker in l]
+        assert not ui_errors, f"_tick swallowed an exception: {ui_errors[:3]}"
+
+        assert conns._model.busy() is False, "the model worker wedged"
+        assert app.engine.fault is None, f"engine faulted: {app.engine.fault}"
+        assert app.engine.is_running() is False, "the engine is still running"
+        assert app.engine._divert is None, "the divert was not released"
+
+        leaked = {t.name for t in threading.enumerate()} - before_stop
+        leaked -= {t.name for t in threading.enumerate() if not t.is_alive()}
+        assert not leaked, f"threads outlived the session: {leaked}"
+    """)


### PR DESCRIPTION
Audit item #11, in two commits that can be judged separately.

`test_concurrency_chaos.py` covered the engine's own threads, and all seven `AsyncModel` tests
feed the worker a fake `build`. Nothing put the layers together - which is exactly how the
off-main-thread Tk call in the old target refresher survived every test: the fake tkinter is
single threaded, so it could not have seen it.

### 1. The model worker meets a live engine

`ConnectionsPage.refresh()` hands the worker **the engine itself**, not a snapshot (a snapshot is
~70 ms at half a million rows - most of what moving the sort off the UI thread bought back). So
`_build_model` calls `connections_snapshot()` on the worker, and that returns
`list(self._conns.values())`: the outer list is a copy taken under the lock, but every row in it
is the live dict the capture thread keeps updating. `model_worker.py` asserts in prose that this
is safe. Nothing checked it.

The new test runs the real pipeline - snapshot, filter, sort, totals, scope - on the real
`AsyncModel`, against a real engine under load, while settings and targeting churn underneath.

**The traffic had to be built for it, and the reason is measured.** `SyntheticDivert` sleeps once
per packet and Windows timer granularity caps it at **~1900 packets/s whatever `gen_kbps` says**,
over three local ports and three hard-coded remote addresses - so its connection table stops at
**12 rows** however long a test runs. Sorting twelve rows proves nothing. `FastDivert`
(test-local, unthrottled) measures **~126 000 packets/s and ~125 000 rows in three seconds**. It
stays in the test file: production has no use for an unthrottled generator, and widening
`SyntheticDivert` to make a test look better would be changing the tool to suit the test.

Verified by mutation, and the negatives are in the docstring so nobody re-derives them:

- **caught:** `connections_snapshot` returning the live `dict.values()` view instead of a copy
  under the lock - the tempting optimisation here.
- **not caught:** taking the copy without the lock (window too narrow to hit in a few seconds);
  iterating a row. The second is harmless only because `_log_conn` builds each row with its full
  key set and never adds one later, so a row never changes size. If that stops being true, this
  test will not warn anybody.

The test watches `crashlog.note` as well as the thread excepthook - `AsyncModel._run` catches
everything and keeps the previous table on screen, so a worker raising on every build would
otherwise leave a green test and a quietly frozen table. It also asserts it ran in the regime it
claims (builds completed, >1000 rows, >10 000 packets), so a green run that never got there fails
instead of passing quietly.

### 2. Chaos through the whole stack

New `tests/test_gui_stack_chaos.py`: real `App` on the fake tkinter, real engine on synthetic
traffic, real connections page and its `AsyncModel`, `_tick` running throughout, while a simulated
user switches pages, searches, re-sorts, freezes, and stops and restarts the session mid-rebuild.

- The off-main-thread check watches the fake's widget **base class**, not named widgets: a named
  spy only catches the widget somebody already suspected. `config = configure` in the fake binds
  the original function at class creation, so both names need patching or half the calls are
  missed silently.
- A failed tick is detected through the **log**, not through the loop surviving. `_tick` catches
  everything by design and reports `log.ui_error`, so "the loop kept running" stays true even when
  every tick failed.
- Scope is stated in the docstring: thread boundaries, not volume. Volume is part 1's job.

Every assertion was verified by injecting the failure it exists for: a widget touched from a
worker thread, a tick that raises, a wedged model worker. The tick probe had to go into `_sample`
rather than `conns.refresh` - the body calls `refresh` directly, so the first attempt blew up on
the wrong line and proved nothing.

### Verification

- Part 1 file: 10 consecutive runs, 0 failures. Part 2 file: 10 consecutive runs, 0 failures,
  median 3.4 s. Flakiness was the declared risk of this item, so it was measured rather than
  hoped for.
- Full suite: 591 -> 593 tests, green, +5.2 s (157.6 s -> 162.8 s).
- Tests only; `beantester/` is untouched.
- No version bump (convention 34).