### PR TITLE
fix: a broken user file may cost you your settings, never your program

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,43 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### ui.json: a valid dict with the wrong types stopped the app from starting (audit item #10)
+
+`jsonfile.read_json` guarantees the file parses and is a dict. Nothing beyond that - and
+`UiStateStore` trusted the rest, while its own module docstring promises that corruption "must
+never break startup, so every failure degrades to the defaults". Measured, by building a real
+`App` over a poisoned `bean_network_tester_ui.json`, three keys broke that promise outright:
+
+| key | value | result |
+|---|---|---|
+| `page` | `[1, 2, 3]` | `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')` |
+| `conn_sort` | `[1, 2]` | `TypeError: object is not iterable` |
+| `event_sort` | `"kb"` | `ValueError: dictionary update sequence element #0 has length 1; 2 is required` |
+
+The window never appeared, and the traceback named none of the files involved.
+
+`UiStateStore._clean` now drops values whose TYPE is not the one `DEFAULTS` promises, records
+which keys it ignored in `self.problem` (already surfaced by `App._report_storage_problems`
+through the existing `log.ui_state_problem` key, so no new i18n), and keeps everything else. It is
+deliberately the same shape as `ProfileStore._clean`, which has always done this for the other
+user file - the mechanism existed, it just was not applied here.
+
+**Only the TYPE is checked, and that is a measured decision, not caution.** Every wrong VALUE of
+the right type was tried first and already degrades gracefully: an unknown page id, an unknown
+stats sub-page, an unknown language code, a missing profile name, a nonsense geometry string, a
+negative or absurd sash position, a sort column that does not exist, `collapsed` holding ints or
+nested lists, `conn_sort` with a list under `col`. Validating further would add rules that catch
+nothing. Unknown keys are kept on purpose: `get` only reads keys it knows, and dropping them would
+silently discard state written by a newer version.
+
+New `tests/test_ondisk_formats.py` (4 tests, more coming for the config and scenario paths):
+per-key type fuzzing at the store level, the whole poison set driven through a real `App` in one
+subprocess, and the unparseable-file half - every shape in `BROKEN_JSON` must leave usable state,
+a reported problem and a `.corrupt-<timestamp>` file rather than a clobbered one.
+
+Verified by mutation: with `_clean` removed the suite fails with the original symptom,
+`the app did not start: page=[1, 2, 3]: TypeError: cannot use 'list' as a dict key`.
+
 ### The chaos test was measuring the machine, not the code
 
 CI failed `test_the_model_worker_survives_a_live_connection_table` with

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,37 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### --dry-run called a scenario valid without ever opening it (audit item #10)
+
+`--dry-run` is the gate a CI/CD pipeline runs before the real command. It returned `OK` for every
+broken scenario file tried - a bare list, a string, a number, truncated JSON, an empty file - and
+printed "Configuration is valid", because the scenario was loaded only inside `_run_session`,
+which `--dry-run` returns before reaching. The same files correctly gave `SCENARIO(4)` on a real
+run. A gate whose verdict disagrees with the thing it gates is worse than no gate.
+
+`run_cli` now loads and validates the scenario inside the `--dry-run` branch, failing with
+`SCENARIO(4)` and the parse error. `--print-config` and `--save-config` return early as before and
+are deliberately left alone: neither claims the configuration is valid, they report or store the
+SETTINGS, and a scenario is not part of those.
+
+**Owner's call: this is a fix, not a BREAKING change** (`--dry-run` on a broken scenario goes from
+`OK` to `SCENARIO(4)`). A script relying on the old outcome is relying on the gate lying to it. No
+`### BREAKING` section, no version bump.
+
+Tests: every shape in `BROKEN_JSON` must be rejected by `--dry-run` *and* the output must not
+contain the word "valid"; the dry run and the real run must return the SAME code for the same
+file; and all seven shipped `scenarios/*.json` must pass `--dry-run` - the check that the fix does
+not start rejecting real files.
+
+Worth recording, because it briefly looked like a regression: the first draft of that test invented
+a scenario shape (`{"duration": 1, "loss": 5}`) instead of using the documented one
+(`{"at": seconds, "settings": {...}}`). `--dry-run` rejected it, correctly, and for a moment that
+read as the fix rejecting good files. The shipped-scenario loop was added as the answer - it
+cannot be argued with.
+
+Verified by mutation: without the change the suite fails with the original symptom, `code=0` and
+`Configuration is valid` for a broken scenario.
+
 ### --config with valid JSON of the wrong shape was a traceback, not an exit code (audit item #10)
 
 `settings.load_config_file` does a raw `json.load` and goes straight to `data.items()`. For

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,34 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### --config with valid JSON of the wrong shape was a traceback, not an exit code (audit item #10)
+
+`settings.load_config_file` does a raw `json.load` and goes straight to `data.items()`. For
+`[1, 2, 3]`, `"x"`, `42`, `null` or `true` the parse succeeds and the type error lands one line
+later as an **AttributeError** - which `cli.py` does not catch, since it catches `ValueError` and
+`OSError`. Measured on all five shapes: a Python traceback on stderr and exit **1 (RUNTIME)**,
+where a bad config file is **CONFIG(3)**.
+
+Two contracts at once: convention 18 (every way of ending has a code from `exitcodes.py`) and the
+comment sitting directly above that `try` in `cli.py`, which promises "a clear CLI error, never a
+raw traceback". For a CI/CD pipeline reading the exit code, the difference is being told the tool
+crashed instead of being told its config is wrong.
+
+`load_config_file` now checks the parsed value is a dict and raises `ValueError` otherwise, which
+the existing handler already turns into `CONFIG(3)`. Deliberately NOT routed through
+`jsonfile.read_json`: quarantine is right for the app's own state files, but silently moving aside
+a file the user named explicitly on the command line would be a surprise.
+
+The GUI path is unaffected - `App.load_config_file` catches `Exception` and shows a dialog - so
+this was CLI-only, which is where the exit-code contract lives.
+
+Tests in `tests/test_ondisk_formats.py`: every shape in `BROKEN_JSON` through `--config` must give
+`CONFIG(3)`, an `error:` line on stderr and a clean stdout, plus the other direction - a
+well-formed config file still loads. Run in-process, so an exception escaping `run_cli` fails the
+test with its own traceback, which is the failure mode being guarded. Verified by mutation:
+without the check the suite fails with the original `AttributeError: 'list' object has no
+attribute 'items'`.
+
 ### ui.json: a valid dict with the wrong types stopped the app from starting (audit item #10)
 
 `jsonfile.read_json` guarantees the file parses and is a dict. Nothing beyond that - and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **`--dry-run` now checks your scenario file as well.** That option exists to tell you whether a
