### PR TITLE
docs: audit PROJECT_NOTES against the code, and measure the numbers it asserted

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,53 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### PROJECT_NOTES audit, part 2: measured numbers, and the coverage gate to 80
+
+Every "costs N ms" in the audit's blast radius was re-measured instead of trusted. Conditions
+are now attached to each figure (Win11 AMD64, CPython 3.14.6, median of 7), because a number
+without conditions cannot be re-verified and the next session cannot tell drift from hardware.
+
+- **`engine.connections_snapshot(limit=None)` was documented at ~25 ms "at the cap"; it is
+  0.7 ms** (2.4 ms at 500k). `conns.py` repeated the same claim as "~70 ms for a 500 000-row
+  copy" - wrong by ~30x under every interpretation (`list(values())` 2.3 ms, `dict()` 6.4 ms,
+  per-row copy 222 ms at 500k). Left as an argument for moving the snapshot back onto the UI
+  thread, which would have been a real regression.
+- The decision survives for a **different and verified** reason, now written down instead:
+  `connections_snapshot()` acquires the engine's `_clock`, the same lock the capture thread
+  takes on every logged packet, so taking it on the UI thread makes the UI queue behind the
+  capture thread. Cheap to copy, still wrong to copy there.
+- **`views.filter_sort_connections` kept its heap-vs-sort ratio test** - re-measurement confirms
+  the crossover (top 400: 12.6 ms heap vs 27.7 ms sort; top 50 000: 130.6 ms heap vs 28.0 ms
+  sort). Only the absolute figures were dated. The docstring now carries a table plus a warning
+  that first bit this audit: benchmark it with keys from a tiny range and Timsort exploits the
+  runs, making the sort column look artificially fast and the optimisation look pointless.
+- **Coverage gate raised 77 -> 80.** Measured with `COVERAGE_PROCESS_START`: **83.03%**
+  (83.07% on re-run), so the gate keeps its ~3-point margin for subprocess-coverage variance.
+  Also measured the counterfactual the comment asserted without evidence: **without** the env
+  var the same suite reports **45%**, not the 51% claimed. Both numbers, and their conditions,
+  now live in `pyproject.toml` only.
+- Notes-side fixes with no code change: the connection table's "max 400 rows" (stated twice)
+  is a limit removed when the tables were virtualised - `row_limit` defaults to 50 000, ranges
+  0-1 000 000 and 0 means no limit; the scroll cost now has one source (`sortable_tree.py`)
+  instead of two that disagreed (0.8 ms vs ~1 ms).
+
+### PROJECT_NOTES audit, part 3: a mechanical guard for the note itself
+
+`PROJECT_NOTES.md` is git-ignored (private Doc repo), so a pytest test would be skipped in CI
+forever and would name a private file inside the public suite. The guard is therefore a Stop
+hook, `.claude/hooks/check_notes.py`, next to the existing `check_changelog.py`; it exits
+silently when the file is absent. Neither the hook nor the note is part of this repository -
+this entry is the public record that they exist.
+
+It refuses to end a turn when the note drifts in a way a machine can see: a named `tests/*.py`
+that does not exist, a named `file.py::test_name` that does not exist, a package module the
+note never mentions (the rule `test_readme_guards.py` already applies to the READMEs, which is
+exactly why the README tree stayed right while the note's lost `crashlog.py`, `gui/labels.py`
+and `gui/rates.py`), and a registered window the note never mentions (`event_log` - the window
+whose docstring says "COPY THIS FILE to make a new one" - was undocumented, so the note pointed
+newcomers at a worse template). All four checks verified by mutation: green on the real note,
+red on each injected drift. It deliberately does not try to check prose.
+
 ### PROJECT_NOTES audit, part 1: prose that would have made the next session write a bug
 
 A full claim-by-claim audit of `PROJECT_NOTES.md` against the code. Convention 5 ("every

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,39 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### PROJECT_NOTES audit, part 1: prose that would have made the next session write a bug
+
+A full claim-by-claim audit of `PROJECT_NOTES.md` against the code. Convention 5 ("every
+`because` is a claim - check it or do not write it") applied to the note itself. This part
+covers the findings that actively mis-instruct; numbers, stale lists and undocumented
+mechanisms follow in their own commits.
+
+- **Convention 16 was backwards about labels.** It told the next session to set
+  `state="disabled"` on field labels. The code deliberately does the opposite: a
+  state-disabled `ttk.Label` paints a FILLED BOX, so `ControlForm._apply_toggle_state` and
+  `apply_overrides` swap the style to `CardOff.TLabel` instead, and
+  `test_an_overridden_field_is_visibly_disabled` even asserts `state is None` on the label.
+  The convention also cited `test_gui_layout.py::test_disabled_fields_are_visibly_disabled`
+  as its guard - **that test has never existed**. Rewritten to separate the field rule
+  (state + a `disabled` map) from the label rule (style swap, never state).
+- **The same stale claim lived in `theme.py`**, five lines below the correct one: the comment
+  above the label `disabled` maps said field labels "are set to state=disabled together with
+  their entries". Nothing in the GUI sets `state` on a label. Comment corrected to say what
+  the maps actually are: defensive, and free.
+- Measured, so the note can stop guessing: removing the `disabled` foreground maps for EVERY
+  label style leaves the whole suite AND `smoke_gui.py` green. The convention now says it has
+  no guard instead of naming one.
+- **Convention 40's guard covered half of what it claimed.**
+  `test_shortcut_buttons_advertise_their_key` asserted on `btn_start` and `btn_apply` only, so
+  dropping `shortcut="Ctrl+S"` from the Save button kept the suite green - verified by
+  mutation. The test now drives a table of all four shortcut buttons and fails naming the
+  offender; re-run against the same mutation it goes red. "Save file" / "Load file" moved from
+  local variables to `App.btn_save` / `App.btn_load` so the guard can reach them.
+- **Convention 42 described a replaced implementation:** `icon.make_gear_icon` is an
+  anti-aliased RGBA PNG built with stdlib `zlib`/`struct`, not "plain `PhotoImage.put`". The
+  per-pixel `put` version had no alpha and rasterised jagged teeth; it survives only as a
+  fallback for a Tk build that cannot read PNG.
+
 ### The hot-path guard now covers the route Linux takes, on every machine
 
 `test_hot_path.py` shipped with an explicit "NOT verified" note: `PortTable` reads the socket table

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -289,14 +289,21 @@ class BeanEngine:
         ``limit=<int>``  the ``limit`` most recently active flows, newest first.
                          Uses ``heapq.nlargest``: O(n log limit), not a full sort
                          of a table that may hold 200 000 rows.
-        ``limit=None``   every flow, UNSORTED - a pointer copy, ~25 ms at the cap.
+        ``limit=None``   every flow, UNSORTED - a pointer copy, cheap (see below).
                          This is what the virtualised tables ask for: they sort by
                          the column the user picked anyway, so sorting here as well
-                         was the same 100 ms of work done twice per refresh.
+                         was the same work done twice per refresh.
 
         The copy is taken under the lock; any sorting happens outside it. A sort
         under ``_clock`` would stall the CAPTURE thread, and a stalled capture
-        thread means WinDivert is queueing the user's packets into a void.
+        thread means WinDivert is queueing the user's packets into a void. THAT is
+        why the sort is outside - not the cost of the copy, which is small:
+
+        Measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, synthetic rows, median of
+        7): the pointer copy is **0.7 ms at the 200k cap** and 2.4 ms at 500k, while
+        a full sort of the same 200k rows through ``views.filter_sort_connections``
+        is ~29 ms. An earlier revision of this docstring claimed ~25 ms for the copy
+        and ~100 ms for the sort; neither reproduced.
         """
         with self._clock:
             values = list(self._conns.values())

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -424,12 +424,17 @@ class App:
                                     command=lambda: self.apply_if_running(announce=True))
         self.btn_apply.pack(side="left", padx=scaled(8))
         add_tooltip(self.btn_apply, "tips.apply", shortcut="Ctrl+Enter")
-        load = ttk.Button(bar, text=T("buttons.load_file"), command=self.load_config_file)
-        load.pack(side="right")
-        save = ttk.Button(bar, text=T("buttons.save_file"), command=self.save_config_file)
-        save.pack(side="right", padx=scaled(6))
-        add_tooltip(load, "tips.load_config", shortcut="Ctrl+O")
-        add_tooltip(save, "tips.save_config", shortcut="Ctrl+S")
+        # Kept on self (like btn_start/btn_apply) so the convention-40 guard can
+        # assert that every shortcut button advertises its key - it used to reach
+        # only the two buttons that happened to have attributes.
+        self.btn_load = ttk.Button(bar, text=T("buttons.load_file"),
+                                   command=self.load_config_file)
+        self.btn_load.pack(side="right")
+        self.btn_save = ttk.Button(bar, text=T("buttons.save_file"),
+                                   command=self.save_config_file)
+        self.btn_save.pack(side="right", padx=scaled(6))
+        add_tooltip(self.btn_load, "tips.load_config", shortcut="Ctrl+O")
+        add_tooltip(self.btn_save, "tips.save_config", shortcut="Ctrl+S")
         # "About" lives HERE, not in the header. The header is where the donate
         # button already gets clipped at 1366x768 (see _fit_header), and the one
         # window carrying our LGPL notice may not be the one that falls off the

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -309,11 +309,16 @@ class ConnsPage:
             return
         self._last_build = now
         self._model.request({
-            # The ENGINE goes to the worker, not a snapshot of it: taking the
-            # snapshot is itself O(n) (a 500 000-row copy costs ~70 ms), and doing
-            # that here would put back on the UI thread most of what moving the
-            # sort off it just saved. connections_snapshot() takes its own lock, so
-            # the worker can call it safely.
+            # The ENGINE goes to the worker, not a snapshot of it - but NOT because
+            # the copy is expensive. It is not: measured 2026-07-21 (Win11 AMD64,
+            # CPython 3.14.6, median of 7) a pointer copy is 0.7 ms at the 200k cap
+            # and 2.4 ms at 500k. This comment used to claim ~70 ms, which is wrong
+            # by a factor of ~30 and would justify moving the call back here.
+            # The real reason is the LOCK: connections_snapshot() acquires the
+            # engine's _clock, the same lock the capture thread takes on every
+            # logged packet. Taking the snapshot here would make the UI THREAD queue
+            # behind the capture thread. On the worker that wait costs nobody a
+            # frame, and the worker may call it safely for exactly that reason.
             "engine": app.engine,
             "query": app.conn_query,
             "sort": dict(self.table.sort),

--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -107,8 +107,11 @@ def init_style(root=None):
     s.configure("Unit.TLabel", background=BG2, foreground=MUT, font=(FONT, 9))
     # the "?" syntax help used to melt into the background
     s.configure("Help.TLabel", background=BG2, foreground=ACC, font=(FONT, 9, "bold"))
-    # a disabled label must grey out too (the field labels next to a switched-off
-    # section are set to state=disabled together with their entries)
+    # Defensive only: NOTHING in this tool switches a label with `state` today.
+    # A switched-off field label is greyed by swapping its style to CardOff.TLabel
+    # (see just above, and ControlForm._apply_toggle_state / apply_overrides),
+    # precisely because a state-disabled ttk.Label paints a filled box. These maps
+    # cost nothing and keep a label readable if some future code does set state.
     for label_style in ("TLabel", "Card.TLabel", "Unit.TLabel", "Hint.TLabel",
                         "Muted.TLabel", "Help.TLabel"):
         s.map(label_style, foreground=[("disabled", DIS_FG)])

--- a/beantester/views.py
+++ b/beantester/views.py
@@ -157,10 +157,25 @@ def filter_sort_connections(conns, query="", sort_col="bytes", reverse=True,
 
     ``limit`` (0 = none) caps the result AND is used to pick the cheaper strategy:
     a partial selection (``heapq``) beats a full sort only when the limit is small
-    next to the input. Measured on 200 000 rows: taking the top 400 costs 28 ms
-    with ``nlargest`` against 107 ms with a sort, but taking the top 50 000 costs
-    371 ms with ``nlargest`` against 123 ms with a sort. Hence the ratio test
-    rather than "always use the heap".
+    next to the input. Hence the ratio test rather than "always use the heap".
+
+    Re-measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, 200 000 synthetic rows with
+    well-spread keys, median of 7):
+
+    ======  ==========  ==============
+    top N   nlargest    sort + slice
+    ======  ==========  ==============
+       400  12.6 ms     27.7 ms
+     5 000  23.4 ms     26.7 ms
+    50 000  130.6 ms    28.0 ms
+    ======  ==========  ==============
+
+    The crossover is what this function encodes; the absolute figures move with the
+    machine and the Python build, so compare the two COLUMNS, never a number here
+    against a number you measured. (A previous revision quoted 28/107 and 371/123 ms
+    with no conditions attached - same shape, roughly 2-4x slower hardware. Beware
+    also of benchmarking this with keys drawn from a tiny range: Timsort exploits
+    the resulting runs and the sort column comes out artificially fast.)
     """
     out = _filter_connections(conns, query, proc_map)
     numeric = sort_col in ("remote_port", "local_port", "packets", "bytes",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,18 @@ concurrency = ["thread", "multiprocessing"]
 omit = ["*/__main__.py"]
 
 [tool.coverage.report]
-# The gate. Re-measured at 79% after the engineering-review test pass (pass-through
-# invariant, jsonfile, views, clilog, crashlog, scenario_runner, processes). Set two
-# points below the measurement so it blocks a real regression without failing on the
-# small run-to-run variance of the subprocess GUI coverage. Raise it as coverage
-# climbs - never lower it to make a red build go green.
+# The gate. Set a few points below the measured total so it blocks a real regression
+# without failing on the small run-to-run variance of the subprocess GUI coverage.
+# Raise it as coverage climbs - never lower it to make a red build go green.
 #
-# NOTE: it only means anything with COVERAGE_PROCESS_START set, because the GUI
-# tests run in subprocesses. Without it the same suite reports 51%, and a gate at
-# 75 would fail on a codebase that is actually fine.
-fail_under = 77
+# Measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, full `pytest tests`):
+#   COVERAGE_PROCESS_START set  -> 83.03%   <- the real number
+#   COVERAGE_PROCESS_START unset -> 45%     <- meaningless, see below
+#
+# NOTE: it only means anything with COVERAGE_PROCESS_START set, because the GUI tests
+# run in subprocesses whose coverage is otherwise never collected. Unset, the same
+# suite reports 45%, so ANY sane gate would fail on a codebase that is actually fine.
+fail_under = 80
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/tests/test_gui_release_fixes.py
+++ b/tests/test_gui_release_fixes.py
@@ -159,10 +159,19 @@ def test_scenario_dialog_defaults_to_the_bundled_scenarios_dir():
 
 
 def test_shortcut_buttons_advertise_their_key():
-    """A control with a keyboard shortcut must show it in its own tooltip (conv 40)."""
+    """A control with a keyboard shortcut must show it in its own tooltip (conv 40).
+
+    It used to assert on btn_start and btn_apply only, so dropping `shortcut=` from
+    "Save file" or "Load file" left the suite green (verified by mutation, 2026-07-21).
+    Every button that has a binding in `_bind_shortcuts` is listed here.
+    """
     run_gui("""
-        assert "F5" in app.btn_start._bnt_tooltip.text, app.btn_start._bnt_tooltip.text
-        assert "Ctrl+Enter" in app.btn_apply._bnt_tooltip.text, app.btn_apply._bnt_tooltip.text
+        for attr, key in (("btn_start", "F5"), ("btn_apply", "Ctrl+Enter"),
+                          ("btn_save", "Ctrl+S"), ("btn_load", "Ctrl+O")):
+            widget = getattr(app, attr)
+            tip = getattr(widget, "_bnt_tooltip", None)
+            assert tip is not None, attr + " lost its tooltip"
+            assert key in tip.text, attr + " does not advertise " + key + ": " + tip.text
     """)
 
 


### PR DESCRIPTION
A claim-by-claim audit of the (private) `PROJECT_NOTES.md` against this repository,
applying convention 5 to the note itself: every "because" is a claim, so check it or
do not write it. Only the code-side outcome lands here - the note is git-ignored and
lives in the private Doc repo - so this PR plus the `CHANGELOG-INTERNAL.md` entries are
the public record of what was found.

Two findings caused code changes, one raised the coverage gate, and every millisecond
figure in the blast radius was re-measured rather than trusted.

## Prose that would have made the next session write a bug

- **Convention 16 told the next session to do the opposite of what the code does.** It
  said to set `state="disabled"` on field labels. A state-disabled `ttk.Label` paints a
  FILLED BOX, which is exactly why `ControlForm` swaps the style to `CardOff.TLabel`
  instead. The convention also named `test_gui_layout.py::test_disabled_fields_are_visibly_disabled`
  as its guard - **that test has never existed**. The same stale claim sat in a
  `theme.py` comment five lines below the correct one; both are fixed here.
- Measured rather than assumed: removing the `disabled` foreground maps for EVERY label
  style leaves the whole suite and `smoke_gui.py` green. The convention now states that
  it has no guard instead of naming one.
- **Convention 40's guard covered half of what it claimed.**
  `test_shortcut_buttons_advertise_their_key` asserted on `btn_start` and `btn_apply`
  only, so dropping `shortcut="Ctrl+S"` from the Save button kept the suite green
  (verified by mutation). It now drives a table of all four shortcut buttons and fails
  naming the offender; "Save file" / "Load file" moved from local variables to
  `App.btn_save` / `App.btn_load` so the guard can reach them.

## Numbers

Re-measured on Win11 AMD64, CPython 3.14.6, median of 7. Conditions are now attached to
each figure, because a number without conditions cannot be re-verified and the next
session cannot tell a regression from different hardware.

| claim | documented | measured |
|---|---|---|
| `connections_snapshot(limit=None)` at the 200k cap | ~25 ms | **0.7 ms** |
| the same copy at 500k (`conns.py`) | ~70 ms | **2.4 ms** |
| coverage with `COVERAGE_PROCESS_START` | ~79% | **83.03%** |
| coverage without it | 51% | **45%** |

The ~70 ms figure argued for moving the snapshot back onto the UI thread. The decision to
keep it on the worker survives for a different, verified reason that had never been
written down: `connections_snapshot()` acquires the engine's `_clock`, the same lock the
capture thread takes on every logged packet, so taking it on the UI thread makes the UI
queue behind capture no matter how cheap the copy is.

`views.filter_sort_connections` keeps its heap-vs-sort ratio test - re-measurement
confirms the crossover (top 400: 12.6 ms heap vs 27.7 ms sort; top 50 000: 130.6 ms heap
vs 28.0 ms sort). Only the absolute figures were dated. Its docstring now carries the
table plus a warning that first misled this audit: benchmark it with keys drawn from a
tiny range and Timsort exploits the resulting runs, making the sort column look
artificially fast and the whole optimisation look pointless.

**Coverage gate raised 77 -> 80**, keeping the usual ~3-point margin for subprocess
coverage variance.

## Verification

- `python -m pytest tests` - green (elevated shell, so no admin-only skips).
- `python smoke_gui.py` - OK.
- Both new guards checked by mutation: green on the real tree, red on the injected defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
