### PR TITLE
feat(engine): read and report the WinDivert queue a session runs behind

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,38 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Added: the driver's own queue is read and reported (audit F10, part a)
+
+- **Symptom.** `pydivert.WinDivert(filt)` never received a `set_param()`, and the package contained
+  no `get_param()` at all, so WinDivert's queue was invisible: with `QUEUE_TIME` at its default a
+  packet may be held for up to **two seconds**, which is latency this tool adds while being blind
+  to it, and no session artefact said what queue produced its numbers.
+- **Measured on the owner's machine before designing anything** (2026-07-28, elevated, real driver,
+  throwaway ICMP handle): `QUEUE_LEN=4096`, `QUEUE_TIME=2000`, `QUEUE_SIZE=4194304`, QPC frequency
+  10 MHz. `QUEUE_SIZE` binds before `QUEUE_LEN` for full frames - 4 MiB / 1500 B = **2796 packets**
+  - so at a saturated gigabit (83k pkt/s of 1500 B) a frozen capture thread has roughly 34 ms
+  before the driver starts discarding.
+- **Deliberately NOT retuned.** The trade is real in both directions and both are invisible today:
+  a large `QUEUE_TIME` is latency the tool hides, a small one is LOSS the tool cannot even count,
+  because a packet the driver drops never reaches us. Picking values before measuring the actual
+  queue delay would be the "machinery around the wrong primitive" convention 6 warns about. The
+  measurement is part b.
+- `BeanEngine._read_driver_queue()` reads the three params after the handle opens (guarded by
+  `crashlog.quiet`), stores them, and `session_info()` carries them into the repro report as
+  `session.driver_queue`; one `log.driver_queue` line at START. `None` - not zeroes - on the
+  simulate path, because "no driver" and "a queue of nothing" are different claims.
+- **The param numbers are spelled out, not imported, and that is the interesting bit.** Reaching
+  for `pydivert.consts.Param` here would import a **win32-only** dependency: the read would return
+  None on the Linux half of the CI matrix while passing on Windows - the exact bug shape that only
+  appears on the runner you did not run. `DRIVER_QUEUE_PARAMS` holds the ABI numbers, and
+  `tests/test_engine.py::test_the_driver_queue_param_numbers_match_pydivert` compares them with the
+  real enum wherever pydivert IS importable, so they cannot drift in silence.
+- `--doctor` gains a line that says where the values live and why it does not read them itself:
+  they need an open handle, and opening one loads the driver, falsifying the "windivert driver"
+  check printed two lines above it in the same report.
+- Three new tests, three mutants, every one caught (including the ABI numbers being swapped).
+  No hot-path change: this is three calls, once per session.
+
 ### BREAKING: metrics.connections_reset counts connections, not packets (audit F7)
 
 - **Symptom.** `repro.py` had `connections_reset=stats["drop_rst"]`, and `drop_rst` counts every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   application left alone, name the one you *do* want broken instead; then anything unidentified
   passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
 
+### Added
+
+- **A session now records the WinDivert queue it is running behind.** WinDivert has its own buffer,
+  ahead of this tool's, and nothing here ever read it - so a packet could sit in the driver for up
+  to two seconds (the default queue time), land on your measured latency, and appear in no counter
+  at all. The three values (length, time, size) are read when a session starts, written to the log,
+  and stored in the reproduction report as `session.driver_queue`, so a report from a machine you
+  do not have in front of you says which queue produced its numbers. Read on this machine:
+  4096 packets / 2000 ms / 4 MiB - and note the size limit binds first for full-size packets,
+  4 MiB / 1500 B = 2796 packets, not 4096. Nothing is changed about how the queue behaves; this is
+  about being able to see it. `--doctor` deliberately does not read them: the values need an open
+  handle, and opening one loads the driver, which would falsify the "windivert driver" line printed
+  in the same report.
+
 ### Fixed
 
 - **A connection's "dropped" count ignored the packets the tool's own queue threw away.** The

