### PR TITLE
Engineering review: atomic start, silent-swallow, repo hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,11 @@ jobs:
       # pytest names the failing file, so the extra checkmarks bought no diagnosis.
       #
       # COVERAGE_PROCESS_START is not optional: the GUI tests run in subprocesses,
-      # and without it every line they exercise is reported as uncovered (the same
-      # suite reads 51% instead of 77%). The gate lives in pyproject (fail_under).
+      # and without it every line they exercise is reported as uncovered, so the same
+      # suite reads far lower and a sane gate would fail on healthy code. The measured
+      # split (with/without it) and the gate itself live in ONE place - pyproject
+      # (fail_under, and the comment above it) - so they are not restated here, where a
+      # copied number only drifts out of date.
       - name: Test suite + coverage gate (engine, i18n, CLI, fail-safe, tables, chaos)
         env:
           COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ bean_run.log
 debug.log
 .hypothesis/
 .coverage
+# coverage runs with parallel=true (pyproject), so each subprocess writes its own
+# .coverage.<host>.<pid>.<rand>; --cov-report=xml (CI) writes coverage.xml. Neither
+# is the bare ".coverage" above, so both must be listed or git add -A would grab them.
+.coverage.*
+coverage.xml
 # runtime crash artefacts (never commit or ship)
 crashes/
 SHA256SUMS.txt

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -67,6 +67,30 @@ to raise after N workers and inspected the engine state), not by reading.
   the engine is not left running, the divert is closed, it is gone from `_LIVE_ENGINES`, and a
   later `start()` succeeds (no longer wedged).
 
+### Fixed: corrupt_packet() records its failures (F3); a core-scoped guard so it cannot swallow again (F4)
+
+Engineering-review findings F3 + F4.
+
+- **F3:** `BeanCore.corrupt_packet`'s `except Exception: return False` swallowed a REAL
+  failure (a raising `packet.payload` setter, a foreign packet type) in a way
+  indistinguishable from its legitimate empty-payload `return False`. A broken corruptor
+  therefore read as `corrupted == 0` - "the traffic had no payloads" - and the tester
+  would blame their traffic, not the tool. It now calls `crashlog.once("core.corrupt",
+  exc)` before returning False. `crashlog` is imported LAZILY inside the handler, so
+  core.py still imports only utils/matchers at load (layering contract) and stays free of
+  logging/print in the hot path; `once()` caps the cost at one traceback. Verified by
+  experiment: a raising setter now lands one `core.corrupt` record and returns False,
+  while the empty-payload path stays a quiet False (no crash-log spam).
+- **F4:** `test_no_silently_swallowed_exceptions` only recognises a `pass`/`...` body, so
+  the `return False` swallow above passed it for as long as it existed. New guard
+  `tests/test_code_hygiene.py::test_the_decision_core_never_swallows_an_exception_silently`
+  asserts the stronger property for core.py ALONE: every broad `except` must reach
+  `crashlog` (quiet/once/note/record) or re-raise. Scoped to the decision core on purpose
+  - the wider package's 50-odd broad handlers are legitimate control-flow fallbacks
+  (parse -> None, `matches()` -> False by hot-path contract, a DPI probe -> default), so
+  holding them to this rule would fire on correct code. Mutation-checked: reverting F3
+  turns the new guard red on `core.py:626`.
+
 ### PROJECT_NOTES audit, part 2: measured numbers, and the coverage gate to 80
 
 Every "costs N ms" in the audit's blast radius was re-measured instead of trusted. Conditions

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -91,6 +91,21 @@ Engineering-review findings F3 + F4.
   holding them to this rule would fire on correct code. Mutation-checked: reverting F3
   turns the new guard red on `core.py:626`.
 