+  run will work before you start it - but it never actually opened the scenario file, so a damaged,
+  empty or half-written scenario passed the check with "Configuration is valid" and then failed the
+  real run moments later. It now reads the scenario too and tells you straight away what is wrong
+  with it. A check that passes everything is worse than no check at all.
 - **A settings file in the wrong form now gives a clear message instead of crashing.** If you
   pointed `--config` at a JSON file that was readable but not a set of settings - a list, say, or
   a single value, which is what some tools produce - the program stopped with a raw Python error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A damaged window-layout file no longer stops the program from starting.** The program
+  remembers your window size, the page you were last on and which sections you had collapsed, in a
+  small file next to it. That file is yours to edit, and it also gets copied between machines - and
+  if an entry in it ended up the wrong shape, the program could fail to open at all, with an error
+  that gave no hint which file was to blame. Anything it cannot make sense of is now ignored, that
+  one setting goes back to its default, and the log tells you which entries were skipped. The rest
+  of your layout is kept.
 - **Ending a session now hands your network back at once, instead of a moment later.** When a run
   finished - whether you pressed STOP or its time ran out - the tool stopped looking at packets
   immediately, but kept its grip on your network traffic for a moment longer while it tidied up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A settings file in the wrong form now gives a clear message instead of crashing.** If you