--- a/README.md
+++ b/README.md
@@ -505,6 +505,11 @@ Designed so that after a bug you can recreate exactly the same conditions:
   into the log.
 - **Save reproduction report** - a single JSON file with the lot: seed, all settings, counters,
   metrics, event log, connections and a **ready CLI command** that recreates the conditions.
+  It also records **the WinDivert queue the session ran behind** (`session.driver_queue`: length,
+  time and size). That is the driver's own buffer, ahead of this tool's: with the default 2000 ms
+  queue time a packet can wait in it, and that wait lands on your latency without appearing in any
+  counter here. A report from a machine you do not have in front of you now says which queue
+  produced its numbers. The same three values go into the log at START.
 - **Copy CLI command** - straight to the clipboard: `BeanNetworkTester.exe --seed ... --loss ...
   --duration ...` (the command adapts to the build: from the repository you get
   `python bean_network_tester.py ...`).

--- a/README.pl.md
+++ b/README.pl.md
@@ -399,7 +399,7 @@ Zaprojektowane tak, by po wystąpieniu błędu odtworzyć dokładnie te same war
 - **Zużycie danych** - Pobrano / Wysłano / Razem (MB) narastająco od startu oraz średnia przepustowość sesji; od razu wiesz, ile danych aplikacja zużyła. (W raporcie jest też „próbowano MB” - ile aplikacja chciała przesłać przed odjęciem strat/limitów.)
 - **Dziennik zdarzeń** ze znacznikami czasu: start, zmiany ustawień, kroki scenariusza, zerwania, oraz Twoje znaczniki błędu - z **sortowaniem** po kliknięciu w nagłówek kolumny.
 - **Zaznacz moment błędu** - kliknij dokładnie gdy zobaczysz błąd; wstawia znacznik z czasem do dziennika.
-- **Zapisz raport reprodukcji** - jeden plik JSON z kompletem: seed, wszystkie ustawienia, liczniki, metryki, dziennik zdarzeń, połączenia oraz **gotową komendę CLI**, która odtwarza warunki.
+- **Zapisz raport reprodukcji** - jeden plik JSON z kompletem: seed, wszystkie ustawienia, liczniki, metryki, dziennik zdarzeń, połączenia oraz **gotową komendę CLI**, która odtwarza warunki. Zapisuje też **kolejkę WinDiverta, za którą działała sesja** (`session.driver_queue`: długość, czas i rozmiar). To bufor samego sterownika, przed buforem tego narzędzia: przy domyślnych 2000 ms pakiet może w nim poczekać, a to czekanie dokłada się do Twojego opóźnienia, nie pojawiając się w żadnym tutejszym liczniku. Raport z maszyny, której nie masz przed sobą, mówi teraz, za jaką kolejką powstały jego liczby. Te same trzy wartości trafiają do logu przy STARCIE.
 - **Kopiuj komendę CLI** - od razu do schowka: `BeanNetworkTester.exe --seed … --loss … --duration …`
   (komenda dopasowuje się do builda: z repozytorium dostaniesz `python bean_network_tester.py …`).
 

--- a/beantester/driver.py
+++ b/beantester/driver.py
@@ -341,6 +341,15 @@ def doctor():
         leftovers = stale_temp_dirs()
         checks.append(("temp leftovers", "warn" if leftovers else "ok",
                        ", ".join(leftovers) if leftovers else "none"))
+        # Deliberately NOT read here. The values live behind an open WinDivert
+        # handle, and opening one loads the driver - which would falsify the
+        # "windivert driver" line printed two checks above, in the same report. A
+        # session reads them at START and puts them in its log and its repro
+        # report, where they cost nothing extra.
+        checks.append(("driver queue", "ok",
+                       "read at session start (log line + repro report "
+                       "'session.driver_queue'); needs an open handle, so --doctor "
+                       "does not load the driver just to look"))
     else:
         checks.append(("pydivert", "warn" if not pydivert_available() else "ok",
                        "not required outside Windows (--simulate works)"))

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -173,6 +173,7 @@ class BeanEngine:
         # poller. See _start_socketwatch. Targeting resolves against it whenever a
         # session has one - the choice is made in _targeting_table().
         self._socketwatch = None