+### Fixed: gitignore coverage artefacts (F7), drop stale numbers from the CI comment (F8)
+
+Engineering-review findings F7 + F8. Neither ships; both are the "prose nothing guards"
+class convention 5 warns about.
+
+- **F7:** `.gitignore` matched only the bare `.coverage`, but `[tool.coverage.run]
+  parallel = true` (pyproject) GUARANTEES per-process `.coverage.<host>.<pid>.<rand>`
+  files, and the CI coverage step writes `coverage.xml`. Both appear as untracked after a
+  coverage run, and `git add -A` would have committed them (against convention 3). Added
+  `.coverage.*` and `coverage.xml`. Verified with `git check-ignore`.
+- **F8:** the comment on the coverage step claimed "the same suite reads 51% instead of
+  77%". 77 was the PREVIOUS gate value (it has since moved 75 -> 77 -> 80), and the real
+  measured split lives in pyproject (45% vs 83.03% when measured). The comment no longer
+  restates any number - it points at pyproject, the single source, so it cannot drift again.
+
 ### PROJECT_NOTES audit, part 2: measured numbers, and the coverage gate to 80
 
 Every "costs N ms" in the audit's blast radius was re-measured instead of trusted. Conditions

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: BeanEngine.start() is now atomic - a partial start fails OPEN (convention 20)
+
+Engineering-review finding F1, confirmed by experiment before the fix (forced `Thread.start()`
+to raise after N workers and inspected the engine state), not by reading.
+
+- **The hole:** `_start_locked` set `self._running = True` and opened the divert BEFORE spawning
+  the resolver + capture/inject/watchdog threads, and called `_LIVE_ENGINES.add(self)` only AFTER
+  all three were up. A failing `Thread.start()` (thread/memory exhaustion - most likely under the
+  load this tool is aimed at) therefore left a "running" engine with an OPEN divert, no capture
+  thread draining it, and **invisible to the `atexit` hook** - WinDivert queueing the user's
+  packets into a void while the UI said "running". Worse, `_running` stayed True, so every later
+  `start()` hit the `RuntimeError("already running")` guard: START was wedged for the process
+  lifetime. GUI `_finish_start(err)` only shows a dialog and resets the button; it never calls
+  `stop()`.
+- **The fix:** `_LIVE_ENGINES.add(self)` moved to BEFORE the worker-spawn block (the moment the
+  divert is open + `_running` is the moment atexit must be able to find it), and the spawn block
+  wrapped in `try/except BaseException` that logs the fault, calls `self.stop(reason="fault")`
+  (closes the divert, stops/joins whatever DID start, clears `_running`, discards from
+  `_LIVE_ENGINES`) and re-raises. `_stop_lock` is an `RLock`, so the nested `stop()` from inside
+  `start()` re-enters cleanly.
+- New test: `tests/test_failsafe.py::test_a_failed_start_never_leaves_an_open_divert` - monkeypatches
+  `threading.Thread.start` to fail after the resolver thread, then asserts: the error propagates,
+  the engine is not left running, the divert is closed, it is gone from `_LIVE_ENGINES`, and a
+  later `start()` succeeds (no longer wedged).
+
 ### PROJECT_NOTES audit, part 2: measured numbers, and the coverage gate to 80
 
 Every "costs N ms" in the audit's blast radius was re-measured instead of trusted. Conditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 - **`--cleanup-driver` explains a refusal instead of calling it "not installed".** Being told
   "access denied - the service exists but this account may not remove it" points somewhere;
   being told the service was never there does not.
+- **A session that fails to start now hands your network back and lets you try again.** Starting a
+  run sets up several background workers, and if your machine could not spare the resources for one
+  of them - most likely while you are already running the heavy load you are testing against - the
+  start failed halfway. The tool could be left holding your traffic without actually impairing it,
+  showing an error while quietly keeping its grip, and every later START was refused until you
+  killed the program. A failed start now releases your network immediately and leaves the tool
+  ready to start again, exactly as if you had never pressed START.
 
 ## [0.3.0] - 2026-07-20
 

--- a/beantester/core.py
+++ b/beantester/core.py
@@ -623,5 +623,16 @@ class BeanCore:
             data[idx] ^= (1 << rng.randrange(8))
             packet.payload = bytes(data)
             return True
