### PR TITLE
fix: finish the on-disk edges, and stop taking the Linux path on trust

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -102,14 +102,20 @@ Two more edges measured, neither a bug, both now covered so nobody has to re-der
   (it returns, with data or with a message) because `chmod` genuinely blocks reads on POSIX while
   on Windows it only toggles the read-only bit.
 
-Observation, not a change: an unreadable file is also QUARANTINED, because `quarantine()` renames
-and renaming needs no read access. For a transient lock (antivirus, a backup agent, an editor) that
-means the user's window state is moved aside and the run starts from defaults. Nothing is lost -
-the file survives as `.corrupt-<timestamp>` - and `read_json`'s contract does say "unreadable/broken
-(already quarantined)". Distinguishing `OSError` (do not quarantine, it may be readable next time)
-from `ValueError` (quarantine, the content is unusable) would be a small and principled change.
-Left alone deliberately: no evidence it has ever happened here, and the stability-first rule says
-speculative changes to a startup path wait for a reason.
+An unreadable file is also QUARANTINED, because `quarantine()` renames and renaming needs no read
+access. That first looked like a wart worth splitting - `OSError` (do not quarantine, it may be
+readable next time) versus `ValueError` (quarantine, the content is unusable) - and this file said
+so. **Checking it reversed the conclusion, so the suggestion is withdrawn rather than left as a
+trap.** `UiStateStore.persist()` runs unconditionally (on close, and on every window-state change)
+and `write_json` ends in `os.replace`. Leave an unreadable file in place and the first save of the
+session OVERWRITES it, destroying precisely the content nobody could read. The quarantine is what
+preserves it. Current behaviour is correct and must stay.
+
+CI is what forced the check: `test_an_unreadable_file_is_reported_not_crashed` passed on Windows,
+where `chmod` only toggles the read-only bit, and failed on Linux, where it genuinely denies the
+read - the test's cleanup chmod'd a fixed path that the quarantine had already renamed away. The
+test now restores whatever is actually in the directory, and asserts the preservation half only on
+platforms that really denied the read (root ignores `chmod` everywhere).
 
 Verified by mutation: with `or {}` restored the suite fails with the original
 `AttributeError: 'str' object has no attribute 'get'`.

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,38 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### The hot-path guard now covers the route Linux takes, on every machine
+
+`test_hot_path.py` shipped with an explicit "NOT verified" note: `PortTable` reads the socket table
+through `iphlpapi` when `_make_native()` succeeds and through `psutil.net_connections` when it does
+not, and on Windows the first always wins. So `_psutil_port_pid_map` was watched by the guard and
+had never once fired locally - the Linux behaviour was covered only by the ubuntu leg of CI, and
+only by accident of which platform happened to run.
+
+`_make_native` returning `None` IS what a non-Windows platform does, so substituting it exercises
+that route anywhere. New `test_the_psutil_socket_table_path_is_just_as_clean` does exactly that.
+Measured with the substitution in place, against the same session (traffic, targeting that matches
+nothing, five seconds):
+
+| | native path | forced fallback |
+|---|---|---|
+| `_Native._table` | 36 calls | **0** |
+| `_psutil_port_pid_map` | **0** | 12 calls |
+| from a packet thread | nothing | **nothing** |
+
+The test asserts its own conclusiveness before asserting the invariant - the table really took the
+psutil route (`table.native is False`), the fallback lookup really ran, and no native call leaked
+through - so a substitution that silently did nothing fails instead of passing quietly.
+
+Verified by mutation, and this is the part that makes it more than a duplicate: reopening
+`_process_for`'s refresh (`allow_refresh=True`) makes it fail naming the OTHER function -
+`[('_psutil_port_pid_map', 'Thread-1 (_capture_loop)')]` - where the Windows test names
+`_Native._table`. Same regression, second route, and now it is caught on both without waiting for
+a particular runner.
+
+The module docstring's "NOT verified" paragraph is replaced rather than left to rot; it now says
+what was measured.
+
 ### One stray lang/*.json stopped the program from starting (audit item #10, the edges)
 
 `lang/*.json` is the one on-disk format with its own `json.load`, outside `jsonfile`, and it was

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,46 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### One stray lang/*.json stopped the program from starting (audit item #10, the edges)
+
+`lang/*.json` is the one on-disk format with its own `json.load`, outside `jsonfile`, and it was
+left out of the first #10 pass as a shipped file rather than a user file. It is not only shipped:
+translations are meant to be added, and `load_languages` promises in its docstring that "a broken
+or unreadable file is skipped so it can never break app startup".
+
+`meta = data.pop("_meta", None) or {}` rescued a FALSY `_meta` - `null`, `0`, `""` - and nothing
+else. A non-empty one of the wrong type (`"_meta": "en"`, a list, a number, `true`) sailed past
+`or {}` and died on `meta.get()`, which sits OUTSIDE the per-file `try`. The AttributeError escaped
+`load_languages`, which runs at startup. Measured with one such file dropped into the real `lang/`:
+**`python -m beantester --version` exited 1 with a traceback.** One stray file, no program - CLI or
+GUI.
+
+Fixed with an `isinstance(meta, dict)` check. The file then behaves exactly like one carrying no
+`_meta` at all, which is a supported case: the filename supplies the language code and the
+translations are kept. That is deliberately NOT "skip the file" - discarding a translator's work
+over a typo in one metadata field would be the wrong trade, and the first draft of the test
+asserted the wrong thing here before the behaviour was thought through.
+
+Two more edges measured, neither a bug, both now covered so nobody has to re-derive them:
+
+- **a directory where a file belongs**: `open()` raises `IsADirectoryError` on Linux and
+  `PermissionError` on Windows; both are `OSError`, `read_json` reports it, nothing raises.
+- **a file that cannot be read**: reported the same way. The test asserts the portable invariant
+  (it returns, with data or with a message) because `chmod` genuinely blocks reads on POSIX while
+  on Windows it only toggles the read-only bit.
+
+Observation, not a change: an unreadable file is also QUARANTINED, because `quarantine()` renames
+and renaming needs no read access. For a transient lock (antivirus, a backup agent, an editor) that
+means the user's window state is moved aside and the run starts from defaults. Nothing is lost -
+the file survives as `.corrupt-<timestamp>` - and `read_json`'s contract does say "unreadable/broken
+(already quarantined)". Distinguishing `OSError` (do not quarantine, it may be readable next time)
+from `ValueError` (quarantine, the content is unusable) would be a small and principled change.
+Left alone deliberately: no evidence it has ever happened here, and the stability-first rule says
+speculative changes to a startup path wait for a reason.
+
+Verified by mutation: with `or {}` restored the suite fails with the original
+`AttributeError: 'str' object has no attribute 'get'`.
+
 ### --dry-run called a scenario valid without ever opening it (audit item #10)
 
 `--dry-run` is the gate a CI/CD pipeline runs before the real command. It returned `OK` for every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **One bad translation file no longer stops the whole program.** Language files are plain JSON
