### PR TITLE
docs(portmap): correct the recycle-check cost - it is elevation-bound, not ~180 ms

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Docs: correct the resolver recycle-check cost - it is elevation-bound, not "~180 ms"
+
+Measured 2026-07-24 with Chrome open, elevated AND non-elevated (`runas /trustlevel:0x20000`),
+because the deferred "~180 ms per rebuild" perf follow-up from the socket-layer work did not
+reproduce elevated. It is real prose drift (convention 5): two docstrings disagreed - `_psutil_created`
+claimed 0.005 ms, `info` claimed ~5 ms - and both were right for a different elevation.
+
+- `create_time()` is ~0.005 ms per PID when `OpenProcess` succeeds and ~5.7 ms when it is DENIED
+  (psutil then scans the whole system for that one PID). Denial is an ELEVATION question, not the
+  "hardened process / Chrome renderer" one the older note assumed - renderers do not own sockets,
+  so they never reach this loop. ELEVATED: 0 of 27 socket-owning PIDs denied, warm recycle check
+  ~0.16 ms, cold `resolve('chrome')` ~36 ms. NON-ELEVATED: 16 of 27 denied, ~90-180 ms warm,
+  ~381 ms cold - which is where the handoff's ~365/180 ms came from.
+- Real impairment ALWAYS runs elevated (WinDivert will not open without admin; a non-admin START
+  fails), so the check is cheap in every real session. The only non-elevated path that runs the
+  resolver at all is `--simulate` (synthetic packets; the cost is on the resolver thread, never
+  the capture one).
+- DECISION, rejected: batching the denied PIDs in one `NtQuerySystemInformation`. It speeds only
+  the non-elevated `--simulate` warm check, does nothing for the elevated hot path, and nothing
+  for the cold resolve (name resolution dominates that, not create_time). Not worth the ctypes
+  surface for a demo mode. This closes the "known perf follow-up" / "handed to a follow-up" notes
+  in the entries below.
+- Corrected in `portmap.py` (`_psutil_created` and `PortTable.info` docstrings) and PROJECT_NOTES.
+  No code behaviour changed - nothing a user notices - so CHANGELOG.md is untouched.
+
 ### Fixed: the UI rebuild no longer piles up `<Configure>` handlers on the root
 
 Follow-up to the teardown-crash fix. `App._build_ui` runs on every language switch, and the root

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -311,12 +311,13 @@ def _psutil_created(pid):
 
     This is what tells a recycled PID from the process that used to own it, and it
     is the reason the cache can be trusted at all. Deliberately its OWN call rather
-    than part of the full lookup: measured on Windows, ``create_time()`` costs
-    ~0.005 ms per PID while ``name()`` costs ~5 ms, because only the latter has to
-    open the process and read its image path. Verifying is a thousand times cheaper
-    than re-resolving, which is what makes checking on EVERY cache hit affordable:
-    it adds 0.35 ms to a resolve that took 0.93 ms, i.e. 2.2% of a core at the
-    resolver's measured rate.
+    than part of the full lookup: it is the cheapest identity probe there is. Its
+    cost is decided by one thing - whether ``OpenProcess`` succeeds. MEASURED
+    2026-07-24 (Win11, CPython 3.14): ~0.005 ms per PID when the handle opens,
+    ~5.7 ms when it is DENIED, because psutil then falls back to a full-system scan
+    for that single PID. Whether it opens is an ELEVATION question, not a "hardened
+    process" one - see ``PortTable.info`` for what that means per refresh, and why
+    it is cheap in every real session.
     """
     try:
         import psutil
@@ -458,18 +459,23 @@ class PortTable:
         impaired, or an innocent process that inherits the old PID is. Both were
         reproduced against the real table before this check existed.
 
-        Verifying is cheaper than a full resolve, but it is NOT free, and an earlier
-        version of this note badly understated it (claimed ``create_time()`` = 0.005 ms
-        and 0.13 ms per rebuild; neither reproduced - convention 5). MEASURED
-        2026-07-22: ``create_time()`` costs ~5 ms per PID when it must open a fresh
-        handle to a HARDENED process (Chrome's renderers, some services), so
-        re-verifying every socket-owning PID is ~180 ms per rebuild with a browser
-        open (26 PIDs) - against sub-millisecond on a quiet machine. It runs on the
-        RESOLVER thread, never the capture one, and it is the price of the recycle
-        check below (catching a PID whose process was replaced). Reducing it - batch
-        the create times in one syscall, or verify by name against a cached process
-        snapshot - is a known perf follow-up, deliberately not folded into the
-        socket-layer work.
+        Verifying is cheaper than a full resolve, but its cost turns entirely on
+        whether ``OpenProcess`` succeeds - and that is an ELEVATION question, not the
+        "hardened process" one an earlier version of this note assumed. MEASURED
+        2026-07-24 (Win11, CPython 3.14, Chrome open): ``create_time()`` is ~0.005 ms
+        per PID when the handle opens and ~5.7 ms when it is DENIED (psutil then
+        scans the whole system for that one PID). An ADMIN opens every socket-owning
+        PID - 0 of 27 denied here - so a warm refresh's recycle check is ~0.16 ms; a
+        NON-admin is denied on system / other-user PIDs (16 of 27) and it climbs to
+        ~90-180 ms, with the cold resolve at ~380 ms against ~36 ms elevated. Real
+        impairment ALWAYS runs elevated (WinDivert will not open without admin), so
+        this is cheap in every real session; the slow figure appears only on the one
+        non-elevated path that runs the resolver at all, ``--simulate`` (synthetic
+        packets, and the cost sits on the RESOLVER thread, never the capture one).
+        Batching the denied PIDs in one ``NtQuerySystemInformation`` was measured and
+        REJECTED (2026-07-24): it speeds only the non-elevated warm check - a demo
+        mode - and does nothing for the elevated hot path or for the cold resolve,
+        which NAME resolution dominates.
         """
         if pid is None:
             return ("", None)


