### PR TITLE
fix(gui): show the connections "impaired?" column as a session-long record

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,45 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: the connections "impaired?" column is a session record, not a live port lookup
+
+- **Symptom (reported from the field, Chrome):** targeting `chrome.exe` showed a connections
+  table where the large majority of rows read "no" in the impaired? column, so the tool looked
+  like it was missing most of the traffic. It was not - the column was misreporting FINISHED
+  connections.
+- **Cause:** `gui/pages/conns.py::_render` computed the column LIVE via
+  `engine.in_scope_now` -> `BeanCore.in_scope` -> `local_port in target_ports`. A closed or idle
+  flow's ephemeral port has left the socket table, so the live test returns False for every
+  connection that is no longer open - which is most of them on a browser. Meanwhile the stored
+  per-flow `scoped` flag (`engine._log_conn`) tracked only the LATEST packet, and both the CSV
+  export (`gui/app.py`) and the column's sort key (`views.py::_SORT["scoped"]`) already read
+  that stored flag - so the on-screen cell, its sort order and the CSV disagreed (two semantics,
+  three call sites).
+- **Fix:** `engine._log_conn` now keeps `scoped` STICKY per flow
+  (`c["scoped"] = c["scoped"] or bool(scoped)`) - a session-long "was ever in impairment scope"
+  record - and `conns.py::_render` reads that stored flag instead of the live lookup. Cell, sort
+  key and CSV now all read the one stored flag. The LIVE "in scope now" signal is unchanged: it
+  is the row HIGHLIGHT (`_tag_of`, still via `in_scope`), so a chrome->firefox narrowing drops
+  the highlight without erasing the record.
+- **Reversed decision (recorded so it is not re-reversed):** the column was deliberately made
+  live once, to stop an idle flow keeping a stale "yes" after the target was narrowed. That
+  concern is now carried by the HIGHLIGHT (live), while the COLUMN is the audit trail (sticky) -
+  the two signals were conflated into one before.
+- New test: `tests/test_engine.py::test_scoped_is_a_sticky_session_record` - three packets on one
+  flow (in scope, then twice out) keep the flag True, and a never-scoped flow stays False, driven
+  straight through `_log_conn` (no thread timing).
+- Updated test: `tests/test_conns_columns.py::test_connection_columns_tag_and_footer` - the
+  out-of-current-target `svchost` row now asserts column "yes" (stored record) with NO highlight
+  tag (live), locking the two-signal split. `tests/test_conns_export.py` and
+  `tests/test_engine.py::test_connection_records_scope_and_dropped` were already consistent with
+  the stored flag and pass unchanged.
+- i18n: `tips.col_scoped` reworded in `lang/en.json` + `lang/pl.json` (values only; key set and
+  sort order unchanged, so `test_i18n.py` parity holds).
+- Scope: this is the display/coherence half (Chunk 1). The underlying port->PID resolution is
+  still a periodic socket-table snapshot, so short-lived connections that open and close inside a
+  refresh window can still escape impairment (`tests/test_target_resolver.py` documents the race);
+  closing that at the source with the WinDivert FLOW/SOCKET layer is tracked separately.
+
 ### Tests: property-based coverage for the two packet-mutating functions (F6)
 
 Engineering-review finding F6: the property suites covered matchers and `decide()`, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The "impaired?" column now reflects the whole session, not just this instant.** When you
+  targeted a process, the column asked "is this connection's port in the target *right now*" -
+  so the moment a connection closed (a browser closes hundreds a minute) its row flipped to
+  "no", and a run that was impairing all of Chrome looked like it was catching almost nothing.
+  The column now records whether a connection was in impairment scope at any point this session
+  and keeps saying "yes" after it closes. Which connections are being impaired *right now* is
+  still shown by the row highlight, which follows your current target. The connections CSV
+  export already worked this way, so the table and the export now agree.
+
 - **One bad translation file no longer stops the whole program.** Language files are plain JSON
   next to the program, and you can add your own. If one of them had a malformed `_meta` header -
   the little block naming the language - the program refused to start at all, with a technical

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -389,9 +389,18 @@ class BeanEngine:
                 c["bytes_in"] += size
             if dropped:
                 c["dropped"] += 1