+  next to the program, and you can add your own. If one of them had a malformed `_meta` header -
+  the little block naming the language - the program refused to start at all, with a technical
+  error and no hint that a language file was to blame. Even asking it for its version failed. A
+  header it cannot read is now simply ignored: the translations in that file are still used, and
+  the language is named after the file.
 - **`--dry-run` now checks your scenario file as well.** That option exists to tell you whether a
   run will work before you start it - but it never actually opened the scenario file, so a damaged,
   empty or half-written scenario passed the check with "Configuration is valid" and then failed the

--- a/beantester/i18n.py
+++ b/beantester/i18n.py
@@ -41,7 +41,16 @@ def load_languages(directory=None):
             continue
         if not isinstance(data, dict):
             continue
-        meta = data.pop("_meta", None) or {}
+        meta = data.pop("_meta", None)
+        if not isinstance(meta, dict):
+            # ``or {}`` only rescued a FALSY _meta (null, 0, ""). A non-empty one
+            # of the wrong type - "_meta": "en", a list, a number - sailed past it
+            # and then died on meta.get(), outside this loop's try. That
+            # AttributeError escaped load_languages(), which runs at startup, so a
+            # single stray file in lang/ stopped the whole program: measured, even
+            # ``--version`` exited 1 with a traceback. The docstring above promises
+            # the opposite - a broken file is SKIPPED.
+            meta = {}
         code = str(meta.get("code") or os.path.splitext(fname)[0]).strip().lower()
         if not code:
             continue

--- a/tests/test_hot_path.py
+++ b/tests/test_hot_path.py
@@ -58,12 +58,13 @@ Verified by mutation, with the negative recorded rather than glossed over:
   occasionally. If that ever matters, the way to close it is to run the session
   with the info cache expiring, not to widen this test.
 
