### PR TITLE
fix(engine): count overflow and shutdown drops in packets, not queue copies (audit F6)

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -42,6 +42,42 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: drop_overflow and drop_shutdown count packets, not queue entries (audit F6)
+
+- **Symptom.** `_enqueue()` runs once per element of `dec.releases`, and pipeline step 12 adds a
+  second element for a duplicate. Both `drop_overflow` (in `_enqueue`) and `drop_shutdown` (in
+  `stop()`, from `len(self._heap)`) therefore counted queue ENTRIES while `tips.stat_overflow` and
+  `tips.stat_shutdown` both promise "Packets". Measured before the fix: `seen=1000`,
+  `duplicated=1000` -> `drop_overflow=1900`, `drop_shutdown=100`, so the "Buffer overflow" tile
+  could read higher than the "Packets" tile in the same session.
+- **Fix (`engine.py` only).** `_enqueue(release, packet, copy=False)`; heap entries carry the flag
+  as a fourth element `(release, counter, packet, copy)` (ordering unaffected, `counter` is unique
+  so comparison never reaches index 2 or 3); `_inject_loop` unpacks four; `stop()` uses
+  `sum(1 for entry in self._heap if not entry[3])`. The capture loop enqueues `releases[0]`
+  directly and only branches into a loop for the duplicates, so the single-release path (every
+  session without duplication) does not pay for an `enumerate`.
+- **The warning follows the counter.** A refused copy no longer warns either, because
+  `log.queue_overflow` interpolates the counter: firing it for a copy would print "the TOOL is now
+  dropping packets you did not ask to lose (0 so far)". Only originals count and warn, which keeps
+  the counter, the log line and the GUI banner (`_drain_engine_warning`, which reads
+  `st["drop_overflow"]`) telling the same story. A queue that refuses only copies is losing the
+  user nothing, so silence is correct.
+- **Known, deliberate gap** (recorded in `_enqueue`'s docstring rather than engineered away): if
+  the original is refused and the injector then frees a slot so the duplicate fits, the packet is
+  delivered up to 20 ms late but counted once as lost. Closing it needs copy/original pairing
+  through the heap.
+- **Hot path measured, not assumed** (Win11 AMD64, CPython 3.14.6, 150k pre-built 1500 B packets
+  through `FakeDivert`, median of 5, both trees benchmarked back to back from a `git worktree` of
+  master): no duplication 153.8k -> 156.0k pkt/s, 100% duplication 100.9k -> 102.4k pkt/s. The
+  medians moved about 1.4% in the new code's favour, but the per-run ranges overlap
+  (147.8-155.5 vs 149.3-157.7), so the honest reading is NO MEASURABLE REGRESSION, not a speedup.
+- New tests, both verified by mutation (reverting each half of the fix turns them red with exactly
+  the pre-fix numbers): `tests/test_engine.py::test_overflow_counts_packets_lost_not_queue_entries`
+  (100% duplication into a 10-slot queue: `drop_overflow == 390` before, `195` after, against
+  `seen=200`) and `::test_drop_shutdown_counts_packets_never_delivered_not_queue_entries`
+  (`drop_shutdown == 400` before, `200` after). Both are deterministic, not statistical:
+  `dup=100%` fires on every packet and the 60 s latency releases nothing before STOP.
+
 ### Fixed: two tooltips that described counters they do not describe (audit F8)
 
 Both in `lang/en.json` and `lang/pl.json`, both user-visible, neither catchable by a test - this is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **"Buffer overflow" and "Dropped at stop" counted up to twice the packets they lost.** With
+  "Duplicate packets" switched on, the tool puts a second copy of the packet in its delay queue,
+  and both counters were charging for the copy as well as for the packet. A run that duplicated
+  everything reported nearly twice as many dropped as it ever captured, so the "Buffer overflow"
+  tile could show a bigger number than the "Packets" tile right beside it, and the overload
+  warning in the log quoted that inflated figure back at you. Both now count packets that never
+  arrived. A dropped copy is not one of them: your application receives one packet instead of
+  two, and one packet is what it would have received without the tool, so a copy that does not
+  fit no longer counts and no longer raises the overload warning on its own. Runs without
+  duplication are unaffected; figures from earlier runs with duplication are not comparable with
+  these, because the old ones were too high.
+
 - **Two tooltips were telling you things that were not true.** "Dropped" said it also counted
   link outages - those have had their own counter for a while, so the tooltip was sending you to
   the wrong number when working out where your packets went. "Downloaded (MB)" promised that

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -808,7 +808,13 @@ class BeanEngine:
             self._fine_timers = False
             winenv.release_fine_timers()
         with self._cv:
-            discarded = len(self._heap)
+            # PACKETS still queued, not queue entries: a duplicate copy left in the
+            # queue means the application got one packet instead of two, and one
+            # packet is what it asked for. An original still sitting here is the
+            # only entry that means something never arrived. Counting entries made
+            # a duplicating session overstate the loss (see _enqueue). The scan is
+            # O(queue) but runs once, at STOP, off the capture thread.
+            discarded = sum(1 for entry in self._heap if not entry[3])
             self._heap.clear()
         if discarded:
             # Packets still queued for delayed injection when the session ended:
@@ -973,9 +979,15 @@ class BeanEngine:
                 continue
             if dec.corrupt and self.core.corrupt_packet(packet, rng):
                 self._bump("corrupted")
-            for rel in dec.releases:
-                self._enqueue(rel, packet)
-            if len(dec.releases) > 1:
+            # releases[0] is the packet itself; anything after it is a duplicate
+            # copy (step 12). Kept as an explicit first call plus a branch rather
+            # than a loop over an enumerate: all but the duplicating sessions have
+            # exactly one release, and this is the per-packet path.
+            rels = dec.releases
+            self._enqueue(rels[0], packet)
+            if len(rels) > 1:
+                for rel in rels[1:]:
+                    self._enqueue(rel, packet, copy=True)
                 self._bump("duplicated")
 
     def _send_rst(self, packet):
@@ -1049,14 +1061,37 @@ class BeanEngine:
             # numbers are wrong must say so in the artefact people read later
             self.log_event("WARN", "events.queue_overflow")
 
-    def _enqueue(self, release, packet):
+    def _enqueue(self, release, packet, copy=False):
+        """Queue one release of ``packet`` for delayed injection.
+
+        ``copy=True`` marks a DUPLICATE release (pipeline step 12): the same
+        packet already has an earlier entry in this queue. Overflow and shutdown
+        then count - and warn about - the ORIGINAL only, so both counters stay in
+        PACKETS, which is what their tooltips promise ("Packets dropped because
+        the queue overflowed"). Charging every release made a session with 100%
+        duplication report nearly twice the damage it did: measured seen=1000,
+        duplicated=1000 -> drop_overflow=1900, drop_shutdown=100, so the overflow
+        tile could read HIGHER than the packet tile beside it.
+
+        A refused copy is not a loss to the application either: it receives one
+        packet instead of two, which is one packet. And it must not warn, because
+        the warning quotes the counter ("...you did not ask to lose (N so far)") -
+        firing it with N unchanged would put a false number in the user's log.
+
+        Known, deliberate edge: if the original is refused and the injector then
+        frees a slot so the duplicate fits, the packet IS delivered (up to 20 ms
+        late) yet counted once as lost. Closing that would mean tracking
+        copy/original pairs through the heap; the window is not worth it.
+        """
         with self._cv:
             if len(self._heap) >= self.max_queue:
-                self._bump("drop_overflow")
-                overflowed = True
+                overflowed = not copy
+                if overflowed:
+                    self._bump("drop_overflow")
             else:
                 overflowed = False
-                heapq.heappush(self._heap, (release, next(self._counter), packet))
+                heapq.heappush(self._heap,
+                               (release, next(self._counter), packet, copy))
                 q = len(self._heap)
                 with self._slock:
                     if q > self.st["peak_queue"]:
@@ -1072,7 +1107,7 @@ class BeanEngine:
                     self._cv.wait()
                 if not self._running:
                     break
-                release, _, packet = self._heap[0]
+                release, _, packet, _ = self._heap[0]
                 now = time.monotonic()
                 if release > now:
                     self._cv.wait(timeout=min(release - now, 0.5))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -383,6 +383,72 @@ def test_queue_overflow_counted():
           s["peak_queue"] <= 10, f"(peak={s['peak_queue']})")
 
 