-            # scoped tracks the LATEST packet: targeting can change mid-session,
-            # and the row should reflect whether the flow is in scope right now
-            c["scoped"] = bool(scoped)
+            # scoped is STICKY: once a flow has been in impairment scope it stays
+            # marked, for the life of the session's connection log. It is the audit
+            # answer to "was this connection impaired", not "is its port in the
+            # target set right now" - those differ the instant a socket closes, and
+            # a browser closes hundreds a minute. A live check flipped every
+            # finished flow to "not impaired" the moment it closed (its ephemeral
+            # port left the socket table), so a run that impaired all of chrome read
+            # as a table full of "no". The LIVE "in scope now" signal still exists -
+            # it is the row highlight (gui/pages/conns.py::_tag_of, via in_scope) -
+            # so narrowing chrome->firefox drops the highlight without erasing the
+            # record that the chrome flow WAS impaired.
+            c["scoped"] = c["scoped"] or bool(scoped)
             c["last"] = now
             c["dir"] = "out" if is_out else "in"
             c["proto"] = proto

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -244,9 +244,15 @@ class ConnsPage:
         idle = max(0.0, now - last)
         dur = max(0.0, last - c.get("first", now))
         packets = c.get("packets") or 0
-        # scope is asked of the engine NOW, not read from the flow's last packet:
-        # an idle flow kept a stale flag (chrome-only target, firefox still "yes")
-        scoped = T("conns.yes") if self._in_scope(c) else T("conns.no")
+        # The COLUMN is the session-long record "was this flow ever in impairment
+        # scope" (a sticky flag the engine keeps per flow), NOT a live lookup. A
+        # closed or idle flow's ephemeral port has left the socket table, so a live
+        # check flips every finished connection to "no" the instant it closes -
+        # which read as "the tool caught almost nothing" even when it had impaired
+        # them all while they were alive. The LIVE "in scope right now" signal is
+        # the row highlight (_tag_of), which still follows the CURRENT target, so
+        # narrowing chrome->firefox drops the highlight without erasing the record.
+        scoped = T("conns.yes") if c.get("scoped") else T("conns.no")
         return (connection_proc(c, self.app.proc_map) or "?",
                 c.get("pid") or "", c.get("proto", "IP"), c.get("remote_ip"),
                 c.get("remote_port"), c.get("local_port"), packets,

--- a/lang/en.json
+++ b/lang/en.json
@@ -385,7 +385,7 @@
   "tips.col_proto": "Transport protocol of the connection (TCP / UDP / IP).",
   "tips.col_remote_ip": "Address this machine is talking to. Right-click a row to limit the impairments to it.",
   "tips.col_remote_port": "Port on the remote side (443 = HTTPS, 53 = DNS, 80 = HTTP).",
-  "tips.col_scoped": "Whether this connection is in targeting scope - i.e. being impaired, not merely observed. With no targeting set, every connection is in scope.",
+  "tips.col_scoped": "Whether this connection was in impairment scope this session - impaired, not just watched. It stays \"yes\" after the connection closes, as a record; the row is highlighted only while it still matches the current target. With no targeting set, every connection is in scope.",
   "tips.col_up": "Data sent (uploaded) on this connection, in kilobytes.",
   "tips.confirm_close": "When on, closing the window during a running capture asks for confirmation first. Turn off to close without being asked.",
   "tips.conn_search": "Filter connections by IP address, port or direction (e.g. '443', '10.0.0', 'out').",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -385,7 +385,7 @@
   "tips.col_proto": "Protokół transportowy połączenia (TCP / UDP / IP).",
   "tips.col_remote_ip": "Adres, z którym rozmawia ta maszyna. Kliknij wiersz prawym przyciskiem, aby ograniczyć do niego zakłócenia.",
   "tips.col_remote_port": "Port po stronie zdalnej (443 = HTTPS, 53 = DNS, 80 = HTTP).",
-  "tips.col_scoped": "Czy to połączenie jest w zakresie celowania - czyli psute, a nie tylko obserwowane. Bez ustawionego celowania w zakresie jest każde połączenie.",
+  "tips.col_scoped": "Czy to połączenie było w zakresie psucia w tej sesji - psute, a nie tylko obserwowane. Zostaje „tak” po zamknięciu połączenia, jako zapis; wiersz jest podświetlony tylko póki pasuje do bieżącego celu. Bez ustawionego celowania w zakresie jest każde połączenie.",
   "tips.col_up": "Dane wysłane (upload) na tym połączeniu, w kilobajtach.",
   "tips.confirm_close": "Gdy włączone, zamknięcie okna w trakcie przechwytywania najpierw pyta o potwierdzenie. Wyłącz, by zamykać bez pytania.",
   "tips.conn_search": "Filtruj połączenia po adresie IP, porcie lub kierunku (np. '443', '10.0.0', 'out').",

--- a/tests/test_conns_columns.py
+++ b/tests/test_conns_columns.py
@@ -12,9 +12,13 @@ def test_connection_columns_tag_and_footer():
     run_gui('''
         page = app.pages["connections"]
         app.engine.now_ref = lambda: 100.0
-        # target the chrome flow's local port only. svchost carries a STALE
-        # scoped=True (it was in scope before the target was narrowed); the column
-        # and tag must follow the CURRENT target, not that stored flag.
+        # target the chrome flow's local port only. svchost carries scoped=True as
+        # a session record: it WAS in impairment scope earlier, before the target
+        # was narrowed to chrome. The two signals now differ on purpose:
+        #   * the COLUMN is that stored record  -> svchost still reads "yes"
+        #   * the ROW HIGHLIGHT is the live target -> svchost is NOT highlighted
+        # (before, a live column flipped every closed flow to "no", so a run that
+        #  impaired all of chrome looked like it had caught nothing.)
         app.engine.core.set_target(True, {5000})
         rows = [
             dict(local_port=5000, remote_ip="1.1.1.1", remote_port=443, proto="TCP",
@@ -41,10 +45,12 @@ def test_connection_columns_tag_and_footer():
         assert chrome_vals[7] == bnt.T("conns.yes"), chrome_vals     # impaired?
         assert str(chrome_vals[8]) == "3", chrome_vals               # dropped
         assert svc_vals[1] == "", svc_vals                           # pid None -> blank
-        # svchost is out of the CURRENT target: "no" despite its stale scoped=True
-        assert svc_vals[7] == bnt.T("conns.no"), svc_vals
+        # svchost was impaired earlier this session: the COLUMN keeps the record
+        # even though it is out of the CURRENT target.
+        assert svc_vals[7] == bnt.T("conns.yes"), svc_vals
 
-        # the in-scope row is tagged for the highlight; the out-of-scope row is not
+        # the HIGHLIGHT is live: only the row in the current target is tagged, so the
+        # out-of-scope svchost row keeps its record but loses the highlight.
         assert "impaired" in chrome_tags, chrome_tags
         assert svc_tags == (), svc_tags
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -284,6 +284,48 @@ def test_connection_records_scope_and_dropped():
           "pid" in targeted and "pid" in other)
 
 
+def test_scoped_is_a_sticky_session_record():
+    """The "impaired?" flag is a session-long record, not the last packet's scope.
+
+    Once a flow has been in impairment scope, its row must keep saying so after the
+    flow LEAVES scope - the target was narrowed, or the flow just went idle and its
+    socket closed. A browser closes hundreds of connections a minute; if the flag
+    tracked only the latest packet (or a live port lookup) every finished flow would
+    read "not impaired" the instant it closed, so a run that impaired all of chrome
+    looked like it had caught nothing. The LIVE "in scope now" signal is a separate
+    thing (the connections page highlights the row via BeanCore.in_scope).
+
+    Driven straight through ``_log_conn`` so the stickiness is asserted without any
+    thread timing: three packets on one flow (in scope, then twice out), plus a flow
+    that is never in scope at all.
+    """
+    eng = BeanEngine()
+
+    def row(port):
+        return {c["local_port"]: c for c in eng.connections_snapshot()}[port]
+
+    key = (5000, "1.1.1.1", 443)
+    # first packet arrives in scope (targeting matched, an impairment applied)
+    eng._log_conn(key, "1.1.1.1", 443, 5000, True, 100, 1.0, "TCP",
+                  dropped=True, scoped=True)
+    check("in scope on the first packet", row(5000)["scoped"] is True,
+          f"(scoped={row(5000)['scoped']})")
+
+    # later packets on the SAME flow arrive OUT of scope (target narrowed away):
+    # the record must not flip back to "not impaired"
+    for t in (2.0, 3.0):
+        eng._log_conn(key, "1.1.1.1", 443, 5000, True, 100, t, "TCP",
+                      dropped=False, scoped=False)
+    check("still recorded as impaired after leaving scope", row(5000)["scoped"] is True,
+          f"(scoped={row(5000)['scoped']})")
+
+    # a flow that is NEVER in scope stays out - stickiness only ever adds "yes"
+    eng._log_conn((5001, "2.2.2.2", 80), "2.2.2.2", 80, 5001, True, 100, 4.0, "TCP",
+                  dropped=False, scoped=False)
+    check("a never-scoped flow is not marked impaired", row(5001)["scoped"] is False,
+          f"(scoped={row(5001)['scoped']})")
+
+
 def test_set_seed_variants():
     sh = BeanEngine()
     for v in (None, "", -1):


### PR DESCRIPTION
## What & why

Targeting a process (e.g. `chrome.exe`) showed a connections table where the large
majority of rows read **"no"** in the *impaired?* column, so the tool looked like it was
missing most of the traffic. It was not — the column was **misreporting finished
connections**.

The column was recomputed **live** (`conns.py::_render` → `engine.in_scope_now` →
`core.in_scope` → `local_port in target_ports`). A closed or idle flow's ephemeral port
has left the socket table, so the live test returns `False` for every connection that is no
longer open — which is most of them on a browser. A run that impaired *all* of Chrome
therefore rendered as a table full of "no".

## The fix

- **`engine._log_conn`** keeps the per-flow `scoped` flag **sticky**
  (`c["scoped"] = c["scoped"] or bool(scoped)`) — a session-long *"was ever in impairment
  scope"* record.
- **`conns.py::_render`** reads that stored flag instead of the live lookup.
- The **live "in scope now"** signal is unchanged: it is the row **highlight** (`_tag_of`,
  still via `in_scope`), so narrowing chrome→firefox drops the highlight without erasing the
  record.

**Two-signal design:** the *column* is the audit trail (sticky); the *row highlight* is the
current target (live).

### Coherence bug also fixed

The on-screen cell was live, while the column's **sort key** (`views.py`) and the **CSV
export** (`gui/app.py`) already read the *stored* flag — three call sites, two semantics.
All three now read the one sticky flag, so the table, its sort order and the export agree.

## Tests

- **new** `tests/test_engine.py::test_scoped_is_a_sticky_session_record` — three packets on
  one flow (in scope, then twice out) keep the flag `True`; a never-scoped flow stays
  `False`. Driven straight through `_log_conn`, no thread timing.
- **rewrote** `tests/test_conns_columns.py::test_connection_columns_tag_and_footer` — an
  out-of-current-target row now asserts column "yes" (stored record) with **no** highlight
  tag (live), locking the two-signal split.
- `tests/test_conns_export.py` and `test_engine.py::test_connection_records_scope_and_dropped`
  were already consistent with the stored flag and pass unchanged.
- Full suite green.

## Scope

This is **Chunk 1 of 2 (display truth)**. The underlying port→PID resolution is still a
periodic socket-table snapshot, so short-lived connections that open and close inside a
refresh window can still escape impairment (`tests/test_target_resolver.py` documents the
race). Closing that at the source with the **WinDivert FLOW/SOCKET layer** is Chunk 2,
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
