### PR TITLE
perf(portmap): collect the socket table outside the refresh lock

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,52 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Performance: PortTable.refresh collects the socket table outside its lock
+
+The capture thread takes `PortTable._lock` too - `name_of(cheap=True)` -> `info()` in
+`engine._process_for` - so whatever `refresh()` holds it for, the packet path can be made to wait
+for. It used to hold it across the four `iphlpapi` calls, the port->pid dict build AND the
+departed-pid diff, all O(number of sockets).
+
+MEASURED first, 2026-07-25 (Win11, CPython 3.14, elevated, medians with a control), because "the hot
+path waits N ms" is exactly the kind of claim convention 5 says to measure rather than estimate:
+
+- Lock hold with everything inside: **0.495 ms median at 119 sockets** (p99 0.843, max 0.950).
+  Python-side work scales linearly: 0.011 ms at 100 sockets, 0.303 at 10 000, **3.555 at 100 000**
+  (syscalls excluded, so a floor).
+- The capture thread's own `name_of(cheap=True)` is **0.4 us median** - and with a thread hammering
+  `refresh(force=True)` alongside, its median, p95 and p99 did not move at all. Only **2 calls in
+  20 000** waited, worst 1.5 ms. At the real rate the lock is held ~0.15% of the time.
+- So at desktop scale this was NOT an observable problem, and the honest conclusion could have been
+  "measured, rejected". What decided it was the scaling: a network tester is the thing that gets
+  pointed at 100 000 connections, and this project's history is a series of "it was fine until
+  someone ran a load test" (the flow table once settled at 3.2 million entries).
+- Also learned while checking WHO refreshes: since chunk 2c the resolver resolves against the
+  `SocketWatcher`, whose `refresh()` is a no-op - so in a real session only the watchdog refreshes
+  the `PortTable`, ~3-5x a second. The up-to-20x a second case is the poller FALLBACK
+  (`--simulate`, tests, non-Windows), which has no real capture thread to stall.
+
+After the change: **the hold is flat at ~0.018 ms** whatever the table size (188x shorter at 100 000
+sockets, and no longer a function of n). The whole call costs the same - the work left the lock
+rather than disappearing. Kept internal-only deliberately: nothing a tester can observe changes, and
+claiming a user-visible win would be unmeasured prose.
+
+- Collection and the departed diff now run unlocked; only the reference swap, `_last`, the
+  `_info` pops and `_expire_info` are taken under the lock.
+- **Overlapping refreshes cannot move the map backwards.** Two threads can now collect at once, so
+  each call takes a GENERATION under the lock before starting and installs only if nothing newer
+  landed. A counter, not a timestamp: `time.monotonic()` has ~15 ms granularity on Windows, so two
+  refreshes inside one tick would compare equal and both install. The hazard was real, not
+  theoretical - the mutation below installs the stale map without the guard.
+- The `native` handle is captured per call and the "it stopped answering" flip is re-checked under
+  the lock (`self._native is native`), so a concurrent refresh cannot have its own conclusion undone.
+- New tests in `tests/test_processes.py`, both mutation-checked:
+  `::test_the_socket_table_is_collected_without_holding_the_lock` - probes the lock from ANOTHER
+  thread, because `_lock` is an RLock and a same-thread acquire would succeed while held and prove
+  nothing; putting the collection back inside turns it red.
+  `::test_an_older_collection_does_not_overwrite_a_newer_map` - gate-driven rather than sleep-raced;
+  removing the generation guard turns it red with the stale map installed.
+
 ### Changed: start() binds the targeting under the lock that protects it
 
 `_start_locked` read `self._targeting` bare and then acted on that reference three times

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -355,41 +355,99 @@ class PortTable:
         self._info = {}                  # pid -> (name, ppid, created, written_at)
         self._bulk_at = 0.0              # last full process_iter (fallback path)
         self._last = 0.0                 # last successful refresh
+        # Generation counter for concurrent refreshes: a collection takes a number
+        # before it starts and installs only if nothing NEWER landed meanwhile. See
+        # refresh() for why this is a counter and not a timestamp.
+        self._gen = 0
+        self._installed_gen = 0
         self._native = _make_native()
         self.native = self._native is not None
 
     # -- port table ------------------------------------------------------------ #
     def refresh(self, now=None, force=False):