+def test_overflow_counts_packets_lost_not_queue_entries():
+    """A duplicating session must not report more overflow drops than packets.
+
+    ``_enqueue`` runs once per release and duplication adds a second one, so
+    charging every release counted the SAME packet twice. The tooltip says
+    "Packets dropped because the queue overflowed", and the "Buffer overflow"
+    tile could read higher than the "Packets" tile next to it.
+
+    Deterministic, not statistical: dup=100% fires on every packet
+    (``random() < 1.0`` always holds), the 60 s latency releases nothing before
+    STOP, so the queue fills once and stays full. Five packets fit (two entries
+    each), every later original is refused.
+    """
+    n, queue = 200, 10
+    pkts = [FakePacket(size=100, port=7300 + i) for i in range(n)]
+    sh = BeanEngine()
+    sh.max_queue = queue
+    sh.set_seed(4242)
+    sh.set_params(0, 0, 100, 60000, 0, 0, 0)     # 100% duplication, 60 s latency
+    sh.start("test", divert=FakeDivert(pkts))
+    deadline = time.time() + 15
+    while time.time() < deadline and sh.stats_snapshot()["seen"] < n:
+        time.sleep(0.02)
+    s = sh.stats_snapshot()
+    sh.stop()
+
+    check("overflow/dup: every packet was duplicated",
+          s["duplicated"] == n, f"(duplicated={s['duplicated']}, seen={s['seen']})")
+    check("overflow/dup: drops never exceed the packets they are drops OF",
+          s["drop_overflow"] <= s["seen"],
+          f"(overflow={s['drop_overflow']}, seen={s['seen']})")
+    check("overflow/dup: originals refused are counted, copies are not",
+          s["drop_overflow"] == n - queue // 2,
+          f"(overflow={s['drop_overflow']}, expected={n - queue // 2})")
+
+
+def test_drop_shutdown_counts_packets_never_delivered_not_queue_entries():
+    """The same unit mix-up at STOP: a queued duplicate is not a lost packet.
+
+    A copy still waiting when the session ends means the application received one
+    packet instead of two - and one is what it would have received without the
+    tool. Only an ORIGINAL left in the queue is something that never arrived.
+    Counting entries made ``drop_shutdown`` twice ``seen`` here.
+    """
+    n = 200
+    pkts = [FakePacket(size=100, is_outbound=False, port=7500 + i) for i in range(n)]
+    fake = FakeDivert(pkts)
+    sh = BeanEngine()
+    sh.set_seed(4242)
+    sh.set_params(0, 0, 100, 60000, 0, 0, 0)     # 100% duplication, 60 s latency
+    sh.start("test", divert=fake)
+    deadline = time.time() + 15
+    while time.time() < deadline and sh.stats_snapshot()["queue"] < 2 * n:
+        time.sleep(0.02)
+    sh.stop()
+
+    s = sh.stats_snapshot()
+    check("shutdown/dup: nothing was delivered", len(fake.sent) == 0,
+          f"(sent={len(fake.sent)})")
+    check("shutdown/dup: queued copies are not counted as lost packets",
+          s["drop_shutdown"] == n, f"(drop_shutdown={s['drop_shutdown']}, seen={s['seen']})")
+    check("shutdown/dup: seen == delivered + drops",
+          s["seen"] == len(fake.sent) + s["drop_shutdown"],
+          f"(seen={s['seen']}, sent={len(fake.sent)}, shutdown={s['drop_shutdown']})")
+
+
 def test_event_log_trim():
     sh = BeanEngine()
     for i in range(5100):


