### PR TITLE
docs(socketwatch): de-stale the 2b/2c prose - targeting reads the live map

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Docs: de-stale the 2b/2c prose - targeting DOES resolve against the live socket map
+
+Prose drift of the kind convention 5 exists for, with a twist: every one of these sentences was
+TRUE when written and acquired an expiry date nobody enforced. Chunks 2b/2c/2d landed (PR #38),
+so "not wired yet" became a lie sitting next to correct code - and `check_notes.py` deliberately
+does not check prose, so nothing went red. Found during an engineering review; no behaviour
+change, comments and docstrings only.
+
+- `engine.py`: the `_socketwatch` attribute comment ("NOT read by targeting yet - that is 2c")
+  and the `_start_socketwatch` docstring ("targeting does not read it yet") now point at
+  `_targeting_table()` / `_start_locked`, which is where the poller-vs-watcher choice is actually
+  made.
+- `socketwatch.py`: the module docstring no longer claims the module is "in isolation... NOT
+  wired into the engine or targeting yet (2b/2c)"; the lifecycle section header drops "in 2b".
+- `tests/test_socketwatch_wiring.py`: the docstring kept the part that is still true (this file
+  covers the plumbing only) and lost the false framing; it now names
+  `tests/test_targeting_socketwatch.py` as the guard for the resolution contract.
+- Deliberately NOT touched: the `SocketEvent` comment saying `remote_ip`/`remote_port` are
+  "carried for the connection log later (2c)". Those fields are still unconsumed, and whether
+  they get used or cut is a separate decision - fixing the sentence now would only mean writing
+  prose that decision will rewrite.
+- Follow-up on its own branch: a mechanical guard for expiring prose (`PENDING(<id>)` markers
+  checked against one list of open stage ids), because discipline alone produced four stale
+  sites in a single transition.
+
 ### Docs: correct the resolver recycle-check cost - it is elevation-bound, not "~180 ms"
 
 Measured 2026-07-24 with Chrome open, elevated AND non-elevated (`runas /trustlevel:0x20000`),

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -101,10 +101,11 @@ class BeanEngine:
         # target_resolver.py). One per engine, retargeted rather than restarted.
         self._resolver = TargetResolver()
         self._ports = portmap.default_table()   # local port -> process (capture time)
-        # Live local_port -> pid map from WinDivert SOCKET events (2b). Created in
+        # Live local_port -> pid map from WinDivert SOCKET events. Created in
         # start() only on the real-WinDivert path (or when a source is injected);
         # None on the synthetic/simulate path, where targeting falls back to the
-        # poller. See _start_socketwatch. NOT read by targeting yet - that is 2c.
+        # poller. See _start_socketwatch. Targeting resolves against it whenever a
+        # session has one - the choice is made in _targeting_table().
         self._socketwatch = None
         self.stop_reason = None     # "user" | "duration" | "fault" | "exit"
         self.fault = None           # last fatal worker error, if any
@@ -601,8 +602,8 @@ class BeanEngine:
         tests): the SOCKET-layer handle needs the same driver the NETWORK handle
         does. On the synthetic/simulate path there is nothing to open, so the engine
         keeps using the polling port table - the testable-without-WinDivert contract
-        holds. This method only keeps the map live; targeting does not read it yet
-        (that is 2c).
+        holds. This method only keeps the map LIVE; pointing targeting at it is
+        _start_locked's job (see _targeting_table).
 
         Failure to open the SOCKET handle DEGRADES to the poller; it does not fail
         the session. A tester who cannot open a second handle still gets impairment

--- a/beantester/socketwatch.py
+++ b/beantester/socketwatch.py
@@ -21,10 +21,12 @@ shrink is closed at the source. (``FLOW_ESTABLISHED`` was measured ~28 ms LATER,
 i.e. after the handshake, which is why the SOCKET layer, not the FLOW layer, is
 the source here.)
 
-Scope of this module (chunk 2a): the map and its event handling, in isolation.
-It is NOT wired into the engine or targeting yet (2b/2c). The event SOURCE is
-injected, so the map is fully testable without WinDivert; the real Windows source
-lives here too but is exercised by the smoke, not the unit tests.
+Scope of this module: the map and its event handling. ``BeanEngine`` owns its
+lifecycle (created and stopped with the session) and points ``ProcessTargeting``
+at it, so in a real session this - not the poller - is what targeting resolves
+against. The event SOURCE is injected, so the map is fully testable without
+WinDivert; the real Windows source lives here too but is exercised by the smoke,
+not the unit tests.
 
 What it is NOT
 --------------