+  pointed `--config` at a JSON file that was readable but not a set of settings - a list, say, or
+  a single value, which is what some tools produce - the program stopped with a raw Python error
+  and reported itself as having crashed. It now says what it expected and stops with the "bad
+  configuration" code, so a script running it can tell the difference between "your file is wrong"
+  and "the tool broke".
 - **A damaged window-layout file no longer stops the program from starting.** The program
   remembers your window size, the page you were last on and which sections you had collapsed, in a
   small file next to it. That file is yours to edit, and it also gets copied between machines - and

--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ ranges, `!`, `>`, `<`, `>=`, `<=`, wildcards, `re:`, and `--dst-ip` additionally
 
 | Flag | Description |
 |---|---|
-| `--dry-run` | check the config and exit (does not touch the driver, passes no traffic) - ideal for validating config files in a pipeline |
+| `--dry-run` | check the config and exit (does not touch the driver, passes no traffic) - ideal for validating config files in a pipeline. A `--scenario` is read and validated too, so the dry run and the real run agree |
 | `--print-config` | print the effective settings (after `defaults < file < preset < flags`) as JSON and exit |
 | `--min-packets N` | exit with code `6` if fewer than N packets were caught |
 | `--fail-on-no-traffic` | shorthand for `--min-packets 1` - **catches a filter that caught nothing** |

--- a/README.pl.md
+++ b/README.pl.md
@@ -517,7 +517,7 @@ BeanNetworkTester.exe --simulate --duration 30 --format json > run.ndjson
 
 | Flaga | Opis |
 |---|---|
-| `--dry-run` | sprawdź konfigurację i wyjdź (nie dotyka sterownika, nie puszcza ruchu) - idealne do walidacji plików konfiguracji w pipeline |
+| `--dry-run` | sprawdź konfigurację i wyjdź (nie dotyka sterownika, nie puszcza ruchu) - idealne do walidacji plików konfiguracji w pipeline. Plik `--scenario` też jest wczytywany i sprawdzany, więc próbny przebieg i prawdziwy dają ten sam werdykt |
 | `--print-config` | wypisz efektywne ustawienia (po `domyślne < plik < preset < flagi`) jako JSON i wyjdź |
 | `--min-packets N` | zakończ kodem `6`, jeśli złapano mniej niż N pakietów |
 | `--fail-on-no-traffic` | skrót na `--min-packets 1` - **łapie filtr, który nie złapał niczego** |

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -570,6 +570,21 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
             log.info(f"Saved settings to {cfg['save_config']}")
             return exitcodes.OK
         if args.dry_run:
+            # The scenario is part of the configuration, and --dry-run is the
+            # "check it before I run it" gate - the one thing a CI/CD pipeline
+            # runs to find out whether the next command will work. It used to be
+            # loaded only once the session started, so --dry-run reported
+            # "Configuration is valid" about a file it had never opened: a
+            # truncated, empty or non-object scenario passed the check with exit
+            # OK and then failed the real run with SCENARIO(4).
+            if cfg["scenario"]:
+                try:
+                    scen = load_scenario_file(cfg["scenario"])
+                except Exception as e:
+                    _fail(exitcodes.SCENARIO,
+                          f"scenario error in {cfg['scenario']!r}: {e}")
+                log.debug(f"scenario: {len(scen.steps)} steps, "
+                          f"{scen.duration:.0f}s, loop={scen.loop or cfg['loop']}")
             _log_effective_settings(log, cfg)
             log.info("Configuration is valid (--dry-run: nothing was started).")
             return exitcodes.OK

--- a/beantester/gui/ui_state.py
+++ b/beantester/gui/ui_state.py
@@ -34,7 +34,41 @@ class UiStateStore:
         if error:
             self.problem = error
             return {}