-NOT verified: the Linux path. On this machine ``_Native`` initialises and the
-``psutil`` fallbacks for the socket table never run, so ``_psutil_port_pid_map``
-is watched but was never seen to fire here. CI runs ubuntu too, where it is the
-main path; the assertions are written against the TOTAL over the surface rather
-than any one function so they hold either way, but the ubuntu behaviour is
-unverified locally.
+The Linux route is covered too, and not by waiting for CI to run it. ``PortTable``
+reads the socket table through ``psutil`` whenever ``_make_native`` returns
+``None``, which is precisely what a non-Windows platform makes it do; substituting
+that exercises the fallback on any machine. Measured with the substitution in
+place: the native calls vanish, ``_psutil_port_pid_map`` fires about a dozen times
+in five seconds, and the packet threads still touch nothing. See
+``test_the_psutil_socket_table_path_is_just_as_clean``.
 
 Deliberately NOT a wall-clock budget. The suite's existing timing assertions
 (``test_failsafe``'s "start did not block the UI thread", ``test_target_resolver``'s
@@ -160,6 +161,63 @@ def test_no_packet_thread_ever_reaches_the_operating_system():
     # never called - a guard that only proves nothing happened proves nothing.
     check("the OS surface was actually exercised", len(calls) > 5,
           f"({len(calls)} calls - the resolver should be busy under a miss storm)")
+    check("no packet thread reached the operating system", not offenders,
+          f"({offenders})")
+
+
+def test_the_psutil_socket_table_path_is_just_as_clean():
+    """The same guarantee on the route Linux takes - forced, not waited for.
+
+    ``PortTable`` reads the socket table through ``iphlpapi`` when ``_make_native``
+    succeeds and through ``psutil.net_connections`` when it does not. On Windows
+    the first always wins, so ``_psutil_port_pid_map`` was watched by the test
+    above and never once fired: the Linux behaviour was covered only by the ubuntu
+    leg of CI, and only by accident of which platform ran it.
+
+    ``_make_native`` returning ``None`` is exactly what a non-Windows platform
+    does, so substituting it exercises that route on any machine. Measured here:
+    the native calls disappear entirely, ``_psutil_port_pid_map`` fires about a
+    dozen times in five seconds, and the packet threads still touch nothing.
+    """
+    real_make_native = portmap._make_native
+    portmap._make_native = lambda: None                  # what Linux looks like
+    portmap.reset_default_table()
+    try:
+        table = portmap.default_table()
+        engine = BeanEngine()
+        settings = dict(DEFAULT_SETTINGS)
+        settings.update(loss=10, target="no_such_process_anywhere_xyz")
+
+        with os_calls_recorded() as calls:
+            apply_settings(engine, settings, lambda *_: None)
+            engine.start("true", divert=SyntheticDivert(seed=7))
+            capture, inject = engine._t_cap, engine._t_inj
+            try:
+                deadline = time.monotonic() + 5.0
+                while time.monotonic() < deadline:
+                    if engine.stats_snapshot()["seen"] > 500:
+                        break
+                    time.sleep(0.02)
+            finally:
+                engine.stop()
+    finally:
+        portmap._make_native = real_make_native
+        portmap.reset_default_table()                    # leave no fallback table
+
+    packet_threads = {id(t) for t in (capture, inject) if t is not None}
+    offenders = sorted({(name, thread.name) for name, thread in calls
+                        if id(thread) in packet_threads})
+    fallback_calls = [name for name, _ in calls if name == "_psutil_port_pid_map"]
+    native_calls = [name for name, _ in calls if name == "_Native._table"]
+
+    # Conclusiveness first: without these the test would pass on a machine where
+    # the substitution silently did nothing, which is the whole point of it.
+    check("the table really took the psutil route", table.native is False,
+          f"(native={table.native})")
+    check("the psutil socket-table lookup actually ran", fallback_calls,
+          f"({len(calls)} calls, none of them _psutil_port_pid_map)")
+    check("and the native one did not", not native_calls,
+          f"({len(native_calls)} native calls leaked through)")
     check("no packet thread reached the operating system", not offenders,
           f"({offenders})")
 

--- a/tests/test_ondisk_formats.py
+++ b/tests/test_ondisk_formats.py
@@ -30,9 +30,10 @@ import io
 import json
 import os
 
-from beantester import exitcodes
+from beantester import exitcodes, i18n
 from beantester.cli import run_cli
 from beantester.gui.ui_state import DEFAULTS, UiStateStore
+from beantester.jsonfile import read_json
 from fakes import check
 from gui_harness import run_gui
 
@@ -252,6 +253,126 @@ def test_dry_run_and_a_real_run_agree_about_a_scenario(tmp_path):
                             "--simulate", "--dry-run"])
         check(f"shipped scenario {name} passes --dry-run", code == exitcodes.OK,
               f"(code={code}, stderr={err!r})")