@@ -160,7 +162,7 @@ class SocketWatcher:
     def ancestors(self, pid, depth=8):
         return self._names.ancestors(pid, depth=depth)
 
-    # -- lifecycle (driven by BeanEngine in 2b) -------------------------------- #
+    # -- lifecycle (driven by BeanEngine) -------------------------------------- #
     def start(self):
         """Open the event source and start the reader thread. Idempotent."""
         with self._lock:

--- a/tests/test_socketwatch_wiring.py
+++ b/tests/test_socketwatch_wiring.py
@@ -1,10 +1,10 @@
-"""BeanEngine drives the SocketWatcher's lifecycle (chunk 2b).
+"""BeanEngine drives the SocketWatcher's lifecycle.
 
-2b is pure plumbing: the engine creates, bootstraps, runs and stops the watcher,
-but targeting does NOT read it yet (that is 2c). So these tests assert the wiring
-- started on the real/injected path, absent on the synthetic path, bootstrapped
-from the port table, degrading (not killing) on failure, and leaving no thread
-behind - not any change in impairment behaviour.
+This file covers the PLUMBING only: the engine creates, bootstraps, runs and stops
+the watcher - started on the real/injected path, absent on the synthetic path,
+bootstrapped from the port table, degrading (not killing) on failure, and leaving
+no thread behind. That targeting actually RESOLVES against the watcher is a
+separate contract, guarded by tests/test_targeting_socketwatch.py.
 
 Driven on a fake divert (idle, so the session stays up) and an injected fake
 socket source, so no WinDivert is needed.


### PR DESCRIPTION
## What and why

Found during an engineering review of the concurrency layer. Chunks 2b/2c/2d landed in #38, so
`ProcessTargeting` has resolved against the live `SocketWatcher` map for a while now - but four
comments across three files still told the reader it was unwired ("NOT read by targeting yet -
that is 2c").

The interesting part is the failure mode, because it is not the one convention 5 usually catches.
Every one of those sentences was **true when it was written**. They carried an expiry date, and
nothing enforced it: `check_notes.py` deliberately does not check prose, so when 2c landed the
sentences quietly became lies sitting next to correct code. That is the exact shape of drift that
sends the next session down the wrong path - it reads "not wired yet" and re-derives, or worse,
re-implements.

**Prose only. No behaviour change, no executable line touched.**

- `engine.py` - the `_socketwatch` attribute comment and the `_start_socketwatch` docstring now
  point at `_targeting_table()` / `_start_locked`, where the poller-vs-watcher choice is actually
  made.
- `socketwatch.py` - the module docstring no longer claims the module is "in isolation ... NOT
  wired into the engine or targeting yet"; the lifecycle section header drops "in 2b".
- `tests/test_socketwatch_wiring.py` - kept the part that is still true (this file covers the
  plumbing only) and dropped the false framing, then named `tests/test_targeting_socketwatch.py`
  as the guard for the resolution contract. The sentence was wrong in its frame, not in its
  substance, so it was corrected rather than deleted.

Deliberately **not** touched: the `SocketEvent` comment saying `remote_ip`/`remote_port` are
"carried for the connection log later". Those fields are genuinely still unconsumed, and whether
they get used or cut is a separate decision - rewriting that sentence now would only produce prose
that decision will rewrite again.

Follow-up, on its own branch: a mechanical guard for expiring prose (`PENDING(<id>)` markers
checked against one list of open stage ids), since discipline alone produced four stale sites in a
single transition.

## Checklist

- [x] `python -m pytest tests` passes locally. (660 tests, 0 failures, on an **elevated** shell -
      so the two known non-admin failures are absent rather than excused. `smoke_gui.py`: OK.)
- [x] New behaviour has tests (see `tests/` for the style). - n/a: no new behaviour; the existing
      guards `test_socketwatch*.py` / `test_targeting_socketwatch.py` already cover the contract
      the prose now describes correctly.
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. -
      n/a: no UI text.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in
      `CHANGELOG-INTERNAL.md`, under `[Unreleased]`. - internal only (convention 39): nothing about
      this is visible to a tester.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