### PR DESCRIPTION
Audit finding **F6**. `drop_overflow` and `drop_shutdown` counted queue ENTRIES while both
tooltips promise "Packets".

`_enqueue()` runs once per element of `dec.releases`, and pipeline step 12 adds a second element
for a duplicate, so a duplicating session charged for the copy as well as for the packet.
Measured before the fix: `seen=1000`, `duplicated=1000` -> `drop_overflow=1900`,
`drop_shutdown=100`. The "Buffer overflow" tile could read higher than the "Packets" tile beside
it in the same session.

## What changed (`beantester/engine.py` only)

- `_enqueue(release, packet, copy=False)`; heap entries carry the flag as a fourth element
  `(release, counter, packet, copy)`. Ordering is unaffected: `counter` is unique, so tuple
  comparison never reaches index 2 or 3.
- `stop()` counts entries that are not copies instead of `len(self._heap)`.
- The capture loop enqueues `releases[0]` directly and only branches into a loop for duplicates,
  so the single-release path (every session without duplication) does not pay for an `enumerate`.
- A refused copy no longer warns either. `log.queue_overflow` interpolates the counter, so
  warning on a copy would print *"the TOOL is now dropping packets you did not ask to lose
  (0 so far)"*. Counter, log line and GUI banner now tell the same story, and a queue that
  refuses only copies is costing the user nothing.

Known, deliberate gap, recorded in the docstring rather than engineered away: if the original is
refused and the injector then frees a slot so the duplicate fits, the packet is delivered up to
20 ms late yet counted once as lost.

## Verification

- `python -m pytest tests` -> **679 passed, 0 failed** on an elevated shell (so zero failures is
  the full bar, not the two known non-admin ones). `python smoke_gui.py` -> OK.
- Two new guards in `tests/test_engine.py`, **both verified by mutation**: reverting each half of
  the fix turns them red with exactly the pre-fix numbers, `drop_overflow=390` and
  `drop_shutdown=400` against `seen=200`. Deterministic, not statistical: `dup=100%` fires on
  every packet and the 60 s latency releases nothing before STOP.
- Hot path measured before and after, back to back against a `git worktree` of master (Win11
  AMD64, CPython 3.14.6, 150k pre-built 1500 B packets through `FakeDivert`, median of 5):

  | path | master | this branch |
  |---|---|---|
  | no duplication | 153.8k pkt/s (147.8-155.5) | 156.0k pkt/s (149.3-157.7) |
  | 100% duplication | 100.9k pkt/s (97.6-104.2) | 102.4k pkt/s (100.7-104.3) |

  Medians moved about 1.4% in this branch's favour, but the per-run ranges overlap, so the honest
  reading is **no measurable regression**, not a speedup.

Not verified: behaviour under a real WinDivert overflow. The queue arithmetic is engine-side and
identical on either driver, so nothing here depends on the real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