+        self._driver_queue = None   # WinDivert's queue settings, read at start()
         # True while this session holds a fine Windows timer tick (see start()).
         # Tracked rather than released blindly: the OS refcounts the requests per
         # process, so releasing one we were never granted unbalances the count.
@@ -217,7 +218,41 @@ class BeanEngine:
                     start=stamp(self._start_wall), start_wall=self._start_wall,
                     stop=stamp(self._stop_wall), stop_wall=self._stop_wall,
                     running=self._running, elapsed=round(elapsed, 1),
-                    duration=self._duration, stop_reason=self.stop_reason)
+                    duration=self._duration, stop_reason=self.stop_reason,
+                    # None on the simulate path, which has no driver queue
+                    driver_queue=self._driver_queue)
+
+    # WinDivert's own queue, the one BEFORE ours. Nothing in this program used to
+    # read it, so a session's numbers could not be interpreted: with QUEUE_TIME at
+    # its default the driver may hold a packet for up to two seconds, and that
+    # delay is added by this tool while being invisible to it. Measured on the
+    # owner's machine (2026-07-28, elevated): LEN 4096, TIME 2000 ms, SIZE 4 MiB -
+    # and note SIZE binds first for full frames, 4 MiB / 1500 B = 2796 packets, not
+    # 4096. Reading them costs one call each, once per session.
+    # The WinDivert ABI numbers, spelled out rather than imported from
+    # ``pydivert.consts.Param``. The import is the problem: pydivert is a win32-only
+    # dependency, so on the Linux half of the CI matrix it is absent, and reaching
+    # for it here would make this return None on that runner while passing on
+    # Windows. They cannot drift silently -
+    # ``tests/test_engine.py::test_the_driver_queue_param_numbers_match_pydivert``
+    # compares them with the real enum wherever pydivert IS importable.
+    DRIVER_QUEUE_PARAMS = (("queue_len", 0), ("queue_time", 1), ("queue_size", 2))
+
+    def _read_driver_queue(self):
+        """The driver's queue settings, or ``None`` when there is nothing to ask.
+
+        Only a real WinDivert handle answers this. ``SyntheticDivert`` and the test
+        doubles have no ``get_param``, and that is not a failure - it is the
+        simulate path, which has no driver queue to describe. ``None`` says exactly
+        that; zeroes would read as "a queue of nothing", a different and false claim.
+        """
+        divert = self._divert
+        if not hasattr(divert, "get_param"):
+            return None
+        with crashlog.quiet("engine.driver_queue"):
+            return {name: divert.get_param(number)
+                    for name, number in self.DRIVER_QUEUE_PARAMS}
+        return None
 
     def time_left(self, now=None):
         """Seconds until the deadline (``None`` when the session has no limit)."""
@@ -699,6 +734,7 @@ class BeanEngine:
             except Exception as _exc:
                 crashlog.note(_exc, "engine")
         self._running = True
+        self._driver_queue = self._read_driver_queue()
         # always establish a concrete seed - this makes EVERY session reproducible
         self._effective_seed = self._seed if self._seed is not None else random.randrange(1, 2**31 - 1)
         self._rng = random.Random(self._effective_seed)
@@ -804,6 +840,12 @@ class BeanEngine:
             self.stop(reason="fault")
             raise
         self.log(f"{T('log.start_filter')}: {filt}  (seed={self._effective_seed})")