-        return data or {}
+        clean, dropped = self._clean(data or {})
+        if dropped:
+            self.problem = f"window-state keys ignored: {', '.join(sorted(dropped))}"
+        return clean
+
+    @staticmethod
+    def _clean(data):
+        """Drop values whose TYPE is not the one ``DEFAULTS`` promises.
+
+        ``read_json`` guarantees the file is a dict and nothing beyond that. Inside
+        it, a hand edit - and these files are meant to be hand-edited, they live
+        next to the executable - can leave any value any shape. Three of them used
+        to stop the app from starting at all: a list under ``page`` (unhashable as
+        a dict key), a list under ``conn_sort``, a string under ``event_sort``.
+        The promise at the top of this module is the exact opposite, so it is now
+        enforced instead of hoped for. Same shape as ``ProfileStore._clean``, which
+        has always done this for the other user file.
+
+        Only the TYPE is checked, deliberately. Measured: every wrong VALUE of the
+        right type already degrades gracefully - an unknown page id, a nonsense
+        geometry string, a negative sash position, a sort column that does not
+        exist - so validating further would add rules that catch nothing.
+
+        Unknown keys are KEPT. ``get`` only reads keys it knows, so they cost
+        nothing, and dropping them would silently discard state written by a newer
+        version of the app.
+        """
+        clean, dropped = {}, []
+        for key, value in data.items():
+            default = DEFAULTS.get(key)
+            if default is not None and not isinstance(value, type(default)):
+                dropped.append(str(key))
+                continue
+            clean[key] = value
+        return clean, dropped
 
     def get(self, key, default=None):
         value = self.data.get(key, DEFAULTS.get(key, default))

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -265,6 +265,15 @@ def _coerce_setting(key, value):
 def load_config_file(path):
     with open(path, encoding="utf-8") as f:
         data = json.load(f)
+    if not isinstance(data, dict):
+        # Valid JSON of the wrong shape. Without this check the next statement
+        # reaches ``data.items()`` and raises AttributeError - and the CLI catches
+        # ValueError and OSError, so the user got a raw Python traceback and exit
+        # RUNTIME(1) where the contract says CONFIG(3), against a comment in
+        # ``cli.py`` promising "a clear CLI error, never a raw traceback".
+        # A settings file that is a JSON ARRAY is not exotic: it is what anything
+        # writing one-entry-per-line produces.
+        raise ValueError(f"expected a JSON object, got {type(data).__name__}")
     s = dict(DEFAULT_SETTINGS)
     s.update({k: _coerce_setting(k, v) for k, v in data.items()
               if k in DEFAULT_SETTINGS})

--- a/tests/test_ondisk_formats.py
+++ b/tests/test_ondisk_formats.py
@@ -26,12 +26,40 @@ may cost you your settings, never your program.**
 validates every entry, drops what it cannot use and says so - and it is the shape
 the others now follow.
 """
+import io
 import json
 import os
 
+from beantester import exitcodes
+from beantester.cli import run_cli
 from beantester.gui.ui_state import DEFAULTS, UiStateStore
 from fakes import check
 from gui_harness import run_gui
+
+
+class _FakeClock:
+    """Virtual time, so a run that would sleep costs microseconds."""
+
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self):
+        return self.t
+
+    def sleep(self, seconds):
+        self.t += max(0.0, float(seconds))
+
+
+def cli(argv):
+    """Run the CLI in-process; returns ``(code, stdout, stderr)``.
+
+    In-process on purpose: an exception that escapes ``run_cli`` fails the test
+    with its own traceback, which is exactly the failure being guarded against.
+    """
+    clock = _FakeClock()
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(argv, sleep=clock.sleep, clock=clock, out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
 
 # Shapes a JSON file arrives in when something went wrong. Valid JSON of the
 # wrong type is the interesting half: the parser is happy, so nothing downstream
@@ -130,6 +158,40 @@ def test_a_broken_ui_state_file_never_stops_the_app_from_starting():
                 failures.append(f"{key}={bad!r}: {type(exc).__name__}: {exc}")
         assert not failures, "the app did not start: " + "; ".join(failures)
     """ % (POISONED_UI_STATE,))