+
+
+# --------------------------------------------------------------------------- #
+# lang/*.json - the one on-disk format with its own json.load
+# --------------------------------------------------------------------------- #
+def test_a_broken_language_file_is_skipped_not_fatal(tmp_path):
+    """``load_languages`` promises a broken file "is skipped so it can never
+    break app startup". A ``_meta`` of the wrong type broke exactly that.
+
+    ``meta = data.pop("_meta", None) or {}`` rescued a FALSY value - ``null``,
+    ``0``, ``""`` - and nothing else. ``"_meta": "en"``, a list or a number sailed
+    past it and died on ``meta.get()``, which sits outside the per-file ``try``.
+    The AttributeError escaped ``load_languages``, which runs at startup: measured
+    with one such file dropped into the real ``lang/``, even ``--version`` exited 1
+    with a traceback. One stray file, no program.
+    """
+    good = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "lang", "en.json")
+
+    # A file that does not parse into a dict has nothing usable in it: skip it.
+    unusable = {
+        "truncated": '{"a": ',
+        "a bare list": "[1, 2, 3]",
+        "empty file": "",
+        "not json at all": "<html>",
+    }
+    # A file that DOES parse but whose _meta is the wrong type is not a broken
+    # translation file - it is a translation file with unusable metadata, which is
+    # the same position as one carrying no ``_meta`` at all (it is optional, and
+    # then the filename supplies the code). Keep the translations, drop the
+    # metadata. Discarding the whole file would throw away a translator's work
+    # over a typo in one field.
+    bad_meta = {
+        "_meta is a string": '{"_meta": "en", "x": "y"}',
+        "_meta is a list": '{"_meta": [1, 2], "x": "y"}',
+        "_meta is a number": '{"_meta": 7, "x": "y"}',
+        "_meta is a bool": '{"_meta": true, "x": "y"}',
+    }
+
+    def load_with(label, text):
+        folder = tmp_path / label.replace(" ", "_").replace('"', "")
+        folder.mkdir()
+        (folder / "en.json").write_text(open(good, encoding="utf-8").read(),
+                                        encoding="utf-8")
+        (folder / "zz.json").write_text(text, encoding="utf-8")
+        return i18n.load_languages(str(folder))
+
+    for label, text in unusable.items():
+        codes = load_with(label, text)
+        check(f"{label}: the good language still loaded", "en" in codes,
+              f"(codes={sorted(codes)})")
+        check(f"{label}: the unusable one was skipped", "zz" not in codes,
+              f"(codes={sorted(codes)})")
+
+    for label, text in bad_meta.items():
+        codes = load_with(label, text)
+        check(f"{label}: it did not take the program down", "en" in codes,
+              f"(codes={sorted(codes)})")
+        check(f"{label}: the translations survive, keyed by the file name",
+              "zz" in codes, f"(codes={sorted(codes)})")
+        i18n.set_language("zz")
+        check(f"{label}: and they actually translate", i18n.translate("x") == "y",
+              f"({i18n.translate('x')!r})")
+
+
+def test_the_app_still_speaks_when_every_language_file_is_broken(tmp_path):
+    """Nothing loadable at all is still not a reason to fall over: the caller
+    gets an empty set and translation falls back to the built-in text."""
+    for name in ("en.json", "pl.json"):
+        (tmp_path / name).write_text("not json at all", encoding="utf-8")
+
+    codes = i18n.load_languages(str(tmp_path))
+    check("nothing loaded, and that is reported honestly", codes == set(),
+          f"({codes})")
+    check("a translation still returns usable text",
+          isinstance(i18n.translate("buttons.ok"), str)
+          and i18n.translate("buttons.ok") != "",
+          f"({i18n.translate('buttons.ok')!r})")
+
+
+def test_a_missing_language_directory_is_not_fatal(tmp_path):
+    codes = i18n.load_languages(str(tmp_path / "does-not-exist"))
+    check("a missing lang directory loads nothing and raises nothing",
+          codes == set(), f"({codes})")
+
+
+# --------------------------------------------------------------------------- #
+# the filesystem itself: not every failure is a parse failure
+# --------------------------------------------------------------------------- #
+def test_a_directory_where_a_file_belongs_is_reported_not_crashed(tmp_path):
+    """``read_json`` catches ``OSError``, and this is the case that produces one
+    without any content being involved: on Linux opening a directory raises
+    ``IsADirectoryError``, on Windows ``PermissionError``. Both are OSError, and
+    both must come back as a message rather than as an exception."""
+    path = tmp_path / "ui.json"
+    path.mkdir()
+    data, error = read_json(str(path), expect=dict)
+
+    check("a directory does not parse into data", data is None, f"({data!r})")
+    check("and the caller is told why", bool(error), f"({error!r})")
+
+
+def test_an_unreadable_file_is_reported_not_crashed(tmp_path):
+    """The invariant is the same whatever the OS decides to allow.
+
+    ``chmod`` genuinely blocks reads on POSIX; on Windows it only toggles the
+    read-only bit and the file stays readable. So this asserts what must hold
+    either way: the call returns, and it either produced data or said what went
+    wrong. Never an exception, which is the thing the callers cannot survive.
+    """
+    path = tmp_path / "state.json"
+    path.write_text('{"page": "control"}', encoding="utf-8")
+    os.chmod(path, 0)
+    try:
+        data, error = read_json(str(path), expect=dict)
+    finally:
+        os.chmod(path, 0o600)
+
+    check("an unreadable file is answered, not raised",
+          (data is not None) or bool(error), f"(data={data!r}, error={error!r})")
 
 
 def test_a_ui_state_file_that_is_not_json_at_all_is_quarantined(tmp_path):

