### PR TITLE
Cover the driver STOP+DELETE path and the in-app dialogs (F5)

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -61,6 +61,27 @@ user's live connection) - had example tests only. New file
   property, dropping the src/dst swap fails the endpoint invariant, and narrowing the `except`
   lets the hostile-packet case raise. No production code changed.
 
+### Tests: cover the driver STOP+DELETE path and the in-app dialogs (F5)
+
+Engineering-review finding F5: the two lowest-covered spots were both error/teardown
+code that only ever runs on a user's machine. No production code changed.
+
+- **`driver.stop_and_remove` was 0%** - it STOPS and DELETES a Windows service and runs on
+  the way out of every real-capture session (`release_on_exit`), so it must not be exercised
+  for the first time in the field. It is pure Service-Manager glue, so `tests/test_driver_windows.py`
+  now drives every branch through a fake advapi (`_FakeAdvapi` + a real `ctypes.Structure` so
+  `byref` has a target, `is_windows` forced True so it runs identically on the Linux CI): stop+
+  delete, a delete that will not take, no SCM handle, access-denied vs not-installed vs an
+  unexpected error, and the off-Windows no-op. Plus four `cleanup_driver` orchestration cases
+  (per-service loop, stale `_MEI*` temp dirs, the admin gate, nothing installed). driver.py
+  75% -> 88%; the stop_and_remove block (was fully uncovered) is now exercised. Mutation-checked:
+  forcing the delete to read as failed turns the success test red.
+- **`gui/dialogs.py` was 16%** - the dark in-app modals. New `tests/test_dialogs.py` drives them
+  on the fake tkinter (where `wait_window` is a no-op, so each modal builds and returns its
+  dismissal default) and exercises `_close` directly. 16% -> 85%; the remaining lines are the
+  `crashlog.note` except-branches that only fire when a real Tk call raises, which the fake
+  cannot provoke.
+
 ### Fixed: STOP no longer blocks for 2 s when it races the duration deadline (F2)
 
 Engineering-review finding F2, measured before and after: a user STOP colliding with the

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,0 +1,41 @@
+"""The in-app dark dialogs (``gui/dialogs.py``), driven on the fake tkinter.
+
+They replace ``tkinter.messagebox`` / ``simpledialog``, which draw un-themable
+native windows and take their button labels from the OS locale (an English UI
+asking "Tak / Nie" on a Polish Windows). Being real modals, they block in
+``wait_window`` until a button sets the result - which on the fake tkinter is a
+no-op, so calling one runs its whole construction path and comes back with the
+DEFAULT a dismissed dialog yields. The click path (``_close`` records the value
+and tears the window down) is driven directly, since there is no modal loop to
+click into.
+"""
+from gui_harness import run_gui
+
+
+def test_every_dialog_builds_and_returns_its_dismissal_default():
+    run_gui('''
+        import beantester.gui.dialogs as d
+
+        # Dismissed without a click, each modal yields its documented default.
+        assert d.show_info(root, "Title", "all good") is True
+        assert d.show_warning(root, "Title", "be careful") is True
+        assert d.show_error(root, "Title", "it broke") is True
+        assert d.ask_yes_no(root, "Title", "proceed?") is False       # default is NO
+        assert d.show_help(root, "Filters", "a, b, 1-9, !x, re:^y$") is True
+        assert d.ask_string(root, "Name", "profile name?") is None    # cancelled
+        print("defaults-ok")
+    ''')
+
+
+def test_clicking_a_dialog_button_records_the_result_and_closes_it():
+    run_gui('''
+        import beantester.gui.dialogs as d
+
+        # _close is what every button command calls: it records the chosen value
+        # under the window key and destroys the dialog. Drive it directly, because
+        # the modal loop that would normally reach it is a no-op on the fake tk.
+        win, body = d._shell(root, "Title")
+        d._close(win, "chosen")
+        assert d._result.get(str(win)) == "chosen", d._result
+        print("close-ok")
+    ''')

--- a/tests/test_driver_windows.py
+++ b/tests/test_driver_windows.py
@@ -125,3 +125,169 @@ def test_release_on_exit_swallows_a_cleanup_fault(monkeypatch):
     check("a cleanup fault does not crash the exit path", result == [])
     check("the driver-used flag is cleared even on fault",
           driver._DRIVER_USED[0] is False)
