### PR TITLE
refactor(socketwatch): carry only the pid and port a socket event is for

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,33 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Changed: SocketEvent carries only what the map is for (closes socket-event-fields)
+
+The SOCKET-layer event used to carry `proto`, `remote_ip`, `remote_port` and `outbound` "for the
+connection log later". Nothing ever read them, and an engineering review found out why that never
+became a problem worth solving: for all four, the NETWORK-layer packet the engine already holds is
+a strictly better source. The connection log takes `remote_ip` / `remote_port` / `proto` / direction
+straight off the packet, and the packet even distinguishes ICMP, which the SOCKET layer does not.
+The one thing a packet cannot tell us is the owning pid - which is precisely what is left.
+
+- `socketwatch.py`: `SocketEvent` is now `kind pid local_port`. `_ipv4()` goes with it, so the real
+  Windows source no longer decodes an address per event for nobody.
+- Dropping `_ipv4()` also removes a live TRAP. It decodes IPv4 only (`addr[0]` read as a 32-bit
+  int), so the first person to "just wire up the field we already have" would have shipped garbage
+  for IPv6 into a user-visible column, in a tool whose traffic filters all cover v4 AND v6.
+- PRESERVED from the deleted `test_ipv4_decodes_high_byte_first`, because the code is gone but the
+  knowledge should not be: the 2026-07-22 spike established that WinDivert stores the IPv4 address
+  MSB-first in `addr[0]`, and that the naive low-byte-first decode rendered 192.168.1.29 as
+  29.1.168.192. If remote addresses are ever wanted again, start there - and extend it to IPv6.
+- Helpers updated in `test_socketwatch.py`, `test_socketwatch_wiring.py` and
+  `test_targeting_socketwatch.py`. `OPEN_PENDING` is now empty, which is its healthy state.
+- Guard fix, found BY this closing: `test_no_stale_pending_markers` now skips `CHANGELOG*.md`. A
+  changelog records what HAPPENED and is dated by its nature, so the entry below that announced the
+  marker stays true after the marker is gone - flagging it was a false positive, and the first real
+  closing walked straight into it. Re-verified by mutation after the fix: a marker naming an
+  unlisted stage in an ordinary `.md` still turns the test red, so the scan was narrowed, not
+  broken.
+
 ### Tests: a mechanical guard for prose with an expiry date (convention 44)
 
 The 2b/2c drift fixed below was not a set of FALSE claims - it was four claims that were true when

--- a/beantester/socketwatch.py
+++ b/beantester/socketwatch.py
@@ -55,26 +55,13 @@ BIND, CONNECT, LISTEN, ACCEPT, CLOSE = 3, 4, 5, 6, 7
 _ADD = frozenset({BIND, CONNECT, LISTEN, ACCEPT})
 
 # One socket-layer event, normalised away from the ctypes struct so the map logic
-# (and its tests) never touch pydivert. The map keys on local_port alone: proto,
-# remote_ip, remote_port and outbound are carried but NOT consumed anywhere yet,
-# and whether the connection log should use them or they should be cut is still
-# open - PENDING(socket-event-fields).
-SocketEvent = namedtuple(
-    "SocketEvent", "kind pid proto local_port remote_ip remote_port outbound")
-
-
-def _ipv4(addr):
-    """WinDivert stores the IPv4 address in ``addr[0]``, MSB = first octet.
-
-    Verified against a known local IP in the 2026-07-22 spike: the naive
-    low-byte-first decode produced ``192.168.1.29`` reversed as ``29.1.168.192``,
-    so the octets are read high-to-low here.
-    """
-    try:
-        v = int(addr[0]) & 0xFFFFFFFF
-    except Exception:
-        return ""
-    return ".".join(str((v >> s) & 0xFF) for s in (24, 16, 8, 0))
+# (and its tests) never touch pydivert. An event carries only what this map is for:
+# WHO owns a local port. It used to also carry proto / remote_ip / remote_port /
+# outbound "for the connection log later", and nothing ever read them - because the
+# NETWORK-layer packet the engine already holds is a strictly better source for all
+# four (it even distinguishes ICMP, which the SOCKET layer does not). The one thing
+# a packet cannot tell us is the owning pid, which is exactly what is left here.
+SocketEvent = namedtuple("SocketEvent", "kind pid local_port")
 
 
 class SocketWatcher:
@@ -247,11 +234,8 @@ class _WinDivertSocketSource:
             sock = pkt.socket
             if sock is None:
                 continue
-            yield SocketEvent(
-                kind=int(pkt.event), pid=int(sock.ProcessId),
-                proto=int(sock.Protocol), local_port=int(sock.LocalPort),
-                remote_ip=_ipv4(sock.RemoteAddr), remote_port=int(sock.RemotePort),
-                outbound=bool(pkt.is_outbound))
+            yield SocketEvent(kind=int(pkt.event), pid=int(sock.ProcessId),
+                              local_port=int(sock.LocalPort))
 
     def close(self):
         with crashlog.quiet("socketwatch.source.close"):

--- a/tests/test_repo_conventions.py
+++ b/tests/test_repo_conventions.py
@@ -155,11 +155,10 @@ def test_no_em_or_en_dashes_in_repo_text():
 # This set is NOT a roadmap. It is the set of stage ids that PROSE currently points
 # at, which is why an id nothing references is a failure too: it means the marker is
 # gone and the entry was left behind.
-OPEN_PENDING = {
-    # SocketEvent carries remote_ip / remote_port / proto / outbound, but the map
-    # consumes only kind / pid / local_port. Use them or cut them - undecided.
-    "socket-event-fields",
-}
+# Empty is the HEALTHY state: it means no prose in the repo is currently waiting on a
+# stage. Add an id the moment you write a sentence with an expiry date, and delete it
+# when the stage lands - the second check below then points at whatever prose is left.
+OPEN_PENDING = set()
 
 PENDING_EXTS = (".py", ".md")
 
@@ -190,6 +189,13 @@ def test_no_stale_pending_markers():
                 continue
             if name == os.path.basename(__file__):
                 continue                 # the registry does not scan itself
+            if name.startswith("CHANGELOG"):
+                # A changelog records what HAPPENED and is dated by its nature: an
+                # entry saying "added a marker named X" stays TRUE after X closes, so
+                # it is history, not drift. Found the hard way - the first real
+                # closing (socket-event-fields) tripped over the very entry that
+                # announced the marker.
+                continue
             path = os.path.join(dirpath, name)
             text = open(path, encoding="utf-8", errors="replace").read()
             for lineno, line in enumerate(text.splitlines(), 1):

--- a/tests/test_socketwatch.py
+++ b/tests/test_socketwatch.py
@@ -11,12 +11,12 @@ import threading
 import time
 
 from beantester.socketwatch import (ACCEPT, BIND, CLOSE, CONNECT, LISTEN,
-                                     SocketEvent, SocketWatcher, _ipv4)
+                                     SocketEvent, SocketWatcher)
 from fakes import check
 
 
-def ev(kind, pid, port, proto=6, remote_ip="1.2.3.4", remote_port=443, outbound=True):
-    return SocketEvent(kind, pid, proto, port, remote_ip, remote_port, outbound)
+def ev(kind, pid, port):
+    return SocketEvent(kind, pid, port)
 
 
 class _FakeNames:
@@ -229,13 +229,3 @@ def test_stop_does_not_record_the_close_induced_error_as_a_crash(monkeypatch):
     time.sleep(0.05)
     check("a mid-run failure IS recorded", len(recorded) == 1, f"({recorded})")
     w2.stop()
-
-
-# -- the address decode locked by the spike ----------------------------------- #
-def test_ipv4_decodes_high_byte_first():
-    """The 2026-07-22 spike proved WinDivert stores the IPv4 addr MSB-first in
-    addr[0]; the naive low-byte-first decode printed 192.168.1.29 as
-    29.1.168.192. This locks the correct order."""
-    check("ipv4 reads MSB-first", _ipv4([0xC0A8011D, 0, 0, 0]) == "192.168.1.29",
-          f"({_ipv4([0xC0A8011D, 0, 0, 0])})")
-    check("a bad addr array is empty, not an exception", _ipv4(None) == "")