-        except Exception:
+        except Exception as exc:
+            # NOT silent (convention 30). This returns False on a REAL failure - a
+            # payload setter that started raising, an unexpected packet type - exactly
+            # as it does for the legitimate empty-payload case above. So a broken
+            # corruptor would read as "0 corrupted", indistinguishable from "no
+            # payloads to corrupt", and the tester would blame their traffic instead
+            # of the tool - the precise class of silent lie this project removes.
+            # once() keeps it free in the packet hot path (a traceback at most once).
+            # Imported lazily so core.py still imports only utils/matchers at load
+            # (layering contract: tests/test_layering.py::test_core_stays_pure).
+            from . import crashlog
+            crashlog.once("core.corrupt", exc)
             return False

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -508,28 +508,44 @@ class BeanEngine:
         # one. Safe to block here: start() already runs off the UI thread (the GUI
         # drives it through _begin_transition), and this is the only place the
         # resolution is allowed to be synchronous.
-        targeting = self._targeting
-        if targeting is not None:
-            with crashlog.quiet("engine.target"):
-                targeting.refresh()
-            # Reconcile: whichever path installed the target (target_for alone, or
-            # set_target), the session starts with the resolver pointed at it.
-            self._resolver.retarget(targeting)
-        # UNCONDITIONALLY, target or no target: the resolver's life is the SESSION's.
-        # Starting it only when a target already exists meant that narrowing down
-        # mid-run - press START, watch, then type a process - left nobody keeping
-        # the port set fresh, so it froze at whatever the first resolve produced and
-        # new sockets were never picked up. That is precisely the failure live
-        # targeting exists to prevent. With no target it blocks on its event and
-        # costs nothing.
-        self._resolver.start()
-        self._t_cap = threading.Thread(target=self._capture_loop, daemon=True)
-        self._t_inj = threading.Thread(target=self._inject_loop, daemon=True)
-        self._t_wd = threading.Thread(target=self._watchdog_loop, daemon=True)
-        self._t_cap.start()
-        self._t_inj.start()
-        self._t_wd.start()
+        # Registered BEFORE the workers are spawned, not after: from the moment the
+        # divert is open and _running is True, atexit and the watchdog must be able to
+        # find this engine. Adding it only once every thread was already up meant a
+        # failed Thread.start() (out of threads/memory - most likely in the very load
+        # tests this tool is aimed at) left a "running" engine holding an open divert
+        # that NOTHING would ever close: the exact fail-open hole convention 20 forbids.
         _LIVE_ENGINES.add(self)
+        try:
+            targeting = self._targeting
+            if targeting is not None:
+                with crashlog.quiet("engine.target"):
+                    targeting.refresh()
+                # Reconcile: whichever path installed the target (target_for alone, or
+                # set_target), the session starts with the resolver pointed at it.
+                self._resolver.retarget(targeting)
+            # UNCONDITIONALLY, target or no target: the resolver's life is the SESSION's.
+            # Starting it only when a target already exists meant that narrowing down
+            # mid-run - press START, watch, then type a process - left nobody keeping
+            # the port set fresh, so it froze at whatever the first resolve produced and
+            # new sockets were never picked up. That is precisely the failure live
+            # targeting exists to prevent. With no target it blocks on its event and
+            # costs nothing.
+            self._resolver.start()
+            self._t_cap = threading.Thread(target=self._capture_loop, daemon=True)
+            self._t_inj = threading.Thread(target=self._inject_loop, daemon=True)
+            self._t_wd = threading.Thread(target=self._watchdog_loop, daemon=True)
+            self._t_cap.start()
+            self._t_inj.start()
+            self._t_wd.start()
+        except BaseException as exc:
+            # A worker (or the resolver) could not be spawned. Do NOT leave a running
+            # engine with an open divert and no capture thread draining it - fail OPEN:
+            # stop() closes the divert, stops/joins whatever DID start, and clears
+            # _running. Then re-raise so the caller (GUI _finish_start, CLI) reports the
+            # failure instead of believing the session is live. Convention 20.
+            self.log(T("log.engine_fault", e=str(exc)))
+            self.stop(reason="fault")
+            raise
         self.log(f"{T('log.start_filter')}: {filt}  (seed={self._effective_seed})")
         self.log_event("START", f"filter={filt}, seed={self._effective_seed}"
                                 + (f", duration={self._duration:g}s" if self._duration else ""))

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -68,3 +68,54 @@ def test_core_decision_hot_path_is_pure():
             bad.append(f"print() (line {node.lineno})")
     check("core.py has no logging/print in the packet hot path",
           not bad, f"({bad})")