-        """Rebuild the port map. Returns True when it actually ran."""
+        """Rebuild the port map. Returns True when THIS call installed a new map.
+
+        The COLLECTION - four ``iphlpapi`` calls (or the psutil walk) plus building
+        the ``port -> pid`` dict - runs OUTSIDE ``_lock``, and so does the departed-pid
+        diff. Only the reference swap and the name-cache pruning are taken under it.
+
+        That split matters because the CAPTURE THREAD holds this same lock, through
+        ``name_of(cheap=True)`` -> ``info()`` in ``engine._process_for``: whatever this
+        method holds the lock for, the packet path can be made to wait for, and a
+        stalled capture thread means WinDivert is queueing the user's packets into a
+        void (convention 20). MEASURED 2026-07-25 (Win11, CPython 3.14, elevated) with
+        the whole body under the lock: **0.495 ms median hold at 119 sockets**, and the
+        Python-side work alone scales linearly - 0.303 ms at 10 000 sockets and
+        **3.555 ms at 100 000** (syscalls excluded, so that last figure is a floor).
+        With the collection and the diff moved out, the hold is **FLAT at ~0.018 ms**
+        whatever the table size - 188x shorter at the top of that range, and no longer
+        a function of n at all. The whole CALL still costs the same; the work did not
+        vanish, it left the lock.
+
+        Worth being straight about the motive: at 119 sockets the effect on the capture
+        thread was NOT measurable above noise (median, p95 and p99 of the capture
+        thread's own lookup were identical with and without a refresher hammering
+        alongside). The top of the range is why this changed anyway, because a network
+        tester is precisely the thing that gets pointed at 100 000 connections.
+
+        Concurrency, and why this is NOT "last writer wins": two threads can now
+        collect at once (the watchdog, and on the poller fallback the resolver). Each
+        call takes a GENERATION under the lock before it starts and installs only if
+        no newer generation has landed meanwhile, so an older collection that happens
+        to finish late is DISCARDED rather than overwriting a fresher map. A counter
+        and not a timestamp on purpose: ``time.monotonic()`` has ~15 ms granularity on
+        Windows, so two refreshes inside one tick would compare equal and both install.
+
+        The contract callers rely on is unchanged: when this returns, the map is at
+        least as new as the moment the call started - either because this call
+        installed it, or because a newer one already had.
+        """
         now = self.clock() if now is None else now
         with self._lock:
             if not force and (now - self._last) < self.interval and self._ports:
                 return False
-            ports = None
-            if self._native is not None:
-                try:
-                    ports = self._native.port_pid_map()
-                except Exception:                        # pragma: no cover
-                    ports = None
-                if ports is None:                        # native path broke: stop using it
-                    self._native = None
-                    self.native = False
+            self._gen += 1
+            gen = self._gen
+            native = self._native
+            previous = self._ports          # O(1); the diff is computed below, unlocked
+
+        # ---- outside the lock: everything that is O(number of sockets) ---------- #
+        ports = None
+        native_broke = False
+        if native is not None:
+            try:
+                ports = native.port_pid_map()
+            except Exception:                        # pragma: no cover
+                ports = None
             if ports is None:
-                ports = _psutil_port_pid_map()
+                native_broke = True                  # it stopped answering
+        if ports is None:
+            ports = _psutil_port_pid_map()
+        # A PID that has just lost every socket is a PID whose process is probably
+        # gone - and a PID can only be handed to somebody else AFTER its owner exits.
+        # So this is the moment to forget its name, before the OS can hand the number
+        # to a process with a different one. It closes the dangerous window (impairing
+        # a process the user never targeted) from "the rest of the session" down to one
+        # refresh interval.
+        #
+        # Two set builds and a difference: 2.5 us at 119 sockets, but O(n), which is
+        # why it moved out here with the collection. The TTL still backstops PIDs that
+        # never owned a socket - ancestors, and whatever a bulk scan swept in - which
+        # cannot be caught this way.
+        departed = () if ports is None else set(previous.values()) - set(ports.values())
+
+        with self._lock:
+            if native_broke and self._native is native:
+                self._native = None                  # stop using the broken path
+                self.native = False
             if ports is None:
-                self._last = now                         # do not hammer a broken lookup
+                self._last = now                     # do not hammer a broken lookup
                 return False