+
+
+# --- stop_and_remove: the STOP + DELETE path, driven through a fake advapi ---- #
+#
+# stop_and_remove runs on the way out of every real-capture session
+# (release_on_exit) and it STOPS and DELETES a Windows service, so it must never be
+# exercised for the first time on a user's machine. It is pure Service-Manager glue,
+# so a fake advapi covers every branch here - no admin, no real driver, and
+# identically on the Linux CI (is_windows is forced True). The one thing the fake
+# cannot stand in for - the 64-bit HANDLE prototypes - is what
+# test_advapi_declares_pointer_sized_prototypes pins on the real thing.
+
+
+class _FakeStatus(ctypes.Structure):
+    # A real ctypes.Structure (not wintypes, so it also builds on Linux) so that
+    # ``ctypes.byref(status)`` inside stop_and_remove has something valid to point at.
+    _fields_ = [("dwCurrentState", ctypes.c_uint)]
+
+
+class _FakeAdvapi:
+    """Records the Service-Manager calls stop_and_remove makes, and returns whatever
+    handles / results the test asked for. A 0 handle means the OS refused."""
+
+    def __init__(self, scm=1, service=1, deleted=True):
+        self.scm = scm
+        self.service = service
+        self.deleted = deleted
+        self.calls = []
+
+    def OpenSCManagerW(self, machine, database, access):
+        self.calls.append(("OpenSCManagerW", access))
+        return self.scm
+
+    def OpenServiceW(self, manager, name, access):
+        self.calls.append(("OpenServiceW", name, access))
+        return self.service
+
+    def QueryServiceStatus(self, handle, buf):
+        return True
+
+    def ControlService(self, handle, control, buf):
+        self.calls.append(("ControlService", control))
+        return True
+
+    def DeleteService(self, handle):
+        self.calls.append(("DeleteService",))
+        return self.deleted
+
+    def CloseServiceHandle(self, handle):
+        self.calls.append(("CloseServiceHandle",))
+        return True
+
+
+def _fake_scm(monkeypatch, fake, last_error=0):
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "_advapi", lambda: fake)
+    monkeypatch.setattr(driver, "_status_type", lambda: _FakeStatus)
+    monkeypatch.setattr(ctypes, "get_last_error", lambda: last_error)
+
+
+def test_stop_and_remove_stops_then_deletes_and_closes_every_handle(monkeypatch):
+    fake = _FakeAdvapi(scm=1, service=42, deleted=True)
+    _fake_scm(monkeypatch, fake)
+    result = driver.stop_and_remove("WinDivert")
+    check("a service that stops and deletes reports both",
+          result == "WinDivert: stopped and removed", f"({result})")
+    ops = [c[0] for c in fake.calls]
+    check("it issues a STOP before the DELETE",
+          "ControlService" in ops and "DeleteService" in ops
+          and ops.index("ControlService") < ops.index("DeleteService"), f"({ops})")
+    check("both the service and the manager handle are closed",
+          ops.count("CloseServiceHandle") == 2, f"({ops})")
+
+
+def test_stop_and_remove_reports_a_removal_that_would_not_take(monkeypatch):
+    fake = _FakeAdvapi(scm=1, service=42, deleted=False)
+    _fake_scm(monkeypatch, fake)
+    result = driver.stop_and_remove("WinDivert")
+    check("a service that stops but will not delete says so",
+          "stopped (removal failed" in result, f"({result})")
+
+
+def test_stop_and_remove_without_a_manager_asks_for_administrator(monkeypatch):
+    fake = _FakeAdvapi(scm=0)
+    _fake_scm(monkeypatch, fake)
+    result = driver.stop_and_remove("WinDivert")
+    check("no Service-Manager handle points at the admin requirement",
+          "Administrator required" in result, f"({result})")
+
+
+def test_stop_and_remove_explains_access_denied(monkeypatch):
+    fake = _FakeAdvapi(scm=1, service=0)
+    _fake_scm(monkeypatch, fake, last_error=driver._ERROR_ACCESS_DENIED)
+    result = driver.stop_and_remove("WinDivert")
+    check("access denied is explained, not disguised as 'not installed'",
+          "access denied" in result, f"({result})")
+
+
+def test_stop_and_remove_reads_a_missing_service_as_not_installed(monkeypatch):
+    fake = _FakeAdvapi(scm=1, service=0)
+    _fake_scm(monkeypatch, fake, last_error=driver._ERROR_SERVICE_DOES_NOT_EXIST)
+    result = driver.stop_and_remove("WinDivert")
+    check("a genuinely absent service reads as not installed",
+          result == "WinDivert: not installed", f"({result})")
+
+
+def test_stop_and_remove_surfaces_an_unexpected_open_error(monkeypatch):
+    fake = _FakeAdvapi(scm=1, service=0)
+    _fake_scm(monkeypatch, fake, last_error=1234)
+    result = driver.stop_and_remove("WinDivert")
+    check("an unexpected Windows error is surfaced with its code",
+          "Windows error 1234" in result, f"({result})")
+
+
+def test_stop_and_remove_is_a_noop_off_windows(monkeypatch):
+    monkeypatch.setattr(driver, "is_windows", lambda: False)
+    result = driver.stop_and_remove("WinDivert")
+    check("off Windows there is nothing to remove",
+          result == "WinDivert: not Windows, nothing to do", f"({result})")
+
+
+# --- cleanup_driver: the --cleanup-driver / release_on_exit orchestration ----- #
+def test_cleanup_driver_stops_every_installed_service(monkeypatch):
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_admin", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers",
+                        lambda: {"WinDivert": "running", "WinDivert1.4": "stopped"})
+    visited = []
+    monkeypatch.setattr(driver, "stop_and_remove",
+                        lambda name: (visited.append(name),
+                                      f"{name}: stopped and removed")[1])
+    monkeypatch.setattr(driver, "stale_temp_dirs", lambda: [])
+    lines = driver.cleanup_driver()
+    check("cleanup visits every installed service",
+          visited == ["WinDivert", "WinDivert1.4"], f"({visited})")
+    check("cleanup reports a line per service",
+          [l for l in lines if "stopped and removed" in l] == lines, f"({lines})")
+
+
+def test_cleanup_driver_surfaces_stale_temp_directories(monkeypatch):
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_admin", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers", lambda: {"WinDivert": "running"})
+    monkeypatch.setattr(driver, "stop_and_remove",
+                        lambda name: f"{name}: stopped and removed")
+    monkeypatch.setattr(driver, "stale_temp_dirs", lambda: [r"C:\Temp\_MEI123"])
+    lines = driver.cleanup_driver()
+    check("a leftover onefile temp dir is surfaced",
+          any("_MEI123" in l for l in lines), f"({lines})")
+
+
+def test_cleanup_driver_refuses_without_administrator(monkeypatch):
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_admin", lambda: False)
+    lines = driver.cleanup_driver()
+    check("cleanup without admin explains why it cannot",
+          any("Administrator" in l for l in lines), f"({lines})")
+
+
+def test_cleanup_driver_with_nothing_installed_says_so(monkeypatch):
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_admin", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers", lambda: {})
+    lines = driver.cleanup_driver()
+    check("nothing installed reports nothing to clean up",
+          any("nothing to clean up" in l for l in lines), f"({lines})")