+
+
+def _is_broad_handler(handler):
+    """A bare ``except:`` or one catching ``Exception``/``BaseException``."""
+    exc = handler.type
+    if exc is None:
+        return True
+    names = exc.elts if isinstance(exc, ast.Tuple) else [exc]
+    return any(getattr(n, "id", "") in ("Exception", "BaseException") for n in names)
+
+
+def _handler_reaches_crashlog_or_reraises(handler):
+    """Does the handler record the failure (crashlog) or re-raise it?
+
+    ``crashlog.quiet``/``once``/``note``/``record`` and a bare ``raise`` all count -
+    the point of convention 30 is that the fault stops being INVISIBLE, not how.
+    """
+    for node in ast.walk(handler):
+        if isinstance(node, ast.Raise):
+            return True
+        if isinstance(node, ast.Attribute) and node.attr in (
+                "quiet", "once", "note", "record"):
+            return True
+    return False
+
+
+def test_the_decision_core_never_swallows_an_exception_silently():
+    """core.py is the pure decision hot path: EVERY broad ``except`` there must
+    route the fault to ``crashlog`` (or re-raise) - never ``return``/assign its way
+    to silence.
+
+    The general guard above only recognises a ``pass``/``...`` body, so a handler
+    that swallowed via ``return False`` passed it - which is exactly how a silent
+    ``except Exception: return False`` lived in ``corrupt_packet`` (finding F3): a
+    real fault (a raising payload setter) read as "0 corrupted", indistinguishable
+    from "no payloads", and got blamed on the traffic instead of the tool.
+
+    The wider package is deliberately NOT held to this: most of its broad handlers
+    are legitimate control-flow fallbacks (a parse that returns ``None`` on bad
+    input, ``matches()`` returning ``False`` in the packet path by contract, a DPI
+    probe falling back to a default). In the DECISION CORE there is no such case -
+    a swallowed exception is always a hidden bug - so the rule can be absolute here.
+    """
+    src = open(os.path.join(ROOT, "beantester", "core.py"), encoding="utf-8").read()
+    offenders = []
+    for node in ast.walk(ast.parse(src)):
+        if (isinstance(node, ast.ExceptHandler) and _is_broad_handler(node)
+                and not _handler_reaches_crashlog_or_reraises(node)):
+            offenders.append(f"core.py:{node.lineno}")
+    check("core.py routes every broad except to crashlog or re-raises (never silent)",
+          not offenders, f"({offenders})")

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -198,6 +198,54 @@ def test_a_dead_capture_thread_fails_open():
           f"({kinds})")
 
 
