### PR TITLE
fix: stray export .tmp, orphaned scenario runner, STOP racing a capture fault

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,58 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: three small ones - stray .tmp, orphaned scenario runner, STOP racing a capture fault (audit F11, F12, F13)
+
+**F11 - `export_connections_csv` left its temp file on failure.** It writes `path + ".tmp"` and
+`os.replace`s it, but the `except` only logged: the half-written temp file stayed next to the real
+one, and the next export silently overwrote it. `jsonfile.write_json` has had the cleanup (and a
+test asserting no `*.tmp` after a failed write) for a while; this is the same guarantee.
+New test: `tests/test_conns_export.py::test_a_failed_connections_export_leaves_no_tmp_file_behind`,
+forcing the failure from inside the row loop (unsubtractable timestamps) so the temp file
+definitely exists when it blows up. NOT changed: the stats CSV appends without an atomic write, so
+a process death mid-flush can still truncate a line. Rewriting an append log through a temp file
+costs the whole file per export; the exposure is a partial final line, and it is recorded here
+rather than engineered away.
+
+**F12 - `start_scenario()` orphaned the previous runner.** It overwrote `self._scenario_runner`
+without stopping it, and `stop_scenario()` only ever knew about the current object, so the old
+thread kept applying its own steps to the same engine. `self.stop_scenario()` first. Found by
+reading; NOT reproduced in the running program, because the GUI and CLI both start one scenario per
+session - which is a property of today's callers, not of the engine. New test:
+`tests/test_engine.py::test_a_second_scenario_stops_the_first_instead_of_orphaning_it`.
+
+**F13 - the capture-fault path waited on a stop that was joining it.** `_fail_stop(blocking=True)`
+called `stop()`, which blocks on `_stop_lock`. When a `recv()` failed for its own reason in the few
+instructions between the `_running` check and that call, an external STOP already held the lock and
+was joining this very thread with a 2.0 s timeout: no deadlock, but STOP took the full 2 s. The
+docstring claimed it "cannot deadlock against an external STOP: that path closes the divert first,
+so the capture loop sees `_running` already False and never reaches here" - true when the fault IS
+that stop closing the divert, and that sentence is why nobody looked further.
+
+- **First attempt was wrong and the suite caught it.** Routing the capture path through
+  `_worker_stop` (the audit's first suggestion, one line) broke
+  `test_a_dead_capture_thread_fails_open`: a divert that fails on its very first reads faults while
+  `start()` still holds the lock, which is not a corner case but the case the blocking path exists
+  for. It would have handed every such teardown to the watchdog a tick later.
+- **What landed:** `_fault_stop_blocking()` polls `acquire(timeout=FAULT_LOCK_POLL_S)` (0.05 s) and
+  bails only when `_running` has gone False. No new state is needed to tell the two holders apart:
+  `_stop_locked` clears `_running` as its second statement, so "held and still running" is a start
+  and "held and not running" is a stop that already owns the teardown.
+- `_fail_stop` now keeps the FIRST fault (`if not self.fault`). The watchdog's "worker thread died
+  unexpectedly" is a symptom; letting it overwrite the cause blanks out the only useful half of the
+  report. Both are still logged.
+- New tests in `tests/test_failsafe.py`, all structural rather than wall-clock so they cannot
+  flake: `::test_a_capture_fault_racing_an_external_stop_does_not_wait_for_it`,
+  `::test_a_capture_fault_still_waits_for_a_start_that_holds_the_lock` (the other half - a mutant
+  that bows out on a start is caught too), and `::test_the_first_fault_is_the_one_kept_for_the_report`.
+- **One of those tests was itself wrong, and mutation is what found it.** The fault test held
+  `_stop_lock` and called `_fail_stop` on the SAME thread - `_stop_lock` is an `RLock`, so the
+  nested `_worker_stop` re-entered, the stop completed, `_running` went False and the second fault
+  returned at the guard. It passed for the wrong reason and guarded nothing. Driving the faults
+  from another thread fixed it. Worth remembering when writing anything that leans on this lock.
+
+Five mutants across the three, every one caught after that repair.
+
 ### Fixed: a failed injection is counted, and stops flooding the log (audit F14)
 
 - **Symptom.** `_inject_loop`'s `except` around `self._divert.send(packet)` logged and moved on.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A failed "Export connections CSV" left a stray `.tmp` file next to the real one.** The export
+  writes to a temporary file and renames it, which is what makes it safe to overwrite the previous
+  export - but when the write failed, the half-written temp file stayed on disk. Nothing cleaned
+  it up, and the next export silently overwrote it, so it was litter you could find but not
+  explain. It is now removed on failure, exactly as the profile and config files already do, and a
+  failed export leaves the previous one untouched.
+
+- **STOP could take two seconds if a capture error happened to land at the same moment.** If the
+  capture side failed for its own reason a fraction of a second before you pressed STOP, the two
+  waited on each other until a two-second safety timeout expired. Nothing was lost or stuck - the
+  session did stop - but the button felt broken. The capture side now waits only for a session
+  that is still starting up, never for a stop that is already under way. Related: when two
+  failures land together, the report keeps the first one, which is the actual cause; it used to be
+  overwritten by the follow-up "a worker thread died", which says nothing useful on its own.
+
+- **Starting a second scenario without stopping the first is no longer possible.** The engine
+  replaced the running scenario with the new one and left the old one running in the background,
+  unreachable: two scenarios then fought over the same settings with nothing on screen to say why.
+  Nothing in the program did this today - it starts one scenario per session - so this is a guard
+  rather than a bug you could have hit.
+
 - **Packets the tool failed to put back on the wire vanished from the numbers.** When re-injecting
   a packet fails - the connection went down mid-session, the driver refused it - the packet is
   gone. It had been counted as seen, it was never delivered, and nothing recorded it as lost, so

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -346,7 +346,18 @@ class BeanEngine:
         return self._running
 
     def start_scenario(self, scenario, base_settings, log=lambda *_: None):
-        """Start a background runner that applies scenario steps over time."""
+        """Start a background runner that applies scenario steps over time.
+
+        Any previous runner is stopped FIRST. Overwriting the attribute without
+        stopping it left the old thread alive and unreachable: ``stop_scenario``
+        only ever knew about the current object, so the orphan kept applying its
+        own steps to the same engine, and two scenarios fought over the settings
+        with nothing on screen to say why. Today's callers start once per session
+        (GUI and CLI both), so this was found by reading, NOT reproduced in the
+        running program - the guard is here because "nobody calls it twice today"
+        is not a property of the engine.
+        """
+        self.stop_scenario()
         self._scenario_runner = ScenarioRunner(self)
         self._scenario_runner.start(scenario, base_settings, log)
 
@@ -895,31 +906,72 @@ class BeanEngine:
         _LIVE_ENGINES.discard(self)
         self.log(T("log.stop"))
 
+    # How long the capture thread waits on _stop_lock before re-checking WHO holds
+    # it. Short enough that a racing external STOP is never delayed noticeably,
+    # long enough not to spin. See _fault_stop_blocking.
+    FAULT_LOCK_POLL_S = 0.05
+
     def _fail_stop(self, error, blocking=True):
         """A worker died: stop the session so the network is never left impaired.
 
         ``blocking`` picks HOW the stop is taken, and the two callers genuinely differ:
 
-        * The CAPTURE thread calls this on a real recv() fault (blocking=True). A plain
-          ``stop()`` is right, and necessary: the fault can arrive while ``start()``
-          still holds ``_stop_lock`` (a divert that fails on its very first reads,
-          before start() has returned) - blocking makes the capture thread wait for
-          start() to finish and then stop cleanly, keeping the REAL fault message. It
-          cannot deadlock against an external STOP: that path closes the divert first,
-          so the capture loop sees ``_running`` already False and never reaches here.
+        * The CAPTURE thread calls this on a real recv() fault (blocking=True). It has
+          to be able to WAIT: the fault can arrive while ``start()`` still holds
+          ``_stop_lock`` (a divert that fails on its very first reads, before start()
+          has returned), and that is not a corner case - it is what
+          ``test_a_dead_capture_thread_fails_open`` exercises. Bowing out there would
+          hand the teardown to the watchdog a tick later for no reason.
         * The WATCHDOG calls this from its liveness check (blocking=False). It must NOT
           block on ``_stop_lock``: an external ``stop()`` holds it while joining the
           watchdog thread, so blocking would hang STOP for the join timeout (F2). It
-          goes through ``_worker_stop`` instead, which bows out under contention.
+          goes through ``_worker_stop``, which bows out under contention.
+
+        What changed (F13): the capture path waits for ``start()`` but never for
+        another STOP - see ``_fault_stop_blocking``. The docstring here used to claim
+        it "cannot deadlock against an external STOP: that path closes the divert
+        first, so the capture loop sees _running already False and never reaches
+        here". True when the fault IS that stop closing the divert; it does not cover
+        a ``recv()`` failing for its own reason in the few instructions between the
+        ``_running`` check below and the stop call. The capture thread then waited on
+        the lock while the external stop waited to join it, and STOP took the full
+        2 s join timeout. Never a deadlock - but "cannot" was too strong, and a
+        sentence like that is what stops the next session from looking. NOT
+        reproduced: found by reading, and the window is a few instructions wide.
         """
         if not self._running:
             return
-        self.fault = str(error)
-        self.log(T("log.engine_fault", e=self.fault))
+        # First fault wins. The watchdog's "worker thread died unexpectedly" is a
+        # SYMPTOM of the real error - if the capture thread recorded the cause a
+        # moment earlier, overwriting it here would throw away the only useful half
+        # of the report. Both are still LOGGED: two failures are two events.
+        if not self.fault:
+            self.fault = str(error)
+        self.log(T("log.engine_fault", e=str(error)))
         if blocking:
-            self.stop(reason="fault")
+            self._fault_stop_blocking()
         else:
             self._worker_stop(reason="fault")
+
+    def _fault_stop_blocking(self):
+        """Take ``_stop_lock`` for a capture-thread fault: wait for a start, never
+        for another stop.
+
+        The difference is visible without any extra state. ``_stop_locked`` clears
+        ``_running`` as its second statement, so while the lock is held: still
+        running means ``start()`` owns it and is about to release it (wait - that is
+        the case the blocking path exists for), and no longer running means a stop
+        already owns the teardown, is closing the divert, and is joining THIS thread
+        with a 2.0 s timeout. Waiting on that one buys nothing and costs the user a
+        two-second STOP.
+        """
+        while not self._stop_lock.acquire(timeout=self.FAULT_LOCK_POLL_S):
+            if not self._running:
+                return
+        try:
+            self._stop_locked("fault")
+        finally:
+            self._stop_lock.release()
 
     # -- watchdog -------------------------------------------------------------- #
     def _watchdog_loop(self):

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -1096,6 +1096,17 @@ class App:
             os.replace(tmp, path)
             self.log(f"{T('log.conns_saved_to')} {os.path.basename(path)} ({len(rows)})")
         except Exception as e:
+            # Clean up the half-written temp file, the way jsonfile.write_json
+            # already does. Without this a failed export left a `.csv.tmp` next to
+            # the real file for the user to find and wonder about - and the next
+            # export silently overwrote it, so the litter was never even stable.
+            # A failure here must leave the previous export untouched and nothing
+            # else behind.
+            try:
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+            except OSError as _exc:
+                crashlog.note(_exc, "gui.app")
             self.log(f"{T('log.csv_error')}: {e}")
 
     def mark_bug(self):

--- a/tests/test_conns_export.py
+++ b/tests/test_conns_export.py
@@ -53,6 +53,40 @@ def test_export_connections_csv_writes_the_current_view():
     ''')
 
 
+def test_a_failed_connections_export_leaves_no_tmp_file_behind():
+    """The export writes `<file>.tmp` and renames it. When the write blew up, the
+    temp file stayed on disk next to the real one for the user to find and wonder
+    about - and the next export silently overwrote it, so the litter was not even
+    stable. `jsonfile.write_json` has cleaned up after itself for a while; this is
+    the same guarantee for the same reason.
+
+    The failure is forced from inside the row loop (a row whose timestamps cannot
+    be subtracted), so the temp file definitely exists by the time it happens.
+    """
+    run_gui('''
+        import os, tempfile
+        import beantester.gui.app as m
+        path = os.path.join(tempfile.mkdtemp(), "conns.csv")
+        m.CONNECTIONS_CSV_FILE = path
+
+        app.engine.now_ref = lambda: 10.0
+        app.engine.connections_snapshot = lambda limit=None: [
+            dict(local_port=51000, remote_ip="1.1.1.1", remote_port=443, proto="TCP",
+                 packets=4, bytes=3072, bytes_in=2048, bytes_out=1024, dropped=0,
+                 scoped=False, pid=None, first="not a number", last="boom",
+                 dir="in", proc="chrome.exe"),
+        ]
+        app.conn_query = ""
+        app.conn_sort = {"col": "packets", "reverse": True}
+        app.export_connections_csv()
+
+        assert not os.path.exists(path + ".tmp"), "a half-written .tmp was left behind"
+        assert not os.path.exists(path), "a failed export must not create the real file"
+        assert any("csv" in line.lower() or "błąd" in line.lower()
+                   for line in app._log_lines), app._log_lines[-3:]
+    ''')
+
+
 def test_export_connections_csv_writes_a_portless_row_with_empty_port_cells():
     """A ping row reaches the export with both ports None. The columns must come
     out EMPTY, not "None" and not shifted - a misaligned row here is silent."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -687,6 +687,39 @@ def test_failed_injections_do_not_flood_the_log():
           "WARN" in kinds, f"({kinds})")
 
 
+def test_a_second_scenario_stops_the_first_instead_of_orphaning_it():
+    """Overwriting `_scenario_runner` left the old thread alive and unreachable.
+
+    `stop_scenario()` only ever knew about the CURRENT object, so the orphan kept
+    applying its own steps to the same engine: two scenarios fighting over the
+    settings with nothing on screen to say why. Found by reading - today's callers
+    (GUI and CLI) start one scenario per session - but "nobody calls it twice" is
+    not a property of the engine.
+    """
+    from beantester.scenario import Scenario
+
+    sh = BeanEngine()
+    sh.start("test", divert=FakeDivert([FakePacket(size=100, port=8100)]))
+    try:
+        scenario = Scenario(steps=[{"at": 30.0, "settings": {"loss": 1}}], loop=True)
+        sh.start_scenario(scenario, dict(loss=0))
+        first = sh._scenario_runner
+        sh.start_scenario(scenario, dict(loss=0))
+        second = sh._scenario_runner
+
+        check("scenario: the second start really replaced the runner",
+              second is not first)
+        check("scenario: the first runner was stopped, not orphaned",
+              first._stop is True, f"(_stop={first._stop})")
+        deadline = time.time() + 5
+        while time.time() < deadline and first._thread.is_alive():
+            time.sleep(0.02)
+        check("scenario: and its thread is gone",
+              not first._thread.is_alive())
+    finally:
+        sh.stop()
+
+
 def test_event_log_trim():
     sh = BeanEngine()
     for i in range(5100):

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -409,6 +409,109 @@ def test_a_worker_stop_never_blocks_on_a_held_stop_lock():
     check("F2: the ordinary stop still tears the session down", eng.is_running() is False)
 
 
+def test_a_capture_fault_racing_an_external_stop_does_not_wait_for_it():
+    """F13: the CAPTURE thread waits for a start, never for another stop.
+
+    A recv() that fails for its own reason a moment before the user presses STOP
+    used to block on ``_stop_lock`` while that stop was joining this very thread
+    with a 2.0 s timeout. No deadlock, but STOP took the whole timeout. The
+    docstring said it "cannot deadlock against an external STOP", which is true
+    only when the fault IS that stop closing the divert.
+
+    Structural, not wall-clock, so it cannot flake: hold the lock the way an
+    external stop does, with ``_running`` already cleared as ``_stop_locked``
+    clears it, and assert the fault path returns instead of waiting.
+    """
+    import threading
+
+    eng = BeanEngine()
+    eng.start("test", divert=QuietDivert())
+    eng._stop_lock.acquire()
+    try:
+        # exactly the state an external stop is in while it joins the workers
+        eng._running = False
+        returned = threading.Event()
+
+        def capture_fault():
+            eng._fault_stop_blocking()
+            returned.set()
+
+        threading.Thread(target=capture_fault, daemon=True).start()
+        check("F13: the capture fault does not wait on a stop that owns the teardown",
+              returned.wait(timeout=2.0),
+              "(it blocked - STOP would take the whole 2 s join timeout)")
+    finally:
+        eng._running = True
+        eng._stop_lock.release()
+    eng.stop()
+    check("F13: the session still tears down normally", eng.is_running() is False)
+
+
+def test_a_capture_fault_still_waits_for_a_start_that_holds_the_lock():
+    """The other half: while ``start()`` holds the lock the session IS still
+    running, and that is the case the blocking path exists for - a divert failing
+    on its very first reads. Bowing out there would hand the teardown to the
+    watchdog a tick later for nothing."""
+    import threading
+
+    eng = BeanEngine()
+    eng.start("test", divert=QuietDivert())
+    eng._stop_lock.acquire()            # stand in for start() still finishing
+    try:
+        returned = threading.Event()
+
+        def capture_fault():
+            eng._fault_stop_blocking()
+            returned.set()
+
+        threading.Thread(target=capture_fault, daemon=True).start()
+        check("F13: it does NOT bow out while a start holds the lock",
+              not returned.wait(timeout=0.4),
+              "(it gave up on a start - the real fault would be lost to the watchdog)")
+        check("F13: and the session is still up while it waits",
+              eng.is_running() is True)
+    finally:
+        eng._stop_lock.release()
+    check("F13: once the lock is free it completes the fail-open stop",
+          _wait_until(lambda: not eng.is_running()), f"(running={eng.is_running()})")
+
+
+def test_the_first_fault_is_the_one_kept_for_the_report():
+    """The watchdog's "worker thread died unexpectedly" is a SYMPTOM of the real
+    error. When both land, the cause has to survive - it is the only half of the
+    report worth reading."""
+    import threading
+
+    eng = BeanEngine()
+    eng.start("test", divert=QuietDivert())
+    # Both faults have to land while the engine is STILL RUNNING - that is the only
+    # state in which the second one reaches `self.fault` at all. So the lock is held
+    # here, which makes `_worker_stop` bow out and leaves the session up.
+    #
+    # From ANOTHER thread, deliberately: `_stop_lock` is an RLock, so calling this
+    # on the thread holding it re-enters, the stop completes, `_running` goes False
+    # and the second fault returns at the guard - the test then passes while
+    # guarding nothing. Which is what it did, until the mutation caught the TEST.
+    eng._stop_lock.acquire()
+    try:
+        def two_faults():
+            eng._fail_stop(RuntimeError("the driver went away"), blocking=False)
+            eng._fail_stop(RuntimeError("worker thread Thread-1 died unexpectedly"),
+                           blocking=False)
+
+        t = threading.Thread(target=two_faults, daemon=True)
+        t.start()
+        t.join(timeout=5.0)
+        check("fault: the faulting thread did not block", not t.is_alive())
+        check("fault: the session is still up, so both faults were recorded",
+              eng.is_running() is True)
+        check("fault: the cause survives the symptom",
+              "driver went away" in str(eng.fault), f"({eng.fault})")
+    finally:
+        eng._stop_lock.release()
+    eng.stop()
+
+
 # --- the GUI ---------------------------------------------------------------- #
 
 


### PR DESCRIPTION
Audit findings **F11**, **F12** and **F13** - three small ones that share nothing but their size.

> Stacked on #58. The diff below is this chunk only; merge #58 first and GitHub retargets this to
> `master` on its own.

## F11 - a failed connections export left its `.tmp` behind

`export_connections_csv` writes `<path>.tmp` and `os.replace`s it, but the `except` only logged.
The half-written temp file stayed next to the real one, and the next export silently overwrote it -
litter you can find but not explain. `jsonfile.write_json` has had this cleanup (and a test
asserting no `*.tmp` after a failed write) for a while.

**Not fixed, recorded instead:** the stats CSV appends without an atomic write, so a process death
mid-flush can still truncate its last line. Rewriting an append log through a temp file costs the
whole file on every export; the exposure is one partial line.

## F12 - a second scenario orphaned the first

`start_scenario()` overwrote `self._scenario_runner` without stopping it, and `stop_scenario()`
only ever knew about the current object - so the old thread kept applying its own steps to the same
engine, two scenarios fighting over the settings with nothing on screen to say why.

Found by reading. **Not reproduced in the running program**: the GUI and CLI both start one
scenario per session. That is a property of today's callers, not of the engine.

## F13 - STOP could take 2 s when a capture fault raced it

`_fail_stop(blocking=True)` called `stop()`, which blocks on `_stop_lock`. When a `recv()` failed
for its own reason in the few instructions between the `_running` check and that call, an external
STOP already held the lock **and was joining this very thread** with a 2.0 s timeout. No deadlock -
but STOP took the full two seconds.

The docstring claimed it *"cannot deadlock against an external STOP: that path closes the divert
first, so the capture loop sees `_running` already False and never reaches here"*. True when the
fault **is** that stop closing the divert. That sentence is why nobody looked further.

**The first attempt was wrong, and the suite caught it.** Routing the capture path through
`_worker_stop` (the audit's own first suggestion, one line) broke
`test_a_dead_capture_thread_fails_open`: a divert that fails on its very first reads faults while
`start()` still holds the lock - not a corner case, but the case the blocking path exists for. It
would have handed every such teardown to the watchdog a tick later.

What landed: `_fault_stop_blocking()` polls `acquire(timeout=0.05)` and bails only once `_running`
has gone False. No new state is needed to tell the two holders apart - `_stop_locked` clears
`_running` as its second statement, so **held and still running** is a start (wait for it) and
**held and not running** is a stop that already owns the teardown (bow out).

`_fail_stop` also keeps the **first** fault now: the watchdog's "worker thread died unexpectedly"
is a symptom, and letting it overwrite the cause blanked out the only useful half of the report.

## Verification

- `python -m pytest tests` -> **696 passed, 0 failed** (elevated shell). `python smoke_gui.py` -> OK.
- Six new guards, **five mutants, every one caught** - after a repair worth reporting:
  **one of the new tests guarded nothing and mutation is what exposed it.** It held `_stop_lock`
  and called `_fail_stop` on the same thread; `_stop_lock` is an `RLock`, so the nested
  `_worker_stop` re-entered, the stop completed, `_running` went False and the second fault
  returned at the guard. It passed for the wrong reason. Driving the faults from another thread
  fixed it - worth remembering for anything else leaning on that lock.
- The F13 guards are structural (does the call return while the lock is held?), never wall-clock,
  so they cannot flake.
- No hot-path change: F13 touches only the fault path, F12 only session setup, F11 only the export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