+
+
+# --------------------------------------------------------------------------- #
+# the config file (--config)
+# --------------------------------------------------------------------------- #
+def test_a_broken_config_file_is_a_coded_error_not_a_traceback(tmp_path):
+    """Convention 18: every way of ending has a code from ``exitcodes.py``.
+
+    ``[1, 2, 3]``, ``"x"``, ``42``, ``null`` and ``true`` are all valid JSON, so
+    ``json.load`` was happy and the type error surfaced one line later at
+    ``data.items()`` - an AttributeError the CLI does not catch. The user got a
+    Python traceback and exit RUNTIME(1) where a bad config file means CONFIG(3),
+    and a CI/CD pipeline reading the exit code was told the tool had crashed
+    rather than that its config was wrong.
+    """
+    for label, text in BROKEN_JSON.items():
+        path = tmp_path / f"config_{label.replace(' ', '_')}.json"
+        path.write_text(text, encoding="utf-8")
+        code, out, err = cli(["--config", str(path), "--simulate", "--dry-run"])
+
+        check(f"{label}: a bad config file is CONFIG(3)", code == exitcodes.CONFIG,
+              f"(code={code}, stderr={err!r})")
+        check(f"{label}: it explains itself on stderr", "error:" in err, f"({err!r})")
+        check(f"{label}: stdout stays clean for the data channel", out == "",
+              f"({out!r})")
+
+
+def test_a_config_file_that_is_a_json_object_still_loads(tmp_path):
+    """The other side of the check: the fix must not reject real config files."""
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"loss": 5, "duration": 1}), encoding="utf-8")
+    code, out, err = cli(["--config", str(path), "--simulate", "--dry-run"])
+    check("a well-formed config file is accepted", code == exitcodes.OK,
+          f"(code={code}, stderr={err!r})")
 
 
 def test_a_ui_state_file_that_is_not_json_at_all_is_quarantined(tmp_path):