+def test_a_failed_start_never_leaves_an_open_divert(monkeypatch):
+    """Regression (F1): start() was not atomic.
+
+    ``_running`` went True and the divert was opened BEFORE the worker threads were
+    spawned, and the engine was added to ``_LIVE_ENGINES`` only AFTER. So a failing
+    ``Thread.start()`` (out of threads/memory - most likely under the load this tool
+    is pointed at) left a 'running' engine with an open divert that nothing drained
+    and that atexit could not even see, and every later START was refused forever.
+    """
+    import threading
+
+    real_start = threading.Thread.start
+    calls = {"n": 0}
+
+    def flaky_start(self, *a, **k):
+        # let the resolver thread come up, then fail like a machine out of threads
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("can't start new thread")
+        return real_start(self, *a, **k)
+
+    eng = BeanEngine()
+    divert = QuietDivert()
+    monkeypatch.setattr(threading.Thread, "start", flaky_start)
+    try:
+        eng.start("test", divert=divert)
+    except RuntimeError as exc:
+        raised = str(exc)
+    else:
+        raised = None
+    monkeypatch.undo()
+
+    check("failed start: the error propagates to the caller",
+          raised == "can't start new thread", f"({raised})")
+    check("failed start: the engine is NOT left running", eng.is_running() is False)
+    check("failed start: the divert is closed (network restored)",
+          divert.closed is True)
+    check("failed start: atexit is not left tracking a half-started engine",
+          eng not in set(_LIVE_ENGINES))
+    # the whole point: START works again instead of being wedged on "already running"
+    recover = QuietDivert()
+    eng.start("test", divert=recover)
+    check("failed start: a later START is not refused", eng.is_running() is True)
+    eng.stop()
+    check("failed start: the recovered session releases its divert too",
+          recover.closed is True)
+
+
 def test_stop_is_idempotent_and_keeps_the_first_reason():
     eng = BeanEngine()
     eng.start("test", divert=QuietDivert())


### PR DESCRIPTION
Three fixes from an engineering-review pass. Each is a separate commit with its own
reasoning and tests; the branch fast-forwards onto master (3 commits ahead, 0 behind).

## fix(engine): make start() atomic so a partial start fails open (F1)

`BeanEngine.start()` set `_running=True` and opened the divert before spawning the
worker threads, and registered with the `atexit` hook only after they were all up. A
failing `Thread.start()` (thread or memory exhaustion - most likely under the very load
this tool is pointed at) left a "running" engine holding an open divert with no capture
thread draining it and invisible to atexit, while every later `start()` was refused with
"already running" for the process lifetime. That is the exact fail-open hole convention
20 forbids: WinDivert keeps queueing the user's packets into a void while the UI still
says "running".

The worker-spawn block is now wrapped so any failure closes the divert, clears
`_running` and re-raises for the caller to report; the engine is registered with atexit
before the block, not after. Regression test
`test_a_failed_start_never_leaves_an_open_divert` - mutation-checked: removing the
cleanup turns it red.

## fix(core): record corrupt_packet failures instead of swallowing them (F3 + F4)

`corrupt_packet`'s `except Exception: return False` hid a real failure (a raising
`packet.payload` setter, a foreign packet type) behind the same False it returns for the
legitimate empty-payload case, so a broken corruptor read as `corrupted == 0` -
indistinguishable from "the traffic had no payloads" - and got blamed on the application
instead of the tool. It now records the fault via `crashlog.once`, imported lazily so
core.py still imports only utils/matchers at load (layering contract) and stays free of
logging/print in the packet hot path.

The existing hygiene guard only recognised a `pass`/`...` body, which is how the
return-style swallow survived. A new core-scoped guard,
`test_the_decision_core_never_swallows_an_exception_silently`, asserts every broad
`except` in core.py reaches crashlog or re-raises. Scoped to the decision core on
purpose - the wider package's broad handlers are legitimate control-flow fallbacks.

## chore(repo): gitignore coverage artefacts, de-stale the CI comment (F7 + F8)

`.gitignore` matched only the bare `.coverage`, but coverage runs with `parallel=true`
(pyproject), which generates per-process `.coverage.<host>.<pid>.<rand>` files, and the
CI step writes `coverage.xml`; `git add -A` would have grabbed both. Now ignored. The
coverage-step comment restated a stale gate value (77, since moved to 80) and split; it
now points at pyproject, the single source, so it cannot drift again.

## Verification

- `python -m pytest tests`: **611 passed, 0 failed** (elevated shell, so no admin flakes)
- coverage **83.04%** with the gate at 80
- `python smoke_gui.py`: OK
- both changelogs updated under `[Unreleased]`; no version bump (the owner owns
  `VERSION.txt`, convention 34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