+        if self._driver_queue:
+            # Said once, at START, because it frames every number that follows: a
+            # queue this deep is latency the tool can add without owning up to it.
+            q = self._driver_queue
+            self.log(T("log.driver_queue", n=q["queue_len"], t=q["queue_time"],
+                       kb=q["queue_size"] // 1024))
         self.log_event("START", f"filter={filt}, seed={self._effective_seed}"
                                 + (f", duration={self._duration:g}s" if self._duration else ""))
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -229,6 +229,7 @@
   "log.dest_set": "Destination set from the connection table",
   "log.donate_opened": "Support page opened",
   "log.driver": "WinDivert driver",
+  "log.driver_queue": "WinDivert queue: {n} packets / {t} ms / {kb} KB. This is the driver's own buffer, before this tool's - packets can wait in it, and that wait is added to your latency without appearing in any counter here.",
   "log.duration_reached": "Time limit reached ({v} s) - session stopped.",
   "log.engine_fault": "Engine fault: {e} - the session was stopped, your network is back to normal.",
   "log.error": "Error",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -229,6 +229,7 @@
   "log.dest_set": "Cel ustawiony z tabeli połączeń",
   "log.donate_opened": "Otwarto stronę wsparcia",
   "log.driver": "Sterownik WinDivert",
+  "log.driver_queue": "Kolejka WinDivert: {n} pakietów / {t} ms / {kb} KB. To bufor samego sterownika, przed buforem tego narzędzia - pakiety mogą w nim czekać, a to czekanie dokłada się do Twojego opóźnienia, nie pojawiając się w żadnym tutejszym liczniku.",
   "log.duration_reached": "Osiągnięto limit czasu ({v} s) - sesja zatrzymana.",
   "log.engine_fault": "Awaria silnika: {e} - sesja została zatrzymana, sieć działa normalnie.",
   "log.error": "Błąd",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -798,6 +798,75 @@ def test_only_the_injector_writes_the_delivered_counters():
           body.count('c["sent') == 3, f"({body.count(chr(99) + chr(91))})")
 
 
+class ParamDivert(FakeDivert):
+    """A divert that answers get_param, the way a real WinDivert handle does.
+
+    The values are the ones measured on the owner's machine (2026-07-28, elevated,
+    real driver): QUEUE_LEN 4096, QUEUE_TIME 2000 ms, QUEUE_SIZE 4 MiB.
+    """
+
+    QUEUE = {0: 4096, 1: 2000, 2: 4194304}      # Param.QUEUE_LEN / _TIME / _SIZE
+
+    def get_param(self, name):
+        return self.QUEUE[int(name)]
+
+
+def test_a_session_records_the_driver_queue_it_is_running_behind():
+    """Nothing in the program used to read WinDivert's own queue settings.
+
+    With QUEUE_TIME at its default the driver may hold a packet for up to two
+    seconds - latency this tool adds while being blind to it - and a session's
+    numbers could not be interpreted without knowing that. The values now travel
+    with the session, so a repro report from a machine you do not have still says
+    what queue it was running behind.
+    """
+    sh = BeanEngine()
+    sh.start("test", divert=ParamDivert([FakePacket(size=100, port=8400)]))
+    info = sh.session_info()
+    sh.stop()
+
+    q = info["driver_queue"]
+    check("driver queue: it is recorded", q is not None, f"({q})")
+    check("driver queue: all three values, under their own names",
+          q == {"queue_len": 4096, "queue_time": 2000, "queue_size": 4194304}, f"({q})")
+    check("driver queue: it survives into the stopped session's info",
+          sh.session_info()["driver_queue"] == q)
+
+
+def test_the_driver_queue_param_numbers_match_pydivert():
+    """The engine spells the WinDivert param numbers out instead of importing them.
+
+    It has to: pydivert is win32-only, so importing it there would make the read
+    return None on the Linux half of the CI matrix while passing on Windows - the
+    exact shape of bug that only shows up on the runner you did not run. This is
+    the other half of that trade: wherever pydivert IS importable, the numbers are
+    checked against its own enum, so they cannot drift in silence.
+    """
+    import importlib.util
+
+    if importlib.util.find_spec("pydivert") is None:
+        return                      # not this machine's job (see the docstring)
+    from pydivert.consts import Param
+    for name, number in BeanEngine.DRIVER_QUEUE_PARAMS:
+        expected = int(getattr(Param, name.upper()))
+        check(f"driver queue: {name} is {expected} in pydivert",
+              number == expected, f"(engine says {number})")
+
+
+def test_a_simulated_session_reports_no_driver_queue_rather_than_a_made_up_one():
+    """There is no driver on the --simulate path, so there is nothing to report.
+
+    `None` says that; zeroes would read as "a queue of nothing", which is a
+    different and false claim.
+    """
+    sh = BeanEngine()
+    sh.start("test", divert=FakeDivert([FakePacket(size=100, port=8401)]))
+    info = sh.session_info()
+    sh.stop()
+    check("driver queue: absent, not invented", info["driver_queue"] is None,
+          f"({info['driver_queue']})")
+
+
 def test_event_log_trim():
     sh = BeanEngine()
     for i in range(5100):


### PR DESCRIPTION
Audit finding **F10, part a** - visibility. The measurement half (part b) follows separately,
because it touches the capture loop and this does not.

`pydivert.WinDivert(filt)` never received a `set_param()`, and the package contained no
`get_param()` at all. So WinDivert's own queue - the one **ahead** of this tool's - was invisible:
with `QUEUE_TIME` at its default a packet may be held for up to **two seconds**, which is latency
this tool adds while being blind to it, and no session artefact said what queue produced its
numbers.

## Measured first, on the real driver

An elevated throwaway ICMP handle on the owner's machine (2026-07-28):

```
QPC frequency  10 MHz          QUEUE_LEN 4096   QUEUE_TIME 2000 ms   QUEUE_SIZE 4 MiB
packet age in the driver queue: 0.049 - 0.163 ms  (median ~0.08 ms, idle machine)
```

`QUEUE_SIZE` binds before `QUEUE_LEN` for full frames - 4 MiB / 1500 B = **2796 packets** - so at a
saturated gigabit (83k pkt/s of 1500 B) a frozen capture thread has roughly **34 ms** before the
driver starts discarding. And the 2000 ms is a *ceiling*, not a routine cost: on an idle machine the
queue adds 0.08 ms. Knowing which of those two a session was living in is exactly what part b is for.

## Deliberately NOT retuned

The trade is real in both directions, and **both sides are invisible today**: a large `QUEUE_TIME`
is latency the tool hides; a small one is **loss the tool cannot even count**, because a packet the
driver drops never reaches us, so no counter can see it. Picking values before measuring the actual
queue delay is machinery around the wrong primitive (convention 6). Measure first.

## What changed

- `_read_driver_queue()` reads the three params once the handle is open, `session_info()` carries
  them into the repro report as `session.driver_queue`, and one line goes to the log at START.
- `None` - not zeroes - on the simulate path. "No driver" and "a queue of nothing" are different
  claims.
- **The param numbers are spelled out rather than imported, and that is the part worth reading.**
  Reaching for `pydivert.consts.Param` here would import a **win32-only** dependency: the read would
  return `None` on the Linux half of the CI matrix while passing on Windows - the exact bug shape
  that only shows up on the runner you did not run. A guard test compares the numbers against the
  real enum wherever pydivert **is** importable, so they cannot drift in silence.
- `--doctor` gains a line saying where the values live and why it does not read them itself: they
  need an open handle, and opening one loads the driver - which would falsify the "windivert driver"
  check printed two lines above it, in the same report.

## Verification

- `python -m pytest tests` -> **703 passed, 0 failed** (elevated shell). `python smoke_gui.py` -> OK.
- Three new guards, **three mutants, every one caught** - including swapping two ABI numbers, which
  the pydivert cross-check catches with `queue_time is 1 in pydivert (engine says 2)`.
- No hot-path change: three calls, once per session.

**Still owed:** an end-to-end run on the real driver, to confirm the numbers actually reach the log
line and the repro report rather than just the unit test. Asked for separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