--- a/tests/test_ondisk_formats.py
+++ b/tests/test_ondisk_formats.py
@@ -1,0 +1,150 @@
+"""What the tool does with a user file that is broken (audit item #10).
+
+Four formats live on disk and belong to the user: the config file (``--config``,
+"Save/Load file"), a scenario, ``profiles.json`` and ``bean_network_tester_ui.json``.
+They are edited by hand on purpose - they sit next to the executable - they are
+copied between machines, they are written by other tools, and a process killed
+mid-write truncates them. ``jsonfile`` exists precisely for that. Nothing fuzzed
+it, and the gap was not theoretical:
+
+* a config file that was valid JSON but not an OBJECT (``[1, 2, 3]``, ``"x"``,
+  ``42``, ``null``) reached ``data.items()`` and left the CLI with a raw
+  ``AttributeError`` traceback and exit 1 - two contracts broken at once, the
+  comment right above that code ("never a raw traceback") and convention 18
+  (every way of ending has a code from ``exitcodes.py``; a bad config is
+  ``CONFIG(3)``);
+* ``ui.json`` holding a valid dict with the wrong TYPE under ``page``,
+  ``conn_sort`` or ``event_sort`` stopped the GUI from starting at all, against
+  a module docstring promising that corruption "must never break startup";
+* ``--dry-run`` reported "Configuration is valid" for a scenario file it had
+  never opened.
+
+The invariants below are what those three have in common: **a broken user file
+may cost you your settings, never your program.**
+
+``profiles.json`` is the format that already got this right - ``ProfileStore._clean``
+validates every entry, drops what it cannot use and says so - and it is the shape
+the others now follow.
+"""
+import json
+import os
+
+from beantester.gui.ui_state import DEFAULTS, UiStateStore
+from fakes import check
+from gui_harness import run_gui
+
+# Shapes a JSON file arrives in when something went wrong. Valid JSON of the
+# wrong type is the interesting half: the parser is happy, so nothing downstream
+# is warned.
+BROKEN_JSON = {
+    "a list": "[1, 2, 3]",
+    "a string": '"just a string"',
+    "a number": "42",
+    "null": "null",
+    "a boolean": "true",
+    "truncated": '{"loss": 1',
+    "empty file": "",
+    "utf-8 BOM": '﻿{"loss": 5}',
+    "not json at all": "<html>nope</html>",
+}
+
+# A dict whose VALUES are the wrong type for their key. This is what a hand edit
+# produces, and what read_json cannot catch: it checks the container, not what is
+# in it.
+POISONED_UI_STATE = {
+    "geometry": {"a": 1},
+    "page": [1, 2, 3],
+    "stats_page": 42,
+    "language": [],
+    "collapsed": "control",
+    "log_height": "big",
+    "conn_sort": [1, 2],
+    "event_sort": "kb",
+    "profile": {},
+}
+
+
+# --------------------------------------------------------------------------- #
+# ui.json
+# --------------------------------------------------------------------------- #
+def test_ui_state_drops_wrongly_typed_values_and_says_which(tmp_path):
+    """Keep what is usable, drop what is not, and report it - never raise."""
+    path = tmp_path / "ui.json"
+    payload = dict(POISONED_UI_STATE)
+    payload["page"] = [1, 2, 3]              # broken
+    payload["language"] = []                 # broken
+    payload["geometry"] = "800x600+0+0"      # GOOD: must survive
+    payload["unknown_future_key"] = {"anything": True}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    store = UiStateStore(str(path))
+
+    check("a usable value is kept", store.get("geometry") == "800x600+0+0",
+          f"({store.get('geometry')!r})")
+    check("a wrongly typed value falls back to its default",
+          store.get("page") == DEFAULTS["page"], f"({store.get('page')!r})")
+    check("the store says what it ignored", "page" in (store.problem or ""),
+          f"({store.problem!r})")
+    # Unknown keys are kept on purpose: `get` only reads keys it knows, and
+    # dropping them would discard state written by a newer version of the app.
+    check("an unknown key is preserved rather than discarded",
+          store.data.get("unknown_future_key") == {"anything": True},
+          f"({store.data.get('unknown_future_key')!r})")
+
+
+def test_every_ui_state_value_can_be_the_wrong_type(tmp_path):
+    """One key at a time, so a single tolerant key cannot hide an intolerant one."""
+    for key, bad in POISONED_UI_STATE.items():
+        path = tmp_path / f"ui_{key}.json"
+        path.write_text(json.dumps({key: bad}), encoding="utf-8")
+        store = UiStateStore(str(path))
+        check(f"{key}: the wrong type does not survive into the store",
+              store.get(key) == DEFAULTS[key],
+              f"(got {store.get(key)!r}, expected the default {DEFAULTS[key]!r})")
+
+
+def test_a_broken_ui_state_file_never_stops_the_app_from_starting():
+    """The invariant the module docstring promises, asserted through a real App.
+
+    Three of these used to raise on startup - a list under ``page`` is not even
+    hashable as a dict key - so the window never appeared and the user had a
+    traceback and no idea which file caused it.
+
+    Every case is driven in ONE subprocess: building the App is the expensive
+    part, and a fresh store per case is enough isolation.
+    """
+    run_gui("""
+        import json
+        import beantester.gui.ui_state as _ui
+
+        POISON = %r
+        path = _ui.UiStateStore.__init__.__defaults__[0]
+        failures = []
+        for key, bad in POISON.items():
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump({key: bad}, fh)
+            try:
+                other = bnt.App(tk.Tk())
+                other._tick()
+            except Exception as exc:
+                failures.append(f"{key}={bad!r}: {type(exc).__name__}: {exc}")
+        assert not failures, "the app did not start: " + "; ".join(failures)
+    """ % (POISONED_UI_STATE,))
+
+
+def test_a_ui_state_file_that_is_not_json_at_all_is_quarantined(tmp_path):
+    """The other half of the guarantee: unparseable content is moved aside, not
+    overwritten, so the user can still get their window layout back."""
+    for label, text in BROKEN_JSON.items():
+        path = tmp_path / f"ui_{label.replace(' ', '_')}.json"
+        path.write_text(text, encoding="utf-8")
+        store = UiStateStore(str(path))
+
+        check(f"{label}: the app still has usable state",
+              store.get("page") == DEFAULTS["page"], f"({store.get('page')!r})")
+        check(f"{label}: the failure is reported, not swallowed",
+              bool(store.problem), f"({store.problem!r})")
+        quarantined = [p for p in os.listdir(tmp_path)
+                       if p.startswith(path.stem) and ".corrupt-" in p]
+        check(f"{label}: the broken file was moved aside rather than clobbered",
+              bool(quarantined), f"(files: {sorted(os.listdir(tmp_path))})")

