### PR TITLE
test(hot-path): guard every route to the OS, not one object

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,33 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### The chaos test was measuring the machine, not the code
+
+CI failed `test_the_model_worker_survives_a_live_connection_table` with
+`traffic really flowed while it did (8342)`. The test asserted `seen > 10_000` after a fixed three
+seconds - a threshold read off a dev machine, where the same three seconds produce hundreds of
+thousands of packets. A CI runner under coverage managed 8342, about fifteen times less.
+
+The interesting part is that the test had already reached the state it exists for: the
+`rows > 1000` assertion, checked one line earlier, PASSED. The table was big enough for the sort to
+be real work. Only the packet count - a proxy for the same thing, and a worse one - was out of
+range. A green run on a fast machine and a red one on a slow machine, with identical behaviour
+under test.
+
+Fixed by asserting the CONDITION and waiting for it, instead of assuming a duration produces it:
+
+- the request/poll loop now runs for at least `STRESS_SECONDS` and then keeps going until
+  `MIN_BUILDS` rebuilds have completed over a table of at least `MIN_ROWS` rows, with a 30 s hard
+  cap so a broken run still ends;
+- the packet-count assertion is gone. The row count already implies traffic - a thousand distinct
+  flows cannot exist without it - and counting packets measured the runner;
+- `FastDivert`'s docstring now says its measured throughput is a dev-machine number and not a
+  promise, so nobody turns it back into a threshold.
+
+Verified by simulating the slow runner rather than by hoping: throttled to ~3000 packets/s (below
+what CI managed), the old assertions fail with the exact CI symptom
+(`traffic really flowed while it did (2429)`) and the new ones pass. Unthrottled, both pass.
+
 ### A hot-path guard that watches the routes, not one object (audit item #8)
 
 The rule is one sentence: nothing on the capture or inject thread may ask the OS a question. It

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,69 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### A hot-path guard that watches the routes, not one object (audit item #8)
+
+The rule is one sentence: nothing on the capture or inject thread may ask the OS a question. It
+already had a guard - `test_target_resolver.py::test_the_capture_thread_never_touches_the_socket_table`
+- but a narrow one, and its first limitation has already bitten this project:
+
+- **it watches an object, so it can watch the WRONG object.** An earlier version gave the counting
+  table only to the targeting and left the engine on `portmap.default_table()`. It passed while
+  `_log_conn` -> `_process_for` -> `process_for_port` rebuilt the real table ~16 times a second on
+  the capture thread. A live run caught what the test could not.
+- **it only knows about the socket table.** Targeting is one route to the OS; `_log_conn` is a
+  second, independent one; a third would be invisible to it.
+
+New `tests/test_hot_path.py` watches the ROUTES instead. `portmap` is the only module in the
+package that touches `psutil` or `iphlpapi`, through five entry points (`_psutil_port_pid_map`,
+`_psutil_process_table`, `_psutil_created`, `_psutil_process_info`, `_Native._table`). Wrapping
+all five catches any caller, including one nobody has written yet. Threads are compared by
+IDENTITY against `engine._t_cap` / `_t_inj`, not by name substring, so it does not depend on how
+CPython happens to name a thread.
+
+The target expression deliberately matches nothing. With no matching port every packet is a miss,
+so the resolver is woken continuously and the surface gets hammered - and the test stops depending
+on which processes exist, so it means the same on a CI runner as here. Measured during a session
+with traffic and targeting active:
+
+| calls | function | thread |
+|---|---|---|
+| 5232 | `_psutil_created` | bean-target-resolver |
+| 1431 | `_psutil_process_info` | bean-target-resolver |
+| 448 | `_psutil_created` | watchdog |
+| 212 | `_Native._table` | bean-target-resolver |
+| 3 | `_psutil_process_table` | bean-target-resolver |
+| **0** | **anything** | **capture / inject** |
+
+The work is real and heavy, and none of it is where the user's packets wait. That is the design,
+now asserted.
+
+**Found no bug** - the invariant holds today. Verified by mutation, negative included:
+
+- **caught:** `_process_for` reopening the refresh (`allow_refresh=True`), the regression that has
+  already happened twice. The failure names both ends:
+  `[('_Native._table', 'Thread-1 (_capture_loop)')]`.
+- **not caught:** a name lookup on the capture thread that HITS the warm info cache. That is the
+  guard's boundary, not a hole - it watches trips to the OS and a cache hit is not one - but a
+  regression that only misses the cache occasionally will only be caught occasionally.
+
+A second test asserts the RECORDER records: a wrapper that silently failed to install would leave
+the guard permanently and invisibly green.
+
+**Deliberately not a wall-clock budget.** The suite's existing timing assertions
+(`test_failsafe`'s "start did not block the UI thread", `test_target_resolver`'s "stop did not wait
+for the scan") all separate outcomes differing by an order of magnitude. "The hot path costs under
+N microseconds" has no such separation: on a shared CI runner it measures the runner, and the first
+thing anybody does with such a test is widen the bound until it stops failing.
+
+**Not verified:** the Linux path. On this machine `_Native` initialises, so the `psutil` fallback
+for the socket table never runs; `_psutil_port_pid_map` is watched but was never seen to fire here.
+CI runs ubuntu too, where it is the main path. The assertions are written against the TOTAL over
+the surface rather than any single function so they hold either way, but the ubuntu behaviour is
+unverified locally.
+
+Stability: 10 consecutive runs, 0 failures, median 3.8 s.
+
 ### Chaos through the whole stack (audit item #11, part 2)
 
 New `tests/test_gui_stack_chaos.py`: the real `App` on the fake tkinter, a real engine on

--- a/tests/test_concurrency_chaos.py
+++ b/tests/test_concurrency_chaos.py
@@ -42,6 +42,12 @@ from fakes import check
 STRESS_SECONDS = 3.0
 CYCLES = 25
 
+# What makes the model-worker test conclusive rather than decorative: enough
+# completed rebuilds to have raced anything, over a table big enough that the sort
+# is real work. Asserted as conditions the test WAITS for - see the loop.
+MIN_BUILDS = 10
+MIN_ROWS = 1000
+
 
 def _watch_worker_exceptions():
     """Collect anything a thread raises (threads swallow exceptions by default)."""
@@ -183,6 +189,12 @@ class FastDivert:
     worker was built for - a filter+sort big enough to take real time while the
     capture thread keeps writing to the very rows it is reading.
 
+    Those numbers are from a dev machine and are NOT a promise: the same three
+    seconds produced 8342 packets on a CI runner under coverage, about fifteen
+    times less. Nothing here may turn them into a threshold - see the loop in
+    the test, which waits for the table it needs instead of assuming a duration
+    produces one.
+
     It lives here rather than in ``beantester``: production has no use for an
     unthrottled generator, and widening ``SyntheticDivert`` to make a test look
     better would be changing the tool to suit the test.
@@ -310,10 +322,22 @@ def test_the_model_worker_survives_a_live_connection_table():
 
     # The "UI thread": ask, pick up, ask again - exactly the request/poll cycle
     # ConnectionsPage drives from _tick and _poll_soon.
-    deadline = time.monotonic() + STRESS_SECONDS
+    #
+    # It runs for at least STRESS_SECONDS and then KEEPS GOING until the table is
+    # big enough for the sort to be real work. A fixed wall-clock budget would let
+    # machine speed decide whether the test is conclusive, and that is not
+    # hypothetical: the first version asserted "> 10 000 packets seen" after three
+    # seconds, a threshold taken from this dev machine, and CI managed 8342 under
+    # coverage on a shared runner. Waiting for the CONDITION costs nothing where
+    # the machine is fast and stops the test being a speed test where it is not.
+    soft_deadline = time.monotonic() + STRESS_SECONDS
+    hard_deadline = time.monotonic() + 30.0
     i = 0
     try:
-        while time.monotonic() < deadline:
+        while time.monotonic() < hard_deadline:
+            if (time.monotonic() >= soft_deadline
+                    and builds["n"] > MIN_BUILDS and builds["rows"] > MIN_ROWS):
+                break
             i += 1
             model.request({"engine": engine, "query": queries[i % len(queries)],
                            "sort": columns[i % len(columns)],
@@ -349,10 +373,16 @@ def test_the_model_worker_survives_a_live_connection_table():
     check("no thread raised", not errors, f"({errors[:3]})")
     # Then the conclusiveness checks. A green run over twelve rows at 900 packets/s
     # would prove nothing, so the test asserts it ran in the regime it claims.
-    check("the worker was actually exercised", builds["n"] > 10, f"({builds['n']})")
+    # These are CONDITIONS, not speeds: the loop above waits for them rather than
+    # hoping a fixed number of seconds produced them. There is no packet-count
+    # assertion because the row count already implies one - a thousand distinct
+    # flows cannot exist without traffic - and counting packets instead measured
+    # how fast the machine was.
+    check("the worker was actually exercised", builds["n"] > MIN_BUILDS,
+          f"({builds['n']} builds; {seen} packets seen)")
     check("the table was big enough for the sort to mean something",
-          builds["rows"] > 1000, f"({builds['rows']} rows - the point is a real sort)")
-    check("traffic really flowed while it did", seen > 10_000, f"({seen})")
+          builds["rows"] > MIN_ROWS,
+          f"({builds['rows']} rows - the point is a real sort; {seen} packets seen)")
     check("nothing went wrong on the driving side", not problems, f"({problems[:3]})")
     check("the worker did not wedge", model.busy() is False)
     check("the engine did not fault", engine.fault is None, f"({engine.fault})")

--- a/tests/test_hot_path.py
+++ b/tests/test_hot_path.py
@@ -1,0 +1,184 @@
+"""The packet threads must never reach the operating system (audit item #8).
+
+The rule this file enforces is one sentence: **nothing on the capture or inject
+thread may ask the OS a question.** Those two threads are the tool's hot path.
+A stalled capture thread means WinDivert keeps diverting into a queue nobody
+drains, so the user silently loses connectivity while the UI says "running" -
+the failure the whole fail-open design exists to prevent (convention 20). A
+stalled inject thread means the delays this tool exists to inject stop being the
+delays it was told to inject.
+
+That invariant already had a guard, but a narrow one.
+``test_target_resolver.py::test_the_capture_thread_never_touches_the_socket_table``
+injects a counting fake table and checks which threads made it look. It is worth
+keeping - it is fast and deterministic - but it has two limits, and the first one
+has already bitten this project once:
+
+* **it watches an object, so it can watch the WRONG object.** An earlier version
+  gave the counting table only to the targeting and left the engine on
+  ``portmap.default_table()``, so it passed while ``_log_conn`` ->
+  ``_process_for`` -> ``process_for_port`` rebuilt the real table about sixteen
+  times a second on the capture thread. A live run caught what the test could not.
+* **it only knows about the socket table.** Targeting is one route to the OS;
+  ``_log_conn`` is a second, independent one. A third would be invisible to it.
+
+So this file watches the ROUTES instead of an object. ``portmap`` is the only
+module in the package that touches ``psutil`` or ``iphlpapi``, and it does so
+through five entry points; wrapping all five catches any caller, including one
+nobody has written yet. Threads are compared by IDENTITY against the engine's own
+handles rather than by name substring, so it does not depend on how CPython
+happens to name a thread.
+
+Measured while writing this, on a real session with traffic and targeting active
+(the numbers are the point of the test, not decoration):
+
+    5232x  _psutil_created         from bean-target-resolver
+    1431x  _psutil_process_info    from bean-target-resolver
+     448x  _psutil_created         from the watchdog
+     212x  _Native._table          from bean-target-resolver
+       3x  _psutil_process_table   from bean-target-resolver
+       0x  anything                from the capture or inject thread
+
+The work is real and it is heavy - and all of it happens somewhere the user's
+packets do not wait for it. That is the whole design, asserted.
+
+**This found no bug.** The invariant holds today; the value is that it keeps
+holding when somebody adds the next lookup.
+
+Verified by mutation, with the negative recorded rather than glossed over:
+
+* **caught:** ``_process_for`` reopening the socket-table refresh
+  (``allow_refresh=True``) - the exact regression that has already happened twice
+  here. The failure names both ends of it:
+  ``[('_Native._table', 'Thread-1 (_capture_loop)')]``.
+* **not caught:** a name lookup on the capture thread that HITS the warm info
+  cache. That is the guard's boundary rather than a hole in it - it watches trips
+  to the OS, and a cache hit is not one. But it means a regression that only
+  misses the cache occasionally (a brand-new PID, say) will only be caught
+  occasionally. If that ever matters, the way to close it is to run the session
+  with the info cache expiring, not to widen this test.
+
+NOT verified: the Linux path. On this machine ``_Native`` initialises and the
+``psutil`` fallbacks for the socket table never run, so ``_psutil_port_pid_map``
+is watched but was never seen to fire here. CI runs ubuntu too, where it is the
+main path; the assertions are written against the TOTAL over the surface rather
+than any one function so they hold either way, but the ubuntu behaviour is
+unverified locally.
+
+Deliberately NOT a wall-clock budget. The suite's existing timing assertions
+(``test_failsafe``'s "start did not block the UI thread", ``test_target_resolver``'s
+"stop did not wait for the scan") all separate outcomes that differ by an order of
+magnitude. "The hot path costs under N microseconds" has no such separation: on a
+shared CI runner it measures the runner, and the first thing anybody does with a
+test like that is widen the bound until it stops failing.
+"""
+import contextlib
+import threading
+import time
+
+from beantester import portmap
+from beantester.engine import BeanEngine
+from beantester.settings import DEFAULT_SETTINGS, apply_settings
+from beantester.synthetic import SyntheticDivert
+from fakes import check
+
+# Every route out of the package and into the operating system. They are module
+# level functions called through module globals, so replacing the attribute is
+# enough - production picks up the replacement at call time.
+OS_FUNCTIONS = ("_psutil_port_pid_map", "_psutil_process_table",
+                "_psutil_created", "_psutil_process_info")
+
+
+@contextlib.contextmanager
+def os_calls_recorded():
+    """Record ``(function name, calling thread)`` for every trip to the OS."""
+    calls = []
+    lock = threading.Lock()
+    originals = {name: getattr(portmap, name) for name in OS_FUNCTIONS}
+    native_table = portmap._Native._table
+
+    def wrap(name, original):
+        def spy(*a, **kw):
+            with lock:
+                calls.append((name, threading.current_thread()))
+            return original(*a, **kw)
+        return spy
+
+    def native_spy(self, *a, **kw):
+        with lock:
+            calls.append(("_Native._table", threading.current_thread()))
+        return native_table(self, *a, **kw)
+
+    for name, original in originals.items():
+        setattr(portmap, name, wrap(name, original))
+    portmap._Native._table = native_spy
+    try:
+        yield calls
+    finally:
+        for name, original in originals.items():
+            setattr(portmap, name, original)
+        portmap._Native._table = native_table
+
+
+def test_no_packet_thread_ever_reaches_the_operating_system():
+    """A real session, targeting on, every route to the OS watched.
+
+    The target deliberately matches NOTHING. That is not laziness about picking a
+    process: with no matching port, every packet is a miss, so the resolver is
+    woken continuously and the OS surface gets hammered - which is exactly the
+    pressure this guard should run under. It also makes the test independent of
+    which processes happen to exist on the machine, so it means the same thing on
+    a CI runner as it does here.
+    """
+    portmap.reset_default_table()        # do not inherit another test's cache
+    engine = BeanEngine()
+    settings = dict(DEFAULT_SETTINGS)
+    settings.update(loss=10, target="no_such_process_anywhere_xyz")
+
+    with os_calls_recorded() as calls:
+        apply_settings(engine, settings, lambda *_: None)
+        engine.start("true", divert=SyntheticDivert(seed=7))
+        capture, inject = engine._t_cap, engine._t_inj
+        try:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if engine.stats_snapshot()["seen"] > 500:
+                    break
+                time.sleep(0.02)
+            seen = engine.stats_snapshot()["seen"]
+        finally:
+            engine.stop()
+
+    packet_threads = {id(t) for t in (capture, inject) if t is not None}
+    offenders = sorted({(name, thread.name) for name, thread in calls
+                        if id(thread) in packet_threads})
+
+    check("the packet threads existed to be watched", len(packet_threads) == 2,
+          f"({packet_threads})")
+    check("traffic actually flowed", seen > 100, f"({seen})")
+    # Without this the test would pass just as happily if the whole surface were
+    # never called - a guard that only proves nothing happened proves nothing.
+    check("the OS surface was actually exercised", len(calls) > 5,
+          f"({len(calls)} calls - the resolver should be busy under a miss storm)")
+    check("no packet thread reached the operating system", not offenders,
+          f"({offenders})")
+
+
+def test_the_recorder_sees_what_it_claims_to_see():
+    """The guard above is only worth its runtime if the recorder really records.
+
+    A wrapper that silently failed to install - a renamed function, a call routed
+    around the module global - would leave the guard permanently, invisibly green.
+    So: call the surface directly and confirm it comes back tagged with this
+    thread.
+    """
+    with os_calls_recorded() as calls:
+        portmap._psutil_created(1)
+        names = [name for name, _ in calls]
+        threads = {thread is threading.current_thread() for _, thread in calls}
+
+    check("the call was recorded", "_psutil_created" in names, f"({names})")
+    check("it was tagged with the calling thread", threads == {True}, f"({threads})")
+    check("the wrappers were removed again",
+          portmap._psutil_created.__name__ != "spy",
+          f"({portmap._psutil_created!r})")


### PR DESCRIPTION
The rule is one sentence: nothing on the capture or inject thread may ask the OS a question. It already had a guard - test_target_resolver's test_the_capture_thread_never_touches_the_socket_table - but a narrow one, and its first limitation has already bitten this project:

  - it watches an OBJECT, so it can watch the wrong one. An earlier version gave the counting table only to the targeting and left the engine on portmap.default_table(); it passed while _log_conn -> _process_for -> process_for_port rebuilt the real table ~16 times a second on the capture thread. A live run caught what the test could not.
  - it only knows about the socket table. Targeting is one route to the OS, _log_conn is a second, and a third would be invisible to it.

tests/test_hot_path.py watches the ROUTES instead. portmap is the only module in the package that touches psutil or iphlpapi, through five entry points, so wrapping all five catches any caller including one nobody has written yet. Threads are compared by IDENTITY against engine._t_cap / _t_inj rather than by name substring, so it does not depend on how CPython names a thread.

The target expression deliberately matches nothing: every packet is then a miss, the resolver is woken continuously and the surface gets hammered, and the test stops depending on which processes exist on the machine. Measured during a session with traffic and targeting active:

  5232x  _psutil_created        from bean-target-resolver
  1431x  _psutil_process_info   from bean-target-resolver
   448x  _psutil_created        from the watchdog
   212x  _Native._table         from bean-target-resolver
     3x  _psutil_process_table  from bean-target-resolver
     0x  anything               from the capture or inject thread

Found no bug - the invariant holds today. Verified by mutation, negative included: reopening the refresh (allow_refresh=True) goes red and names both ends, [('_Native._table', 'Thread-1 (_capture_loop)')]; a name lookup that HITS the warm info cache is NOT caught, which is the guard's boundary rather than a hole, since it watches trips to the OS and a cache hit is not one.

A second test asserts the recorder records - a wrapper that silently failed to install would leave the guard permanently and invisibly green.

Deliberately not a wall-clock budget. Every timing assertion already in the suite separates outcomes that differ by an order of magnitude; "the hot path costs under N microseconds" has no such separation, so on a shared CI runner it measures the runner.

Not verified: the Linux path. _Native initialises here, so the psutil fallback for the socket table never runs locally. The assertions are written against the total over the surface rather than any single function, so they hold either way.

Verified: 10 consecutive runs, 0 failures, median 3.8 s.