--- a/tests/test_driver_windows.py
+++ b/tests/test_driver_windows.py
@@ -182,7 +182,12 @@ def _fake_scm(monkeypatch, fake, last_error=0):
     monkeypatch.setattr(driver, "is_windows", lambda: True)
     monkeypatch.setattr(driver, "_advapi", lambda: fake)
     monkeypatch.setattr(driver, "_status_type", lambda: _FakeStatus)
-    monkeypatch.setattr(ctypes, "get_last_error", lambda: last_error)
+    # ctypes.get_last_error is Windows-only (POSIX ctypes has get_errno instead), so
+    # on the Linux CI the attribute does not exist to replace. raising=False CREATES
+    # it for the duration of the test - which is exactly right, since we are forcing
+    # the Windows-only stop_and_remove path to run on every platform. monkeypatch
+    # removes it again on teardown.
+    monkeypatch.setattr(ctypes, "get_last_error", lambda: last_error, raising=False)
 
 
 def test_stop_and_remove_stops_then_deletes_and_closes_every_handle(monkeypatch):


### PR DESCRIPTION
Engineering-review finding **F5**: the two lowest-covered spots in the codebase were both
**error / teardown code that only ever runs on a user's machine** - exactly where an untested
edge is worst. This adds coverage for both. **No production code changed.**

## `driver.stop_and_remove` was 0%

It STOPS and DELETES a Windows service, and it runs on the way out of **every real-capture
session** (`release_on_exit`), so it must never be exercised for the first time in the field.
It is pure Service-Manager glue, so `tests/test_driver_windows.py` now drives every branch
through a fake advapi - no admin, no real driver, and identically on the Linux CI (`is_windows`
is forced True; the fake status is a real `ctypes.Structure` so `byref` has a valid target):

- stop + delete succeeds (and both handles are closed, STOP before DELETE)
- a delete that will not take ("stopped (removal failed)")
- no Service-Manager handle -> the Administrator hint
- access-denied vs not-installed vs an unexpected error code (the distinction the access-mask
  fix exists to preserve)
- the off-Windows no-op

Plus four `cleanup_driver` orchestration cases (the per-service loop, stale `_MEI*` temp dirs,
the admin gate, nothing installed). **driver.py 75% -> 88%**; the `stop_and_remove` block, which
was entirely uncovered, is now exercised. Mutation-checked: forcing the delete to read as failed
turns the success test red.

The one thing a fake cannot stand in for - the 64-bit HANDLE prototypes that a real advapi call
needs on Win64 - stays pinned by the existing `test_advapi_declares_pointer_sized_prototypes`
against the real library.

## `gui/dialogs.py` was 16%

The dark in-app modals that replace `tkinter.messagebox` (native, un-themable, OS-locale
buttons). New `tests/test_dialogs.py` drives them on the fake tkinter - where `wait_window` is a
no-op, so each modal runs its whole construction path and returns its dismissal default - and
exercises `_close` directly. **16% -> 85%**; the remaining lines are the `crashlog.note`
except-branches that only fire when a real Tk call raises, which the fake cannot provoke.

## Verification

- `python -m pytest tests`: **632 passed, 0 failed** (elevated shell, no admin flakes)
- coverage gate: **84.53%** with the gate at 80 (up from 82.99%)
- `python smoke_gui.py`: OK
- new tests noted in `CHANGELOG-INTERNAL.md` (convention 39); no user-facing change, no version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