--- a/tests/test_ondisk_formats.py
+++ b/tests/test_ondisk_formats.py
@@ -194,6 +194,66 @@ def test_a_config_file_that_is_a_json_object_still_loads(tmp_path):
           f"(code={code}, stderr={err!r})")
 
 
+# --------------------------------------------------------------------------- #
+# the scenario file (--scenario), and what --dry-run is worth
+# --------------------------------------------------------------------------- #
+def test_dry_run_actually_opens_the_scenario_it_calls_valid(tmp_path):
+    """``--dry-run`` is the gate a pipeline runs before the real command.
+
+    It used to load the scenario only once the session had started, so every
+    broken scenario file - truncated, empty, a bare list - passed ``--dry-run``
+    with "Configuration is valid" and exit OK, then failed the real run with
+    SCENARIO(4). The check that exists to catch exactly this reported the
+    opposite of the truth.
+    """
+    for label, text in BROKEN_JSON.items():
+        path = tmp_path / f"scen_{label.replace(' ', '_')}.json"
+        path.write_text(text, encoding="utf-8")
+        code, out, err = cli(["--scenario", str(path), "--simulate", "--dry-run"])
+
+        check(f"{label}: --dry-run rejects it", code == exitcodes.SCENARIO,
+              f"(code={code}, stderr={err!r})")
+        check(f"{label}: it does NOT claim the configuration is valid",
+              "valid" not in out.lower(), f"({out!r})")
+
+
+def test_dry_run_and_a_real_run_agree_about_a_scenario(tmp_path):
+    """The property behind the fix: the gate and the gated must give the same
+    verdict, or the gate is worse than not having one."""
+    broken = tmp_path / "broken.json"
+    broken.write_text('{"steps": ', encoding="utf-8")
+    # The real schema: {"at": seconds, "settings": {...}}. Written out rather than
+    # guessed - the first draft of this test invented a shape, --dry-run rejected
+    # it correctly, and for a moment that looked like the fix rejecting good files.
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"steps": [{"at": 0, "settings": {"loss": 5}}]}),
+                    encoding="utf-8")
+
+    dry_broken, _, _ = cli(["--scenario", str(broken), "--simulate", "--dry-run"])
+    run_broken, _, _ = cli(["--scenario", str(broken), "--simulate", "--duration", "1"])
+    dry_good, _, _ = cli(["--scenario", str(good), "--simulate", "--dry-run"])
+
+    check("a broken scenario fails the dry run", dry_broken == exitcodes.SCENARIO,
+          f"({dry_broken})")
+    check("and it fails the real run the same way", run_broken == exitcodes.SCENARIO,
+          f"({run_broken})")
+    check("the two agree", dry_broken == run_broken,
+          f"(dry={dry_broken}, run={run_broken})")
+    check("a good scenario still passes the dry run", dry_good == exitcodes.OK,
+          f"({dry_good})")
+
+    # And the strongest form: the scenarios we ship must survive their own gate.
+    shipped = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                           "scenarios")
+    for name in sorted(os.listdir(shipped)):
+        if not name.endswith(".json"):
+            continue
+        code, _, err = cli(["--scenario", os.path.join(shipped, name),
+                            "--simulate", "--dry-run"])
+        check(f"shipped scenario {name} passes --dry-run", code == exitcodes.OK,
+              f"(code={code}, stderr={err!r})")
+
+
 def test_a_ui_state_file_that_is_not_json_at_all_is_quarantined(tmp_path):
     """The other half of the guarantee: unparseable content is moved aside, not
     overwritten, so the user can still get their window layout back."""


### PR DESCRIPTION
Audit item #10. Three commits, each a separate contract violation found by actually feeding the
tool broken files rather than by reading the code. `jsonfile` exists precisely for this and
nothing fuzzed it.

The common invariant: **a broken user file may cost you your settings, never your program.**

## 1. `fix(gui)`: a hand-edited `ui.json` must not stop the app from starting