--- a/tests/test_socketwatch_wiring.py
+++ b/tests/test_socketwatch_wiring.py
@@ -27,7 +27,7 @@ def _wait(pred, timeout=5.0):
 
 
 def ev(kind, pid, port):
-    return SocketEvent(kind, pid, 6, port, "1.2.3.4", 443, True)
+    return SocketEvent(kind, pid, port)
 
 
 class _FakeSocketSource:

--- a/tests/test_targeting_socketwatch.py
+++ b/tests/test_targeting_socketwatch.py
@@ -29,7 +29,7 @@ def _wait(pred, timeout=5.0):
 
 
 def ev(kind, pid, port):
-    return SocketEvent(kind, pid, 6, port, "1.2.3.4", 443, True)
+    return SocketEvent(kind, pid, port)
 
 
 class _Names:


### PR DESCRIPTION
## What and why

`SocketEvent` carried `proto`, `remote_ip`, `remote_port` and `outbound` "for the connection log
later". Nothing ever read them, and the review found out why that never hurt: **for all four, the
NETWORK-layer packet the engine already holds is a strictly better source.** The connection log
takes the remote address, port, proto and direction straight off the packet, and the packet even
distinguishes ICMP, which the SOCKET layer does not. The one thing a packet cannot tell us is the
owning pid - and that is exactly what the event still carries.

So the honest answer to "what do we gain by wiring these up" was: nothing. The Connections table
already shows all of it, from a better source.

Keeping them was not free either. `_ipv4()` ran per event for nobody, and it decodes **IPv4 only**
(`addr[0]` read as a 32-bit int). The first person to "just wire up the field we already have"
would have shipped garbage for IPv6 into a user-visible column, in a tool whose traffic filters all
cover v4 **and** v6. A dead field with a plausible-looking comment on it is a trap, which is the
shape of drift this project keeps paying for.

**What a reviewer should know:**

- **A deleted test's knowledge was preserved, not dropped.** `test_ipv4_decodes_high_byte_first`
  encoded a real measured finding from the 2026-07-22 spike: WinDivert stores the IPv4 address
  MSB-first in `addr[0]`, and the naive low-byte-first decode rendered `192.168.1.29` as
  `29.1.168.192`. The decoder is gone, so the test goes with it - but the finding now lives in
  `CHANGELOG-INTERNAL.md`, with a note to extend it to IPv6 if remote addresses are ever wanted
  again.
- **This closes the first `PENDING` marker** added in #44, so `OPEN_PENDING` is empty again. The
  code says that empty is its *healthy* state, so nobody reads it as an unused mechanism.
- **The guard reddened on its first real closing, and it was the guard's fault.** It flagged this
  repo's own `CHANGELOG-INTERNAL.md`, which literally names the marker while announcing it. That is
  a false positive: a changelog records what HAPPENED and is dated by nature, so "added a marker
  named X" stays true after X is gone. Fixed by skipping `CHANGELOG*.md`, and the reasoning is in
  the code next to the skip.
- **The narrowed scan was re-verified by mutation, not assumed.** Weakening a guard can silently
  disable it, so after the fix a probe marker naming an unlisted stage in an ordinary `.md` was
  confirmed to still turn the test red, and green again once removed. The scan was narrowed, not
  broken. Both probe files were deleted (`git status --untracked-files=all` clean).
- **Hot path untouched:** `test_hot_path.py` (packet threads must never reach the OS) was run
  explicitly and is green. Net effect on the code is -16 lines.

## Checklist

- [x] `python -m pytest tests` passes locally. (660 tests, 0 failures - one fewer than before,
      which is precisely the deleted `_ipv4` test; on an **elevated** shell, so the two known
      non-admin failures are absent rather than excused. `smoke_gui.py`: OK.)
- [x] New behaviour has tests (see `tests/` for the style). - no new behaviour: dead fields removed
      and the existing `test_socketwatch*.py` / `test_targeting_socketwatch.py` suites still cover
      the map and its wiring through the trimmed event.
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. -
      n/a: no UI text.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in
      `CHANGELOG-INTERNAL.md`, under `[Unreleased]`. - internal only (convention 39): the fields
      were never read, so nothing a tester sees changes.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
