### PR TITLE
Fix STOP hanging 2 s when it races the duration deadline (F2)

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,34 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: STOP no longer blocks for 2 s when it races the duration deadline (F2)
+
+Engineering-review finding F2, measured before and after: a user STOP colliding with the
+session deadline took **2091 ms**; it is now **~160 ms** (40-trial worst case).
+
+- **The deadlock:** `stop()` holds `_stop_lock` and joins the worker threads with a 2.0 s
+  timeout. When the watchdog fired the duration deadline at the same instant, its
+  `stop(reason="duration")` blocked waiting for that same lock while the user's `stop()` was
+  blocked waiting to join the watchdog - a lock-ordering inversion broken only by the join
+  timeout. The capture thread's `_fail_stop` -> `stop()` had the same shape.
+- **The fix:** `stop()` is split into `stop()` (external callers - GUI/CLI/atexit/tests -
+  which BLOCK on `_stop_lock`, preserving start/stop serialisation), `_worker_stop()` (worker
+  threads, which take the lock NON-blocking and bow out under contention), and the shared
+  `_stop_locked()` body. The watchdog's deadline and liveness stops go through `_worker_stop`;
+  `_deadline` is now cleared at the TOP of the stop body so a watchdog finishing a slow op sees
+  nothing to fire.
+- **Subtlety that cost a round:** `_fail_stop` is called by BOTH the capture thread and the
+  watchdog. Routing both through `_worker_stop` regressed `test_a_dead_capture_thread_fails_open`
+  - a divert that faults on its first reads does so while `start()` still holds `_stop_lock`, so
+  the capture thread's non-blocking stop no-opped and the watchdog stopped it a tick later with a
+  generic "died unexpectedly" instead of the real "driver went away". So `_fail_stop` grew a
+  `blocking` flag: the capture thread blocks (safe - an external STOP closes the divert first, so
+  the capture loop sees `_running` False and never reaches `_fail_stop`), only the watchdog's
+  liveness path is non-blocking.
+- New test `tests/test_failsafe.py::test_a_worker_stop_never_blocks_on_a_held_stop_lock` - holds
+  `_stop_lock` and asserts `_worker_stop` returns anyway (structural, not wall-clock, so it cannot
+  flake). Mutation-checked: making `_worker_stop` blocking turns it red.
+
 ### Fixed: BeanEngine.start() is now atomic - a partial start fails OPEN (convention 20)
 
 Engineering-review finding F1, confirmed by experiment before the fix (forced `Thread.start()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   showing an error while quietly keeping its grip, and every later START was refused until you
   killed the program. A failed start now releases your network immediately and leaves the tool
   ready to start again, exactly as if you had never pressed START.
+- **STOP is immediate again when you press it just as a timed run ends.** If you hit STOP at the
+  same moment a run reached its set duration, the tool could sit on "stopping" for about two seconds
+  before the window went back to normal. Your network was already handed back at once - it was only
+  the button that lagged - but a STOP that looks stuck is exactly the wrong thing in a tool whose
+  whole job is undoing what you did to your own connection. It now finishes right away either way.
 
 ## [0.3.0] - 2026-07-20
 

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -554,72 +554,129 @@ class BeanEngine:
                        "fault": "events.fault"}
 
     def stop(self, reason="user"):
-        """Stop the session and release the divert. Safe to call twice / from any thread."""
-        with self._stop_lock:
-            if not self._running:
-                return
-            self._running = False
-            self._stop_mono = time.monotonic()
-            self._stop_wall = time.time()
-            self.stop_reason = reason
-            # FIRST, before anything that can block. Closing the divert unblocks a
-            # capture thread stuck in recv() AND releases the WinDivert driver
-            # (which otherwise keeps its .sys file locked - see driver.py).
-            #
-            # The order matters because ``_capture_loop`` runs ``while self._running``:
-            # the line above has already ended it, so from this point NOTHING is
-            # draining the divert while WinDivert keeps diverting into it. Every step
-            # that used to sit in between can block - ``_resolver.stop()`` joins with
-            # a 0.25 s timeout and a resolve in flight really does use it (measured:
-            # STOP took 252 ms with a scan running, against ~100 ms idle). That was up
-            # to a quarter of a second of the user's packets queued into a void, which
-            # is the exact failure FAIL-OPEN exists to prevent (convention 20). It is
-            # invisible on a synthetic divert, whose recv() blocks, and shows up on the
-            # real one, whose recv() returns immediately under traffic.
-            #
-            # It must NOT move above ``self._running = False``: recv() would then raise
-            # while the session still looked live, so ``_capture_loop`` would take the
-            # ``_fail_stop`` path and report a fault for an ordinary stop.
-            if self._divert is not None:
-                try:
-                    self._divert.close()
-                except Exception as _exc:
-                    crashlog.note(_exc, "engine")
-            self.stop_scenario()
-            # Joins: the resolver holds OS handles and must stop touching them when
-            # the session does, not "eventually".
-            self._resolver.stop()
-            self.log_event("STOP", self.EVENT_BY_REASON.get(reason, "events.stopped"))
-            with self._cv:
-                self._cv.notify_all()
-            # join the worker threads before releasing self._divert: they read the
-            # attribute live, so a quick stop->start would otherwise leave an old
-            # capture thread consuming packets from the NEW session's divert
-            for t in (self._t_cap, self._t_inj, self._t_wd):
-                if t is not None and t.is_alive() and t is not threading.current_thread():
-                    t.join(timeout=2.0)
-            self._t_cap = self._t_inj = self._t_wd = None
-            self._divert = None
-            self._deadline = None
-            with self._cv:
-                discarded = len(self._heap)
-                self._heap.clear()
-            if discarded:
-                # Packets still queued for delayed injection when the session ended:
-                # counted at capture (seen / bytes_*_total) but never delivered. Record
-                # them instead of letting them vanish from the seen/delivered/dropped
-                # balance - they were dropped BY the shutdown, not lost in transit.
-                self._bump("drop_shutdown", discarded)
-            _LIVE_ENGINES.discard(self)
-            self.log(T("log.stop"))
+        """Stop the session and release the divert. Safe to call twice / from any thread.
 
-    def _fail_stop(self, error):
-        """A worker died: stop the session so the network is never left impaired."""
+        External callers (GUI, CLI, atexit, tests) come through here and BLOCK on
+        ``_stop_lock``, which serialises stop against ``start()``. A worker thread that
+        needs to stop the engine from the inside (the watchdog on a deadline, or
+        ``_fail_stop`` when a worker dies) must NOT use this - it goes through
+        ``_worker_stop``, which never blocks on the lock. See there for why.
+        """
+        with self._stop_lock:
+            self._stop_locked(reason)
+
+    def _worker_stop(self, reason):
+        """Stop initiated BY one of the engine's own worker threads.
+
+        It must not BLOCK on ``_stop_lock``. A concurrent external ``stop()`` holds
+        that lock AND joins this very thread (join timeout 2.0 s), so blocking here
+        would hang STOP for the whole timeout - measured at 2.09 s when the user
+        pressed STOP at the same instant the duration deadline fired: the watchdog's
+        ``stop()`` waited for the lock while the user's ``stop()`` waited to join the
+        watchdog. The user's ``stop()`` is already closing the divert, so the
+        fail-open guarantee holds without us. So: take the lock only if it is free
+        and do the stop ourselves (the uncontended deadline / fault case); if another
+        stop already holds it, return AT ONCE so its join of this thread completes and
+        this thread dies.
+        """
+        if not self._stop_lock.acquire(blocking=False):
+            return
+        try:
+            self._stop_locked(reason)
+        finally:
+            self._stop_lock.release()
+
+    def _stop_locked(self, reason):
+        """The stop body. The caller MUST hold ``_stop_lock`` - ``stop()`` blocks to
+        take it, ``_worker_stop`` takes it without blocking."""
+        if not self._running:
+            return
+        self._running = False
+        # Cleared EARLY (it used to be set near the end): once the deadline is gone,
+        # a watchdog that is just finishing a slow maintenance op sees nothing to fire
+        # and exits its loop instead of calling a second, racing stop.
+        self._deadline = None
+        self._stop_mono = time.monotonic()
+        self._stop_wall = time.time()
+        self.stop_reason = reason
+        # FIRST, before anything that can block. Closing the divert unblocks a
+        # capture thread stuck in recv() AND releases the WinDivert driver
+        # (which otherwise keeps its .sys file locked - see driver.py).
+        #
+        # The order matters because ``_capture_loop`` runs ``while self._running``:
+        # the line above has already ended it, so from this point NOTHING is
+        # draining the divert while WinDivert keeps diverting into it. Every step
+        # that used to sit in between can block - ``_resolver.stop()`` joins with
+        # a 0.25 s timeout and a resolve in flight really does use it (measured:
+        # STOP took 252 ms with a scan running, against ~100 ms idle). That was up
+        # to a quarter of a second of the user's packets queued into a void, which
+        # is the exact failure FAIL-OPEN exists to prevent (convention 20). It is
+        # invisible on a synthetic divert, whose recv() blocks, and shows up on the
+        # real one, whose recv() returns immediately under traffic.
+        #
+        # It must NOT move above ``self._running = False``: recv() would then raise
+        # while the session still looked live, so ``_capture_loop`` would take the
+        # ``_fail_stop`` path and report a fault for an ordinary stop.
+        if self._divert is not None:
+            try:
+                self._divert.close()
+            except Exception as _exc:
+                crashlog.note(_exc, "engine")
+        self.stop_scenario()
+        # Joins: the resolver holds OS handles and must stop touching them when
+        # the session does, not "eventually".
+        self._resolver.stop()
+        self.log_event("STOP", self.EVENT_BY_REASON.get(reason, "events.stopped"))
+        with self._cv:
+            self._cv.notify_all()
+        # join the worker threads before releasing self._divert: they read the
+        # attribute live, so a quick stop->start would otherwise leave an old
+        # capture thread consuming packets from the NEW session's divert. The
+        # watchdog can be among them, and it is joined here too - safe now only
+        # because a watchdog-initiated stop goes through _worker_stop and never
+        # blocks on _stop_lock, so joining it cannot deadlock against this stop.
+        for t in (self._t_cap, self._t_inj, self._t_wd):
+            if t is not None and t.is_alive() and t is not threading.current_thread():
+                t.join(timeout=2.0)
+        self._t_cap = self._t_inj = self._t_wd = None
+        self._divert = None
+        with self._cv:
+            discarded = len(self._heap)
+            self._heap.clear()
+        if discarded:
+            # Packets still queued for delayed injection when the session ended:
+            # counted at capture (seen / bytes_*_total) but never delivered. Record
+            # them instead of letting them vanish from the seen/delivered/dropped
+            # balance - they were dropped BY the shutdown, not lost in transit.
+            self._bump("drop_shutdown", discarded)
+        _LIVE_ENGINES.discard(self)
+        self.log(T("log.stop"))
+
+    def _fail_stop(self, error, blocking=True):
+        """A worker died: stop the session so the network is never left impaired.
+
+        ``blocking`` picks HOW the stop is taken, and the two callers genuinely differ:
+
+        * The CAPTURE thread calls this on a real recv() fault (blocking=True). A plain
+          ``stop()`` is right, and necessary: the fault can arrive while ``start()``
+          still holds ``_stop_lock`` (a divert that fails on its very first reads,
+          before start() has returned) - blocking makes the capture thread wait for
+          start() to finish and then stop cleanly, keeping the REAL fault message. It
+          cannot deadlock against an external STOP: that path closes the divert first,
+          so the capture loop sees ``_running`` already False and never reaches here.
+        * The WATCHDOG calls this from its liveness check (blocking=False). It must NOT
+          block on ``_stop_lock``: an external ``stop()`` holds it while joining the
+          watchdog thread, so blocking would hang STOP for the join timeout (F2). It
+          goes through ``_worker_stop`` instead, which bows out under contention.
+        """
         if not self._running:
             return
         self.fault = str(error)
         self.log(T("log.engine_fault", e=self.fault))
-        self.stop(reason="fault")
+        if blocking:
+            self.stop(reason="fault")
+        else:
+            self._worker_stop(reason="fault")
 
     # -- watchdog -------------------------------------------------------------- #
     def _watchdog_loop(self):
@@ -663,12 +720,19 @@ class BeanEngine:
                 crashlog.note(_exc, "engine")
             if deadline_reached(self._deadline, time.monotonic()):
                 self.log(T("log.duration_reached", v=f"{self._duration:g}"))
-                self.stop(reason="duration")
+                # _worker_stop, not stop(): this runs on the watchdog thread, and a
+                # user pressing STOP at the same instant holds _stop_lock while joining
+                # this very thread. Blocking on the lock here would hang STOP for its
+                # 2 s join timeout (measured 2.09 s); the user's stop already closes
+                # the divert, so we can just bow out.
+                self._worker_stop(reason="duration")
                 return
             for t in (self._t_cap, self._t_inj):
                 if t is not None and not t.is_alive():
+                    # blocking=False: this is the watchdog thread, and an external
+                    # stop() joining it must never wait on a lock we are blocked on (F2).
                     self._fail_stop(RuntimeError(
-                        f"worker thread {t.name} died unexpectedly"))
+                        f"worker thread {t.name} died unexpectedly"), blocking=False)
                     return
 
     # -- worker threads -------------------------------------------------------- #

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -266,6 +266,47 @@ def test_a_running_engine_is_registered_for_the_exit_hook():
     check("atexit: the divert was released", divert.closed is True)
 
 
+def test_a_worker_stop_never_blocks_on_a_held_stop_lock():
+    """Regression (F2): STOP took 2.09 s when it raced the duration deadline.
+
+    An external stop() holds ``_stop_lock`` AND joins the worker threads (2 s timeout).
+    The watchdog firing the deadline - and ``_fail_stop`` on a dead worker - used to call
+    the same blocking ``stop()``: it waited for the lock the user's stop was holding,
+    while the user's stop waited to join the watchdog, so STOP hung for the full join
+    timeout. They now go through ``_worker_stop``, which takes the lock non-blockingly
+    and bows out when it cannot, so the join completes at once.
+
+    Asserted structurally (does the worker stop return while the lock is held?), not as
+    elapsed wall-clock, so it cannot flake - exactly like
+    test_stop_releases_the_divert_before_anything_that_can_block.
+    """
+    import threading
+
+    eng = BeanEngine()
+    eng.start("test", divert=QuietDivert())
+    # Stand in for an external stop() already in flight: hold _stop_lock the way it does.
+    eng._stop_lock.acquire()
+    try:
+        returned = threading.Event()
+
+        def worker_stop():
+            eng._worker_stop(reason="duration")   # must NOT block on the held lock
+            returned.set()
+
+        threading.Thread(target=worker_stop, daemon=True).start()
+        check("F2: a worker-initiated stop does not block on a held _stop_lock",
+              returned.wait(timeout=2.0),
+              "(_worker_stop blocked - STOP would hang for the whole join timeout)")
+        # it bowed out WITHOUT stopping, because the (simulated) external stop owns the
+        # teardown - the fail-open close is that stop's job, not a second racing one
+        check("F2: while another stop holds the lock, the worker stop is a no-op",
+              eng.is_running() is True, f"(running={eng.is_running()})")
+    finally:
+        eng._stop_lock.release()
+    eng.stop()
+    check("F2: the ordinary stop still tears the session down", eng.is_running() is False)
+
+
 # --- the GUI ---------------------------------------------------------------- #
 
 


### PR DESCRIPTION
Engineering-review finding **F2**: STOP hung for ~2 seconds when it was pressed at the same
instant a timed run reached its deadline. Measured before and after: **2091 ms -> ~160 ms**
(40-trial worst case).

## The deadlock

`stop()` holds `_stop_lock` and joins the worker threads with a 2.0 s timeout. When the
watchdog fired the duration deadline at the same moment, its `stop(reason="duration")` blocked
waiting for that same lock, while the user's `stop()` was blocked waiting to join the watchdog -
a lock-ordering inversion broken only by the 2 s join timeout. The capture thread's
`_fail_stop -> stop()` had the same shape.

The divert is closed first, so the user's network was already restored; it was the STOP call
(and the "stopping" state in the GUI) that hung. In a tool whose whole job is undoing what you
did to your own connection, a STOP that looks stuck is exactly the wrong failure.

## The fix

`stop()` is split into three:

- **`stop()`** - external callers (GUI, CLI, atexit, tests) that BLOCK on `_stop_lock`,
  preserving the serialisation against `start()`.
- **`_worker_stop()`** - the engine's own worker threads, which take the lock NON-blocking and
  bow out at once under contention (the other stop is already closing the divert, so fail-open
  holds without them).
- **`_stop_locked()`** - the shared body. `_deadline` is now cleared at the TOP of it, so a
  watchdog just finishing a slow maintenance op sees nothing to fire.

The watchdog's deadline and liveness stops go through `_worker_stop`.

### Subtlety that cost a round (documented for the next reader)

`_fail_stop` is called by both the capture thread and the watchdog. Routing both through
`_worker_stop` regressed `test_a_dead_capture_thread_fails_open`: a divert that faults on its
first reads does so while `start()` still holds `_stop_lock`, so the capture thread's
non-blocking stop no-opped and the watchdog stopped it a tick later with a generic "died
unexpectedly" instead of the real "driver went away". So `_fail_stop` grew a `blocking` flag -
the capture thread blocks (safe: an external STOP closes the divert first, so the capture loop
sees `_running` False and never reaches `_fail_stop`), only the watchdog's liveness path is
non-blocking.

## Verification

- `python -m pytest tests`: **612 passed, 0 failed** (elevated shell, no admin flakes)
- F2 repro re-run against the fix: worst STOP latency **160 ms** (was 2091 ms)
- capture-fault message restored to "driver went away" (the mid-implementation regression)
- new `tests/test_failsafe.py::test_a_worker_stop_never_blocks_on_a_held_stop_lock` - structural
  (holds the lock, asserts the worker stop returns anyway), so it cannot flake; mutation-checked:
  a blocking `_worker_stop` turns it red
- `python smoke_gui.py`: OK
- both changelogs updated under `[Unreleased]`; no version bump (owner owns `VERSION.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