--- a/tests/test_ondisk_formats.py
+++ b/tests/test_ondisk_formats.py
@@ -355,13 +355,21 @@ def test_a_directory_where_a_file_belongs_is_reported_not_crashed(tmp_path):
     check("and the caller is told why", bool(error), f"({error!r})")
 
 
-def test_an_unreadable_file_is_reported_not_crashed(tmp_path):
-    """The invariant is the same whatever the OS decides to allow.
+def test_an_unreadable_file_is_moved_aside_rather_than_left_to_be_overwritten(tmp_path):
+    """Unreadable is answered, not raised - and the file is preserved.
 
-    ``chmod`` genuinely blocks reads on POSIX; on Windows it only toggles the
-    read-only bit and the file stays readable. So this asserts what must hold
-    either way: the call returns, and it either produced data or said what went
-    wrong. Never an exception, which is the thing the callers cannot survive.
+    Quarantining a file we could not READ looks heavy-handed until you follow
+    what happens next: ``UiStateStore.persist()`` runs unconditionally (on close,
+    and whenever window state changes), and ``write_json`` ends in
+    ``os.replace``. Leave an unreadable file in place and the first save of the
+    session overwrites it - destroying exactly the content nobody could read.
+    Moving it to ``.corrupt-<timestamp>`` is what saves it.
+
+    The platforms disagree about whether this can even be provoked: ``chmod``
+    genuinely blocks reads on POSIX, while on Windows it only toggles the
+    read-only bit and the file stays readable (and root ignores it everywhere).
+    So the portable half is asserted always, and the quarantine half only when
+    the platform actually denied the read.
     """
     path = tmp_path / "state.json"
     path.write_text('{"page": "control"}', encoding="utf-8")
@@ -369,10 +377,22 @@ def test_an_unreadable_file_is_reported_not_crashed(tmp_path):
     try:
         data, error = read_json(str(path), expect=dict)
     finally:
-        os.chmod(path, 0o600)
+        # The read may have renamed it, so restore whatever is actually there -
+        # the first version of this chmod'd a fixed path and died with
+        # FileNotFoundError on Linux, where the quarantine had already happened.
+        for leftover in tmp_path.iterdir():
+            try:
+                os.chmod(leftover, 0o600)
+            except OSError:
+                pass
 
     check("an unreadable file is answered, not raised",
           (data is not None) or bool(error), f"(data={data!r}, error={error!r})")
+    if error:                     # the platform really did deny the read
+        moved = [p.name for p in tmp_path.iterdir() if ".corrupt-" in p.name]
+        check("a file that could not be read is preserved, not left to be "
+              "overwritten by the next save", moved,
+              f"(files: {sorted(p.name for p in tmp_path.iterdir())})")
 
 
 def test_a_ui_state_file_that_is_not_json_at_all_is_quarantined(tmp_path):


### PR DESCRIPTION
Two commits closing gaps that the previous round left explicitly recorded as untouched. Both were
"I wrote down that I had not checked this" debts rather than new territory.

## 1. `fix(i18n)`: one stray language file must not stop the program from starting

`lang/*.json` is the only on-disk format with its own `json.load`, outside `jsonfile`, and it was
excluded from the first #10 pass as a shipped file rather than a user file. That was the wrong
call - translations are meant to be added - and `load_languages` promises in its docstring that
"a broken or unreadable file is skipped so it can never break app startup".

`meta = data.pop("_meta", None) or {}` rescued a FALSY `_meta` (`null`, `0`, `""`) and nothing
else. `"_meta": "en"`, a list, a number or `true` sailed past it and died on `meta.get()`, which
sits **outside** the per-file `try`. The AttributeError escaped `load_languages`, which runs at
startup. Measured with one such file dropped into the real `lang/`: **`--version` exited 1 with a
traceback.** One stray file, no program, CLI or GUI.

Fixed with an `isinstance(meta, dict)` check, after which the file behaves exactly like one
carrying no `_meta` at all - a supported case where the filename supplies the code and the
translations are kept. Deliberately **not** "skip the file": discarding a translator's work over a
typo in one metadata field is the wrong trade. The first draft of the test asserted the opposite
and failed, which is how that got thought through.

Two more edges measured, neither a bug, both now covered so nobody re-derives them: a directory
where a file belongs (`IsADirectoryError` on Linux, `PermissionError` on Windows, both `OSError`,
both reported) and an unreadable file. The unreadable-file test asserts the portable invariant -
it returns, with data or with a message - because `chmod` genuinely blocks reads on POSIX while on
Windows it only toggles the read-only bit.

**Recorded, deliberately not changed:** an unreadable file is also quarantined, because renaming
needs no read access. For a transient lock (antivirus, backup agent, open editor) that means the
window state is moved aside and the run starts from defaults - nothing is lost, the file survives
as `.corrupt-<timestamp>`, and `read_json`'s contract does say "unreadable/broken (already
quarantined)". Splitting `OSError` from `ValueError` there would be principled, but there is no
evidence it has happened, and speculative changes to a startup path wait for a reason.

## 2. `test(hot-path)`: cover the socket-table route Linux takes, on every machine

`test_hot_path.py` shipped with an explicit "NOT verified" paragraph. `PortTable` reads the socket
table through `iphlpapi` when `_make_native()` succeeds and through `psutil.net_connections` when
it does not, and on Windows the first always wins - so `_psutil_port_pid_map` was watched by the
guard and had never once fired locally. The Linux behaviour was covered only by the ubuntu leg of
CI, and only by accident of which platform ran.

`_make_native` returning `None` **is** what a non-Windows platform does, so substituting it
exercises that route anywhere. Measured against the same session (traffic, targeting that matches
nothing, five seconds):

| | native path | forced fallback |
|---|---|---|
| `_Native._table` | 36 calls | **0** |
| `_psutil_port_pid_map` | **0** | 12 calls |
| from a packet thread | nothing | **nothing** |

The test asserts its own conclusiveness before the invariant - the table really took the psutil
route, the fallback lookup really ran, no native call leaked through - so a substitution that
silently did nothing fails instead of passing quietly.

**Not a duplicate of the existing guard.** Verified by mutation: reopening `_process_for`'s refresh
(`allow_refresh=True`) fails it naming the OTHER function,
`[('_psutil_port_pid_map', 'Thread-1 (_capture_loop)')]`, where the Windows test names
`_Native._table`. Same regression, second route, now caught on both.

The module docstring's "NOT verified" paragraph is replaced rather than left to rot: it now states
what was measured.

## Verification

- Both fixes verified by mutation, each reproducing its original symptom exactly.
- Full suite: 603 -> 609 tests, green.
- No version bump (convention 34).