`read_json` guarantees the file parses and is a dict, and nothing beyond that. `UiStateStore`
trusted the rest, while its own module docstring promises corruption "must never break startup,
so every failure degrades to the defaults". Measured by building a real `App` over a poisoned
file, three keys broke that outright:

| key | value | result |
|---|---|---|
| `page` | `[1, 2, 3]` | `TypeError: cannot use 'list' as a dict key` |
| `conn_sort` | `[1, 2]` | `TypeError: object is not iterable` |
| `event_sort` | `"kb"` | `ValueError: dictionary update sequence element #0 ...` |

The window never appeared and the traceback named none of the files involved. `UiStateStore._clean`
now drops wrongly typed values, records which keys it ignored (surfaced through the existing
`log.ui_state_problem`, so no new i18n) and keeps the rest - the same shape as `ProfileStore._clean`,
which has always done this for the other user file.

**Only the TYPE is checked, and that is measured, not cautious.** Every wrong VALUE of the right
type was tried first and already degrades gracefully: unknown page id, unknown language, nonsense
geometry, negative sash, a sort column that does not exist. Validating further would add rules that
catch nothing. Unknown keys are kept, so state written by a newer version is not discarded.

## 2. `fix(cli)`: a config file of the wrong shape is `CONFIG(3)`, not a traceback

`load_config_file` does a raw `json.load` and goes straight to `data.items()`. For `[1, 2, 3]`,
`"x"`, `42`, `null` or `true` the parse succeeds and the type error lands one line later as an
**AttributeError**, which `cli.py` does not catch. Measured on all five: a Python traceback and
exit **1 (RUNTIME)** where a bad config file is **CONFIG(3)**.

Two contracts at once - convention 18, and the comment directly above that `try` promising "a clear
CLI error, never a raw traceback". For a pipeline reading the exit code, that is being told the tool
crashed instead of being told its config is wrong. A settings file that is a JSON array is not
exotic; it is what anything writing one entry per line produces.

Deliberately NOT routed through `jsonfile.read_json`: quarantine is right for the app's own state
files, but silently moving aside a file the user named on the command line would be a surprise. The
GUI path already catches `Exception` and shows a dialog, so this was CLI only.

## 3. `fix(cli)`: `--dry-run` validates the scenario it calls valid

`--dry-run` is the gate a pipeline runs before the real command. It returned `OK` and printed
"Configuration is valid" for every broken scenario tried, because the scenario was loaded only
inside `_run_session`, which `--dry-run` returns before reaching. The same files correctly gave
`SCENARIO(4)` on a real run. **A gate whose verdict disagrees with the thing it gates is worse than
no gate.**

`--print-config` and `--save-config` return early as before and are left alone: neither claims the
configuration is valid, and a scenario is not part of the settings they handle.

**Treated as a fix, not a BREAKING change**, by the owner's decision: a script relying on the old
outcome is relying on the gate lying to it. No version bump.

## Verification

- Every fix verified by **mutation** - each reverted in turn, each reproducing its original symptom
  exactly (`the app did not start: page=[1, 2, 3]: TypeError...`, `AttributeError: 'list' object
  has no attribute 'items'`, `code=0` with "Configuration is valid").
- New `tests/test_ondisk_formats.py`, 8 tests: per-key type fuzzing on the store, the whole poison
  set driven through a real `App`, the unparseable half (quarantine, not clobber), every broken
  shape through `--config` and through `--scenario --dry-run`, dry run and real run agreeing, and
  **all seven shipped `scenarios/*.json` passing `--dry-run`** - the check that the fix does not
  start rejecting real files.
- Full suite: 595 -> 603 tests, green. Item 3 changes CLI behaviour, so the existing exit-code
  contract tests are the real check here; none moved.
- Both READMEs now state that `--dry-run` validates the scenario too.

## Recorded because it briefly misled me

The first draft of the scenario test invented a shape (`{"duration": 1, "loss": 5}`) instead of the
documented one (`{"at": seconds, "settings": {...}}`). `--dry-run` rejected it, correctly, and for a
moment that read as the fix rejecting good files. The shipped-scenario loop is the answer, because
it cannot be argued with.