### PR DESCRIPTION
## What and why

The socket-layer work left a deferred perf follow-up: "resolver refresh is ~180 ms/rebuild (create_time recycle check)", with a plan to batch the create-times in one syscall. Before building that, I measured it — and the premise does not hold under the conditions that matter.

**Measured 2026-07-24** (Win11, CPython 3.14, Chrome open), elevated *and* non-elevated (`runas /trustlevel:0x20000`):

| | **elevated** (every real session) | **non-elevated** (`--simulate` on non-admin) |
|---|---|---|
| socket PIDs the recycle check is slow on | **0** of 27 | **16** of 27 |
| warm refresh (the recycle check) | **0.16 ms** | ~90–180 ms |
| cold `resolve('chrome')` | **36 ms** | **381 ms** |

The cost of `create_time()` is decided by one thing: whether `OpenProcess` succeeds — ~0.005 ms when it does, ~5.7 ms when it's **denied** (psutil then scans the whole system for that one PID). Denial is an **elevation** question, not the "hardened process / Chrome renderer" one the old note assumed — renderers don't own sockets, so they never reach this loop. The handoff's ~365/180 ms was measured **non-elevated**; my 381 ms non-elevated cold matches it.

Real impairment **always** runs elevated — WinDivert won't open without admin, so a non-admin START fails outright. So the recycle check is already cheap (0.16 ms warm / 36 ms cold) in every real session. The *only* non-elevated path that runs the resolver at all is `--simulate` (synthetic packets; the cost sits on the resolver thread, never the capture one).

Two docstrings had drifted apart — `_psutil_created` claimed 0.005 ms, `info` claimed ~5 ms — and each was right for a different elevation. This states it once, accurately.

### Changes

- **Docs only, no behaviour change.** Corrected the `_psutil_created` and `PortTable.info` docstrings in `beantester/portmap.py`, and the matching PROJECT_NOTES line (in the private Doc repo, not this PR).
- **Recorded the decision:** batching the denied PIDs via `NtQuerySystemInformation` was measured and **rejected** — it speeds only the non-elevated `--simulate` warm check, does nothing for the elevated hot path, and nothing for the cold resolve (which name resolution dominates, not `create_time`). Written down so the next session doesn't re-open it.

### Reviewer notes

- No `CHANGELOG.md` line: nothing a user notices (pure prose). Documented in `CHANGELOG-INTERNAL.md`, which also closes the "known perf follow-up" notes in two earlier entries.
- No new test: this changes no code path. The existing guard (`tests/test_processes.py`, the recycle-protection suite) still passes (31/31), and no test pinned the old prose.

## Checklist

- [x] `python -m pytest tests` passes locally. (`tests/test_processes.py` 31/31; docs-only change, no code path touched.)
- [x] New behaviour has tests (see `tests/` for the style). *(No behaviour change — docstring/notes correction only.)*
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. *(No UI text.)*
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`. *(Internal-only, nothing a user notices.)*
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump — the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
