### PR TITLE
docs(socketwatch): say what the layer timing actually measures

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,43 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Docs: the SOCKET-layer timing now says what was measured (prose only, no behaviour change)
+
+The whole SOCKET-layer targeting design (PR #38) is justified by two numbers that came from a
+2026-07-22 spike note and were never re-measured. Both are wrong, in different ways, and the
+conclusion drawn from the first claimed more than it supports.
+
+**Re-measured 2026-07-28** (Win11, elevated, three sniff-only handles opened SEQUENTIALLY and
+compared on one clock - the QPC stamp WinDivert puts on every event - across 10 outbound TCP
+connections to 8.8.8.8:53):
+
+| claim in the code | measured |
+|---|---|
+| `SOCKET_CONNECT` ~0.1 ms before the SYN | before in **10/10**, by **0.018-0.027 ms** (median 0.020) |
+| `FLOW_ESTABLISHED` ~28 ms after | **37.7-41.3 ms** after (median 38.7) |
+
+- **The ORDER holds, the margin does not.** `SOCKET_CONNECT` really does precede the SYN every
+  time, so choosing the SOCKET layer over polling stands. But the margin is **five times smaller**
+  than the docstring said.
+- **"The race is closed at the source" is now cut.** Those tens of microseconds are the gap between
+  the two events AT THE DRIVER. Whether `socketwatch`'s own handling - thread wake, parse, dict
+  insert - finishes inside that gap has **not** been measured, and at 20 us it is no longer
+  self-evident the way it looked at 100 us. The prose now guarantees ordering and explicitly does
+  not guarantee slack.
+- **The FLOW number was a property of somebody's network, not of the FLOW layer.** 38.7 ms tracks
+  the round trip to the peer (ping to the same host on this link: 23-47 ms), because the flow is
+  established once the handshake completes. Recorded as such, so nobody reads it as a constant.
+  The reason for rejecting FLOW is unchanged: it lands after the handshake either way.
+
+Corrected in `socketwatch.py` (module docstring), `engine.py::_pid_for`, `targeting.py` (module
+docstring) and PROJECT_NOTES in three places. **Deliberately NOT touched:** the `~0.1 ms` in
+`model_worker.py`, `gui/panels/event_log.py` and `gui/pages/conns.py` - that is the virtualised
+table's repaint cost, a different measurement that happens to share a number. Historical changelog
+entries are left as written; they record what was believed at the time.
+
+No test guards this and none can - it is prose. What can be done was done: the numbers now carry
+their conditions, so the next session can tell whether they still apply to its machine.
+
 ### Fixed: the forged RST now lands on loopback connections too (audit F15)
 
 Measured on the owner's machine (2026-07-28, elevated, real driver) by watching what the

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -658,9 +658,11 @@ class BeanEngine:
         poller second. That order is the point: the poller is a snapshot taken a few
         times a second, so a flow that opens AND finishes inside one refresh interval
         left a row with no owner at all, and short-lived connections are exactly what
-        this tool gets pointed at. The watcher is told the owner ~0.1 ms before the SYN
-        reaches the NETWORK layer (measured), so the row can be stamped from its first
-        packet.
+        this tool gets pointed at. The watcher is told the owner BEFORE the SYN reaches
+        the NETWORK layer - measured 2026-07-28 at 0.018-0.027 ms ahead, 10 runs out of
+        10 - so the row can usually be stamped from its first packet. "Usually": that
+        margin is the gap at the DRIVER, and whether the watcher's own handling fits
+        inside a few tens of microseconds is not measured (see socketwatch.py).
 
         Neither path may touch the OS from here - this is the capture thread. The
         watcher lookup is a lock-free dict read (see ``SocketWatcher.pid_for``) and the

--- a/beantester/socketwatch.py
+++ b/beantester/socketwatch.py
@@ -14,12 +14,27 @@ WinDivert 2.2 exposes a SOCKET layer that delivers an event the moment a socket
 is bound / connected / accepted / closed, carrying the owning ``ProcessId``. A
 **sniff-only** handle (``SNIFF | RECV_ONLY`` - it cannot drop or modify anything)
 turns "guess the owner from a stale snapshot" into "be told the owner as it
-happens". Measured (spike, 2026-07-22): ``SOCKET_CONNECT`` arrives ~0.1 ms
-*before* the outbound SYN reaches the NETWORK layer, so the mapping is ready
-before the connection's first packet - the race the polling design could only
-shrink is closed at the source. (``FLOW_ESTABLISHED`` was measured ~28 ms LATER,
-i.e. after the handshake, which is why the SOCKET layer, not the FLOW layer, is
-the source here.)
+happens".
+
+**Re-measured 2026-07-28** (Win11, elevated, three sniff-only handles compared on
+one clock - the QPC stamp WinDivert puts on every event - across 10 outbound TCP
+connections to 8.8.8.8:53):
+
+* ``SOCKET_CONNECT`` came before the outbound SYN in **10 runs out of 10**, by
+  **0.018-0.027 ms, median 0.020**. The ORDER is what this design rests on, and it
+  holds. The margin does not: an earlier note here said "~0.1 ms", five times what
+  this machine shows.
+* ``FLOW_ESTABLISHED`` came **37.7-41.3 ms after** the SYN, median 38.7 - i.e.
+  after the handshake, which is why the SOCKET layer and not the FLOW layer is the
+  source here. That number is **the round trip to the peer, not a property of the
+  FLOW layer**: ping to the same host measured 23-47 ms on this link, and an
+  earlier note quoting "~28 ms" was quoting somebody's network.
+
+What this does NOT establish, and used to be claimed here: that "the race is
+closed at the source". The tens of microseconds above are the gap between the two
+events AT THE DRIVER. Whether this module's own handling - thread wake, parse,
+dict insert - finishes inside that gap has not been measured. Ordering is
+guaranteed; comfortable slack is not.
 
 Scope of this module: the map and its event handling. ``BeanEngine`` owns its
 lifecycle (created and stopped with the session) and points ``ProcessTargeting``

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -59,11 +59,14 @@ was wrong (PROJECT_NOTES rule 6):
   PID, so the mapping is a snapshot race - it can be made small, not closed, and
   the first packet of a brand-new connection may slip through;
 * against the **live SOCKET-event map** (:class:`beantester.socketwatch.SocketWatcher`,
-  the default in a real session since chunk 2c), the race is closed for outbound
-  connections: the SOCKET_CONNECT event is delivered before the SYN reaches the
-  NETWORK layer (measured ~0.1 ms ahead), so the port is already mapped when the
-  first packet arrives. ``set_table`` is how the engine points this at one or the
-  other.
+  the default in a real session since chunk 2c), the ORDER is in our favour rather
+  than left to chance: the SOCKET_CONNECT event is delivered before the SYN reaches
+  the NETWORK layer, measured 2026-07-28 in 10 runs out of 10, by 0.018-0.027 ms.
+  So the port can be mapped before the first packet is judged - but note the size
+  of that margin: it is the gap at the DRIVER, and whether the watcher's own
+  handling fits inside a few tens of microseconds is NOT measured. This used to say
+  "the race is closed", which claimed more than the number supports.
+  ``set_table`` is how the engine points this at one or the other.
 """
 import threading
 import time


### PR DESCRIPTION
Prose only. No behaviour change, no code paths touched, no i18n.

The SOCKET-layer targeting design (#38) is justified by two numbers that came from a 2026-07-22
spike note and were never re-measured. **Both are wrong, in different ways** - and the conclusion
drawn from the first claimed more than it supports.

## Re-measured

Win11, elevated. Three sniff-only handles (`SNIFF | RECV_ONLY` - cannot drop or modify anything),
opened **sequentially**, compared on one clock: the QPC stamp WinDivert puts on every event. 10
outbound TCP connections to 8.8.8.8:53.

| claim in the code | measured |
|---|---|
| `SOCKET_CONNECT` ~0.1 ms before the SYN | before in **10/10**, by **0.018-0.027 ms** (median 0.020) |
| `FLOW_ESTABLISHED` ~28 ms after the SYN | **37.7-41.3 ms** after (median 38.7) |

## What changes, and what does not

**The order holds; the margin does not.** `SOCKET_CONNECT` really does precede the SYN every time,
so choosing the SOCKET layer over polling stands and the design is unchanged. But the margin is
**five times smaller** than the docstring said.

**"The race is closed at the source" is cut.** Those tens of microseconds are the gap between the
two events *at the driver*. Whether `socketwatch`'s own handling - thread wake, parse, dict insert -
finishes inside that gap has **not** been measured, and at 20 us that is no longer self-evident the
way it looked at 100 us. The prose now guarantees ordering and explicitly does not guarantee slack.
That is a weaker claim than before, and it is the one the evidence carries.

**The FLOW number was a property of somebody's network.** 38.7 ms tracks the round trip to the peer
(ping to the same host on this link: 23-47 ms), because the flow is established once the handshake
completes - so it is recorded as an RTT, not as a constant of the FLOW layer. The reason for
rejecting FLOW is unchanged: it lands after the handshake either way.

## Scope

Corrected in `socketwatch.py`, `engine.py::_pid_for`, `targeting.py`, and PROJECT_NOTES (three
places, carried by hand - that file is gitignored).

**Deliberately not touched:** the `~0.1 ms` in `model_worker.py`, `gui/panels/event_log.py` and
`gui/pages/conns.py`. That is the virtualised table's repaint cost - a different measurement that
happens to share a number, and rewriting it would have been the exact mistake this change is
correcting. Historical changelog entries are left as written; they record what was believed then.

## Verification

`python -m pytest tests` -> **709 passed, 0 failed**. `python smoke_gui.py` -> OK. No test guards
prose and none can; what could be done was done - every number now carries its conditions, so the
next session can tell whether it still applies to its machine.

**Left open on purpose:** whether the first packet of a fresh connection really lands in scope
end-to-end. That is the question the 20 us margin raises, and it needs its own experiment rather
than a sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