-            # A PID that has just lost every socket is a PID whose process is
-            # probably gone - and a PID can only be handed to somebody else AFTER
-            # its owner exits. So this is the moment to forget its name, before the
-            # OS can hand the number to a process with a different one. It closes
-            # the dangerous window (impairing a process the user never targeted)
-            # from "the rest of the session" down to one refresh interval.
-            #
-            # Costs 2.5 us (measured): two set builds and a difference. The TTL
-            # above still backstops PIDs that never owned a socket - ancestors,
-            # and whatever a bulk scan swept in - which cannot be caught this way.
-            departed = set(self._ports.values()) - set(ports.values())
+            if gen < self._installed_gen:
+                # A newer collection already landed, so ours describes an older world.
+                # Installing it would move the map BACKWARDS.
+                return False
+            self._installed_gen = gen
             self._ports = ports
             self._last = now
             for pid in departed:

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -3,6 +3,7 @@
 psutil is faked, so the tests run anywhere (the real lookup needs a live system).
 """
 import sys
+import threading
 import time
 import types
 
@@ -583,3 +584,83 @@ def test_names_are_warmed_for_the_connection_log_without_a_target(monkeypatch):
     check("warming resolves every socket-owning pid", table._info.get(8100) is not None)
     check("so the capture thread's cheap read now answers",
           table.name_of(8100, cheap=True) == "app.exe")
+
+
+# -- the refresh lock: the capture thread waits on exactly what it holds ------- #
+def test_the_socket_table_is_collected_without_holding_the_lock():
+    """The CAPTURE THREAD takes this lock too - ``name_of(cheap=True)`` -> ``info()``
+    in ``engine._process_for`` - so whatever ``refresh()`` holds it for, the packet
+    path can be made to wait for, and a stalled capture thread means WinDivert is
+    queueing the user's packets (convention 20).
+
+    MEASURED 2026-07-25 (Win11, CPython 3.14, elevated): with the collection inside the
+    lock the hold scaled with the socket table - 0.303 ms at 10 000 sockets, 3.555 ms at
+    100 000 - and a network tester is exactly what gets pointed at 100 000 connections.
+    With the collection and the departed-pid diff outside it, the hold is FLAT at
+    ~0.018 ms whatever the size, which is a 188x shorter hold at the top of that range.
+
+    Probed from ANOTHER thread on purpose: ``_lock`` is an RLock, so a same-thread
+    acquire would succeed even while the lock was held and would prove nothing.
+    """
+    from beantester import portmap
+
+    table = portmap.PortTable()
+    probed = {}
+
+    class _Native:
+        def port_pid_map(self):
+            def probe():
+                got = table._lock.acquire(timeout=1.0)
+                probed["free"] = got
+                if got:
+                    table._lock.release()
+
+            thread = threading.Thread(target=probe)
+            thread.start()
+            thread.join(timeout=3.0)
+            return {5000: 1234}
+
+    table._native = _Native()
+    table.native = True
+    check("the refresh installed the collected map", table.refresh(force=True) is True)
+    check("the lock was FREE while the socket table was being collected",
+          probed.get("free") is True, f"({probed})")
+
+
+def test_an_older_collection_does_not_overwrite_a_newer_map():
+    """Collecting outside the lock lets two refreshes overlap, so a slow one must not
+    move the map BACKWARDS when it finishes late.
+
+    Each call takes a generation before it starts and installs only if nothing newer
+    landed meanwhile. Driven by a gate rather than by sleeps, so it asserts the ordering
+    rule instead of racing the scheduler.
+    """
+    from beantester import portmap
+
+    table = portmap.PortTable()
+    gate = threading.Event()
+    stale, fresh = {1111: 11}, {2222: 22}
+
+    class _Slow:
+        def port_pid_map(self):
+            gate.wait(timeout=5.0)
+            return dict(stale)
+
+    class _Fast:
+        def port_pid_map(self):
+            return dict(fresh)
+
+    table._native = _Slow()
+    table.native = True
+    slow = threading.Thread(target=lambda: table.refresh(force=True))
+    slow.start()
+    time.sleep(0.05)                    # the slow call has taken its generation
+    table._native = _Fast()             # the slow one already captured its own native
+    check("the second refresh installed", table.refresh(force=True) is True)
+    check("...and its map is the one in place", table.snapshot() == fresh,
+          f"({table.snapshot()})")
+
+    gate.set()                          # now let the STALE collection finish
+    slow.join(timeout=5)
+    check("the stale collection did not move the map backwards",
+          table.snapshot() == fresh, f"({table.snapshot()})")


### PR DESCRIPTION
## What and why

The capture thread takes `PortTable._lock` too - `name_of(cheap=True)` -> `info()` in
`engine._process_for` - so **whatever `refresh()` holds that lock for, the packet path can be made to
wait for**. It held it across four `iphlpapi` calls, the `port -> pid` dict build *and* the
departed-pid diff, all O(number of sockets).

## Measured before touching anything

"The hot path waits N ms" is exactly the claim convention 5 says to measure rather than estimate, so
this started as a measurement that could have ended in "rejected" (Win11, CPython 3.14, elevated,
medians with a control):

| | before | after |
|---|---|---|
| lock hold @ 119 sockets | 0.495 ms (p99 0.843) | - |
| lock hold @ 10 000 | 0.303 ms | 0.018 ms |
| lock hold @ 50 000 | 1.816 ms | 0.018 ms |
| **lock hold @ 100 000** | **3.555 ms** | **0.019 ms (188x)** |

The hold is now **flat** - no longer a function of table size. The whole *call* costs the same; the
work left the lock rather than disappearing.

**The honest part:** at desktop scale this was not an observable problem. The capture thread's own
lookup is 0.4 us, and its median, p95 and p99 **did not move** with a thread hammering
`refresh(force=True)` alongside - only 2 calls in 20 000 waited at all, worst 1.5 ms, with the lock
held ~0.15% of the time. "Measured, rejected" was a legitimate outcome here. What decided it was the
**scaling**: a network tester is the thing that gets pointed at 100 000 connections, and this
project's history is a series of "it was fine until someone ran a load test" (the flow table once
settled at 3.2 million entries). That reasoning is written into the docstring so it is not
re-litigated as a perf win it never was.

## What a reviewer should know

- **Overlapping refreshes cannot move the map backwards.** Collecting outside the lock lets two
  refreshes overlap, so each call takes a **generation** under the lock before it starts and installs
  only if nothing newer landed. **This hazard was real, not theoretical** - the mutation test without
  the guard installs the stale map. It is a counter and not a timestamp because `time.monotonic()`
  has ~15 ms granularity on Windows, so two refreshes inside one tick would compare equal and both
  install.
- **The freshness contract is unchanged:** when `refresh()` returns, the map is at least as new as
  the moment the call started - either this call installed it, or a newer one already had.
- The `native` handle is captured per call and the "it stopped answering" flip is re-checked under
  the lock (`self._native is native`), so a concurrent refresh cannot have its conclusion undone.
- **A methodology note worth having in the record:** the first measurement script timed the whole
  `refresh()` call, which equalled the hold time only *while everything was inside the lock*. Used
  unchanged after the change it reported "3.6 ms, no improvement" - the right number for the wrong
  quantity. The lock had to be instrumented and the hold measured directly.
- **Incidental finding:** since chunk 2c the resolver resolves against the `SocketWatcher`, whose
  `refresh()` is a no-op, so in a real session only the watchdog refreshes this table (~3-5/s). The
  up-to-20/s case is the poller fallback (`--simulate`, tests, non-Windows), which has no real
  capture thread to stall.
- Both new tests are mutation-checked. The lock is probed **from another thread** on purpose -
  `_lock` is an RLock, so a same-thread `acquire()` would succeed while held and prove nothing - and
  the generation rule is driven by a **gate** rather than raced with sleeps.

## Checklist

- [x] `python -m pytest tests` passes locally. (669 tests, 0 failures, on an **elevated** shell, so
      the two known non-admin failures are absent rather than excused. Verified through pytest's own
      exit code and the collected count. `smoke_gui.py`: OK.)
- [x] New behaviour has tests (see `tests/` for the style). - two, both mutation-checked.
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. -
      n/a: no UI text.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in
      `CHANGELOG-INTERNAL.md`, under `[Unreleased]`. - **internal only, deliberately**: nothing a
      tester can observe changes, and claiming a user-visible win would be unmeasured prose.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
