### PR TITLE
fix(targeting): let the first packet of a fresh connection be in scope

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,51 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed: the first packet of a fresh connection can be in targeting scope (audit F16)
+
+- **Symptom, measured end to end before writing anything.** `ProcessTargeting.__contains__` answers
+  from `_ports`, a frozenset rebuilt on the resolver's thread, so a socket opened microseconds ago
+  is unknown there - and the first packet of a connection is judged BEFORE any rebuild it triggers.
+  20 fresh connections against a process target with `--syn-drop 100`: **20 established, `drop_syn`
+  0**. `--syn-drop` combined with `--target` was a complete no-op, and every other impairment missed
+  one packet per connection.
+- **This is NOT the 0.02 ms.** The SOCKET-layer margin measured the same day is real, but nothing
+  consumed it: the live map fed the REBUILD, not the packet-path test. The order being in our favour
+  is worth nothing until something reads it at the right moment.
+- **Fix.** `ProcessTargeting.syn_covers(port)` - a lock-free `pid_for` read checked against `_pids`,
+  the set the last rebuild concluded - and `BeanCore.decide` step 1 calls it **for a TCP SYN only**,
+  i.e. once per connection rather than once per packet. `_syn_covers` is bound in `set_target`, so
+  the packet path does not even do a `getattr`, and a plain port set (tests, one-shot resolution)
+  binds `None` and keeps exactly the behaviour it had.
+- **It drags a second fix with it, and this is the part that would have been missed.** Step 4 arms a
+  reset on the first in-scope TCP packet. With SYNs now in scope that becomes the SYN - and the RST
+  forged from a SYN copies its `ack_num` as the sequence, which a SYN does not have, so it goes out
+  with `seq=0` and no ACK. RFC 793 lets a stack in SYN_SENT ignore that, and **it was measured doing
+  exactly that** (2026-07-28: the client hung until its own timeout, `rst_sent` reported 1). So a
+  reset is no longer ARMED from a SYN, while a SYN arriving inside an existing cooldown is still
+  held down. Without this, F16 would have traded a working reset for a hang.
+- **Known limits, both deliberate and both in the docstring:** a process with no socket yet is not
+  in `_pids`, so the FIRST connection of a freshly started target still slips through (covering it
+  needs the matcher plus a name lookup in the packet path - convention 20); and `_pids` is up to one
+  resolver cycle stale, so a recycled PID can pull one packet of an unrelated socket into scope -
+  a DIFFERENT false positive from the stale `_ports` this code already lived with. UDP has no SYN
+  and is not covered.
+- **Contract widened on purpose:** `set_table` documented `snapshot`/`name_of`/`ancestors`/`refresh`;
+  `pid_for` is now part of it. Both real tables always had it, but `syn_covers` reads it through
+  `getattr` so a table that does not - a test double, an older implementation - answers False
+  instead of raising `AttributeError` **on the capture thread**.
+- **Hot path measured** against a worktree of master (150k 1500 B packets, median of 5). No
+  targeting: 135.9k -> 140.3k pkt/s. **Targeting on with every packet missing** - the common path
+  when a target is set, and where the new test lives: 164.0/164.7k -> 164.5/170.4k. No regression
+  either way; the added cost is one boolean that short-circuits on `is_syn`, below the noise floor.
+- Six new guards across `tests/test_core.py` and `tests/test_targeting_socketwatch.py`; **six
+  mutants, every one caught after a repair worth recording** - two of them first pointed at
+  `test_core.py`, which drives a local fake rather than `ProcessTargeting`, so the real `getattr`
+  guard was not covered by anything. It has its own test now.
+- `test_core_properties.py::test_an_armed_gate_wins_over_every_later_step` drove every gate with
+  `is_syn=True`; the rst gate now needs an ordinary packet. The test states why, rather than being
+  quietly relaxed.
+
 ### Docs: the SOCKET-layer timing now says what was measured (prose only, no behaviour change)
 
 The whole SOCKET-layer targeting design (PR #38) is justified by two numbers that came from a

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -120,12 +120,21 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   exactly that** (2026-07-28: the client hung until its own timeout, `rst_sent` reported 1). So a
   reset is no longer ARMED from a SYN, while a SYN arriving inside an existing cooldown is still
   held down. Without this, F16 would have traded a working reset for a hang.
-- **Known limits, both deliberate and both in the docstring:** a process with no socket yet is not
-  in `_pids`, so the FIRST connection of a freshly started target still slips through (covering it
-  needs the matcher plus a name lookup in the packet path - convention 20); and `_pids` is up to one
-  resolver cycle stale, so a recycled PID can pull one packet of an unrelated socket into scope -
-  a DIFFERENT false positive from the stale `_ports` this code already lived with. UDP has no SYN
-  and is not covered.
+- **Acceptance, and it corrected the limitation as written.** Predicted 19 of 20 blocked; the first
+  run gave **6**. The gap is not the 0.02 ms: `_pids` is rebuilt from pids owning CURRENTLY OPEN
+  sockets, and the probe connected, closed at once and idled 0.2 s, so a rebuild landing in that
+  gap dropped the process out again. A second probe **holding its sockets open** was blocked **19
+  of 20** (`drop_syn` 38 - each connection's SYN plus its retransmit), the single escape being
+  attempt 0, before the process had any socket at all. Two candidate causes existed and this
+  separated them: it is `_pids` churn, not the watcher failing to process the event in time.
+- **So the documented limit was too narrow and is now precise:** not "the first connection of a
+  freshly started target" but "any target with no open socket when a rebuild runs". A browser or an
+  app under test is covered; a script opening one connection, closing it and pausing keeps slipping
+  through. Both measured numbers (6/20 closing, 19/20 holding) are in the docstring, because the
+  difference between them IS the limitation.
+- Also: `_pids` is up to one resolver cycle stale, so a recycled PID can pull one packet of an
+  unrelated socket into scope - a DIFFERENT false positive from the stale `_ports` this code already
+  lived with. UDP has no SYN and is not covered.
 - **Contract widened on purpose:** `set_table` documented `snapshot`/`name_of`/`ancestors`/`refresh`;
   `pid_for` is now part of it. Both real tables always had it, but `syn_covers` reads it through
   `getattr` so a table that does not - a test double, an older implementation - answers False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,32 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Aiming at a process missed the first packet of every new connection - and your test results
+  will change because of it.** Working out which connections belong to your target means keeping a
+  set of its ports, and that set is rebuilt in the background. A connection opened a moment ago was
+  not in it yet, so its very first packet was waved through untouched, every time. Measured here:
+  20 fresh connections against a targeted process with "Drop SYN" at 100% produced 20 successful
+  connections and not one dropped SYN. **"Drop SYN" combined with process targeting therefore did
+  nothing at all** - the SYN is by definition the first packet, so it always escaped. The first
+  packet is now checked against the live socket map, so it is caught like any other.
+
+  What changes for you: with loss (or blocking, or a link outage) aimed at a process, **connections
+  will now take noticeably longer to open**, because the SYN can be lost and TCP has to retransmit
+  it - and a minority will fail to open at all, which is what a bad network does. Before, every
+  connection opened at full speed and only then started suffering. If a test of yours measured
+  "time to first byte" under impairment, expect it to move.
+
+  Two limits worth knowing. The **first connection of a freshly started program** still slips
+  through - until it has one socket, the tool has no way to know the process exists. And a program
+  using UDP has no SYN, so its first packet is not covered by this.
+
+- **"Reset connections" no longer fires on a connection that is still opening.** It could not have
+  worked there anyway: the reset packet the tool forges from a connection request carries no
+  acknowledgement number, and Windows is entitled to ignore exactly that - measured, the connection
+  hung until its own timeout instead of being reset. That combination was unreachable before the
+  change above; it would have become the normal case. Resets now fire on established connections,
+  where they were measured to work.
+
 - **"Reset connections" did nothing to local (loopback) connections - it just made them go
   quiet.** Aim the tool at `127.0.0.1` traffic with resets switched on and the connection was not
   reset: it stopped carrying anything for the length of the cooldown, so the application sat there

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,9 +121,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   connection opened at full speed and only then started suffering. If a test of yours measured
   "time to first byte" under impairment, expect it to move.
 
-  Two limits worth knowing. The **first connection of a freshly started program** still slips
-  through - until it has one socket, the tool has no way to know the process exists. And a program
-  using UDP has no SYN, so its first packet is not covered by this.
+  Two limits worth knowing, both measured rather than guessed. The tool recognises your target by
+  the connections it currently has open, so **a program that has none open at the moment the tool
+  looks is invisible again**: over 20 fresh connections with "Drop SYN", a program keeping its
+  connections open was caught **19 times out of 20** (only the very first escaped, before it had
+  opened anything), while the same program closing each connection before starting the next was
+  caught **6 times out of 20**. So a browser or an app under test is covered; a script that opens
+  one connection, closes it and pauses will keep slipping through. And a program using UDP has no
+  SYN, so its first packet is not covered by any of this.
 
 - **"Reset connections" no longer fires on a connection that is still opening.** It could not have
   worked there anyway: the reset packet the tool forges from a connection request carries no

--- a/beantester/core.py
+++ b/beantester/core.py
@@ -210,6 +210,11 @@ class BeanCore:
         # targeting
         self.target_active = False
         self.target_ports = set()
+        # Bound in set_target, so the packet path does not even do a getattr.
+        # None whenever the port container cannot answer for a fresh socket - a
+        # plain set (tests, one-shot resolution), which is the behaviour that
+        # existed before this check did.
+        self._syn_covers = None
         self.dst_active = False
         self.dst_ip = ""            # raw expression text (for summaries/reports)
         self.dst_port = ""          # raw expression text
@@ -299,6 +304,7 @@ class BeanCore:
                 self.target_ports = set(ports)
             else:
                 self.target_ports = ports
+            self._syn_covers = getattr(self.target_ports, "syn_covers", None)
 
     def set_dest(self, active, ip=None, port=None):
         """Destination targeting. ``ip``/``port`` are filter expressions (see
@@ -489,7 +495,17 @@ class BeanCore:
         with self._lock:
             # 1) process targeting
             if self.target_active and local_port not in self.target_ports:
-                return Decision(False, False, [now], scoped=False)
+                # The port set is rebuilt on another thread, so a socket opened
+                # microseconds ago is unknown HERE even when the live SOCKET map
+                # already knows its owner - and the first packet of every fresh
+                # connection was therefore judged out of scope. Measured end to
+                # end: 20 of 20 SYNs walked past a process target. For a SYN, and
+                # only a SYN (once per connection, not once per packet), ask that
+                # map. `not in` above has already flagged the miss and woken the
+                # resolver, so the rest of the connection takes the usual path.
+                if not (is_syn and self._syn_covers is not None
+                        and self._syn_covers(local_port)):
+                    return Decision(False, False, [now], scoped=False)
             # 2) destination targeting (remote IP/port) - filter expressions
             if self.dst_active:
                 if self.dst_ip_matcher and not self.dst_ip_matcher.matches(remote_ip):
@@ -568,8 +584,19 @@ class BeanCore:
                 until = self._reset_until.get(key, 0.0)
                 if now < until:
                     return Decision(True, False, [], "rst")
-                trigger = (now < self._reset_now_deadline) or \
-                          (self.rst_prob > 0 and rng.random() < self.rst_prob)
+                # NOT armed from a SYN. The RST we would forge copies the packet's
+                # ack_num as its sequence, and a SYN has none - so the reset goes
+                # out with seq=0 and no ACK, which a stack in SYN_SENT is entitled
+                # to ignore (RFC 793). MEASURED 2026-07-28: exactly that left the
+                # client hanging until its own timeout instead of resetting it,
+                # while rst_sent reported 1. This was unreachable until a SYN could
+                # be in targeting scope; now it is the FIRST packet a reset would
+                # fire on, so arming here would trade a working reset for a hang.
+                # The cooldown check above still applies to a SYN: a retransmit of
+                # a connection already being held down stays held down.
+                trigger = not is_syn and (
+                    (now < self._reset_now_deadline)
+                    or (self.rst_prob > 0 and rng.random() < self.rst_prob))
                 if trigger:
                     self._reset_until.set(key, now + self.rst_cooldown_s)
                     return Decision(True, False, [], "rst", True)

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -176,10 +176,16 @@ class ProcessTargeting:
 
         Two limits, both deliberate, both measured rather than assumed:
 
-        * a process with NO socket yet is not in ``_pids`` at all, so the FIRST
-          connection of a freshly started target still slips through. Covering
-          that needs the matcher and a name lookup in the packet path, which is
-          what convention 20 forbids.
+        * ``_pids`` is rebuilt from the pids owning CURRENTLY OPEN sockets, so a
+          target that has none when a rebuild runs drops out of it and its next
+          connection is uncovered again. Measured with ``--syn-drop 100`` over 20
+          fresh connections: a probe holding its sockets open was caught **19 of
+          20** (only its first, before it had any socket, escaped), while the same
+          probe closing each connection before the next was caught **6 of 20**.
+          So this covers a target that keeps sockets - a browser, an app under
+          test - and keeps missing one that opens a connection, closes it and
+          pauses. Covering that needs the matcher and a name lookup in the packet
+          path, which is what convention 20 forbids.
         * ``_pids`` is up to one resolver cycle stale (0.30 s). If the target
           exits and Windows recycles its PID inside that window, one packet of an
           unrelated new socket can be pulled into scope. That is a DIFFERENT false

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -145,13 +145,57 @@ class ProcessTargeting:
         (:class:`beantester.socketwatch.SocketWatcher`) when a session has one, and
         back at the polling :class:`~beantester.portmap.PortTable` otherwise (no real
         WinDivert, or the SOCKET handle could not open). Both expose the same read
-        surface (``snapshot`` / ``name_of`` / ``ancestors`` / ``refresh``), which is
-        why the swap is a one-line reference change. The resolved port set is left as
+        surface (``snapshot`` / ``name_of`` / ``ancestors`` / ``refresh``, plus
+        ``pid_for`` since ``syn_covers`` exists - both real tables have always had
+        it, but it is part of the contract now), which is why the swap is a
+        one-line reference change. The resolved port set is left as
         it is until the next ``refresh()`` (the resolver runs those continuously), so
         the swap never blips the hot-path ``__contains__``.
         """
         with self._lock:
             self.table = table if table is not None else portmap.default_table()
+
+    def syn_covers(self, port):
+        """Is this port a brand-new socket of a process we ALREADY target?
+
+        ``__contains__`` answers from ``_ports``, a frozenset rebuilt on another
+        thread, so the first packet of a fresh connection is judged BEFORE any
+        rebuild it triggers - it was never in scope, however early the SOCKET
+        event arrived. MEASURED end to end 2026-07-28: 20 fresh connections
+        against a process target with ``--syn-drop 100``, 20 SYNs straight
+        through, ``drop_syn`` 0. The live map knew each owner 0.02 ms before its
+        SYN; nothing consumed that.
+
+        This is the one place that does. ``BeanCore.decide`` calls it for a TCP
+        SYN only - once per connection, not once per packet - and it costs a
+        lock-free dict read plus a frozenset lookup, no lock of its own.
+
+        ``_pids`` is what the last rebuild concluded, so every expression form
+        (name, PID, list, range, ``!`` exclusion, ancestor match) is already
+        resolved into it. This does not re-run the matcher.
+
+        Two limits, both deliberate, both measured rather than assumed:
+
+        * a process with NO socket yet is not in ``_pids`` at all, so the FIRST
+          connection of a freshly started target still slips through. Covering
+          that needs the matcher and a name lookup in the packet path, which is
+          what convention 20 forbids.
+        * ``_pids`` is up to one resolver cycle stale (0.30 s). If the target
+          exits and Windows recycles its PID inside that window, one packet of an
+          unrelated new socket can be pulled into scope. That is a DIFFERENT false
+          positive from the stale ``_ports`` this code already lived with - named
+          here rather than implied.
+        """
+        if port is None:
+            return False
+        # `pid_for` is asked of the table by getattr because `set_table` accepts
+        # anything with the read surface, and a table that predates this (or a
+        # test double) would otherwise raise AttributeError ON THE CAPTURE THREAD.
+        pid_for = getattr(self.table, "pid_for", None)
+        if pid_for is None:
+            return False
+        pid = pid_for(port)
+        return pid is not None and pid in self._pids
 
     # -- the container BeanCore tests against ---------------------------------- #
     def __contains__(self, port):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -276,6 +276,126 @@ def test_lan_mode_gate():
     check("LAN: disabled = internet passes", not off.drop, f"(drop={off.drop})")
 
 
+class _FakePorts:
+    """A live port container the way ``ProcessTargeting`` presents itself.
+
+    ``ports`` is what the asynchronous rebuild has caught up with; ``owners`` is
+    what the live socket map knows RIGHT NOW; ``pids`` is the set the last rebuild
+    concluded. A brand-new socket is in ``owners`` but not yet in ``ports`` - the
+    exact state every fresh connection is judged in.
+    """
+
+    def __init__(self, ports=(), owners=None, pids=(), with_pid_for=True):
+        self._ports = set(ports)
+        self.owners = dict(owners or {})
+        self.pids = set(pids)
+        self.misses = 0
+        if not with_pid_for:                 # a table that predates syn_covers
+            del self.__dict__["owners"]
+
+    def __contains__(self, port):
+        if port in self._ports:
+            return True
+        self.misses += 1
+        return False
+
+    def syn_covers(self, port):
+        owners = getattr(self, "owners", None)
+        if owners is None:
+            return False
+        pid = owners.get(port)
+        return pid is not None and pid in self.pids
+
+
+def test_a_syn_from_a_fresh_socket_of_a_targeted_process_is_in_scope():
+    """The first packet of a fresh connection used to walk past targeting.
+
+    ``__contains__`` answers from a set rebuilt on another thread, so a socket
+    opened microseconds ago is unknown there even when the live SOCKET map already
+    has its owner. MEASURED end to end 2026-07-28: 20 fresh connections against a
+    process target with ``--syn-drop 100`` produced 20 established connections and
+    ``drop_syn`` 0. The SYN - and only the SYN - now asks that map.
+    """
+    core = BeanCore()
+    rng = random.Random(0)
+    # port 5000 is a brand new socket of pid 42, which IS the target; the rebuilt
+    # port set has not caught up with it yet
+    ports = _FakePorts(ports={4000}, owners={5000: 42, 6000: 99}, pids={42})
+    core.set_target(True, ports)
+
+    kw = dict(remote_ip="1.1.1.1", remote_port=80, is_tcp=True)
+    syn = core.decide(100, True, 5000, 0.0, rng, is_syn=True, **kw)
+    check("fresh SYN of the target is in scope", syn.scoped is True,
+          f"(scoped={syn.scoped})")
+
+    other = core.decide(100, True, 6000, 0.0, rng, is_syn=True, **kw)
+    check("a SYN of ANOTHER process stays out of scope", other.scoped is False,
+          f"(scoped={other.scoped})")
+
+    data = core.decide(100, True, 5000, 0.0, rng, is_syn=False, **kw)
+    check("a non-SYN on the same unknown port is unchanged - still out of scope",
+          data.scoped is False, f"(scoped={data.scoped})")
+
+    known = core.decide(100, True, 4000, 0.0, rng, is_syn=False, **kw)
+    check("a port the rebuild already knows needs none of this",
+          known.scoped is True, f"(scoped={known.scoped})")
+
+    check("the miss still wakes the resolver, as before", ports.misses >= 3,
+          f"(misses={ports.misses})")
+
+
+def test_a_port_container_without_pid_for_does_not_break_the_packet_path():
+    """``set_table`` accepts anything with the read surface, and ``pid_for`` was
+    not part of it until now. A container that cannot answer must fall back to the
+    old behaviour, not raise AttributeError on the CAPTURE THREAD."""
+    core = BeanCore()
+    rng = random.Random(0)
+    core.set_target(True, _FakePorts(ports={4000}, pids={42}, with_pid_for=False))
+    d = core.decide(100, True, 5000, 0.0, rng, remote_ip="1.1.1.1", remote_port=80,
+                    is_tcp=True, is_syn=True)
+    check("no owner map -> out of scope, and no exception", d.scoped is False)
+
+
+def test_a_plain_port_set_keeps_the_behaviour_it_always_had():
+    """`set_target(True, {9999})` - tests and one-shot resolution - hands over a
+    plain set, which cannot answer for a fresh socket. The SYN check must simply
+    not exist for it."""
+    core = BeanCore()
+    rng = random.Random(0)
+    core.set_target(True, {9999})
+    d = core.decide(100, True, 5000, 0.0, rng, remote_ip="1.1.1.1", remote_port=80,
+                    is_tcp=True, is_syn=True)
+    check("plain set: a SYN on an unknown port is out of scope", d.scoped is False)
+    check("and the fast path was not even bound", core._syn_covers is None)
+
+
+def test_a_reset_is_never_armed_from_a_syn():
+    """The RST forged from a SYN copies its ack_num as the sequence - and a SYN has
+    none, so it goes out with seq=0 and no ACK, which SYN_SENT is entitled to
+    ignore (RFC 793). MEASURED 2026-07-28: it left the client hanging until its own
+    timeout instead of resetting it. Unreachable until a SYN could be in targeting
+    scope; now it would be the FIRST packet a reset fires on."""
+    core = BeanCore()
+    rng = random.Random(0)
+    core.set_rst(100, 5.0)          # every eligible packet arms a reset
+    kw = dict(remote_ip="1.1.1.1", remote_port=80, is_tcp=True)
+
+    syn = core.decide(100, True, 5000, 0.0, rng, is_syn=True, **kw)
+    check("a SYN does not arm a reset", not (syn.drop and syn.reason == "rst"),
+          f"(drop={syn.drop}, reason={syn.reason})")
+
+    data = core.decide(100, True, 5001, 0.0, rng, is_syn=False, **kw)
+    check("an ordinary packet still does",
+          data.drop and data.reason == "rst" and data.emit_rst is True,
+          f"(drop={data.drop}, reason={data.reason}, emit={data.emit_rst})")
+
+    # ...and a SYN retransmitted into an ALREADY armed cooldown stays held down
+    held = core.decide(100, True, 5001, 1.0, rng, is_syn=True, **kw)
+    check("a SYN inside an existing cooldown is still dropped",
+          held.drop and held.reason == "rst" and held.emit_rst is False,
+          f"(drop={held.drop}, reason={held.reason})")
+
+
 def test_decision_scoped_reflects_targeting():
     """`scoped` says whether a packet passed the targeting gate (steps 1-2), i.e.
     whether the flow is in scope for impairment - the signal behind the "impaired?"

--- a/tests/test_core_properties.py
+++ b/tests/test_core_properties.py
@@ -255,7 +255,14 @@ def test_an_armed_gate_wins_over_every_later_step(gate, seed, size,
     """
     core = _armed(gate, rst_cooldown, flap_period)
     rng = random.Random(seed)
-    kw = dict(remote_ip="8.8.8.8", remote_port=443, is_tcp=True, is_syn=True)
+    # A SYN can no longer ARM the RST gate, deliberately: the reset forged from a
+    # SYN copies its ack_num as the sequence, and a SYN has none, so it goes out
+    # with seq=0 and no ACK - which SYN_SENT is entitled to ignore (RFC 793).
+    # Measured 2026-07-28: such a reset left the client hanging until its own
+    # timeout instead of resetting it. So the rst gate is armed with an ordinary
+    # packet here; the syn gate needs a SYN by definition, and the rest do not care.
+    kw = dict(remote_ip="8.8.8.8", remote_port=443, is_tcp=True,
+              is_syn=(gate != "rst"))
     now = 0.0
     if gate == "nat":
         core.decide(100, True, 5000, 0.0, rng, **kw)     # create the mapping...

--- a/tests/test_targeting_socketwatch.py
+++ b/tests/test_targeting_socketwatch.py
@@ -142,6 +142,54 @@ def test_a_connection_is_targeted_the_moment_its_socket_event_arrives():
         watcher.stop()
 
 
+def test_syn_covers_reads_the_live_map_without_waiting_for_a_rebuild():
+    """`__contains__` answers from a set rebuilt on the resolver's thread, so the
+    FIRST packet of a fresh connection is judged before any rebuild it triggers.
+    Measured end to end 2026-07-28: 20 fresh connections against a process target
+    with `--syn-drop 100` gave 20 established connections and `drop_syn` 0.
+
+    `syn_covers` is the one path that consults the live map instead, so it answers
+    correctly with NO refresh having happened - which is what this asserts by
+    never starting a resolver.
+    """
+    names = _Names({100: "chrome.exe", 200: "svchost.exe"})
+    watcher = SocketWatcher(names=names,
+                            source_factory=lambda: _Source([ev(CONNECT, 100, 5000),
+                                                            ev(CONNECT, 200, 6000)]))
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=watcher)
+    watcher.start()
+    try:
+        _wait(lambda: watcher.pid_for(5000) == 100)
+        # no resolver: the rebuilt port set is still empty, as it is for every
+        # brand-new socket at the moment its SYN is judged
+        check("the rebuilt set knows nothing yet", 5000 not in targeting)
+        check("...and syn_covers cannot help until a rebuild names the pid",
+              targeting.syn_covers(5000) is False)
+
+        targeting.refresh()          # what the resolver does on the miss above
+        check("after the rebuild the fresh socket is covered",
+              targeting.syn_covers(5000) is True)
+        check("another process's socket is not",
+              targeting.syn_covers(6000) is False)
+    finally:
+        watcher.stop()
+
+
+def test_syn_covers_survives_a_table_that_cannot_answer():
+    """`set_table` takes anything with the read surface, and `pid_for` only became
+    part of that contract with `syn_covers`. This runs on the CAPTURE THREAD, so a
+    table without it has to answer False - an AttributeError there would kill the
+    capture thread and fail the session open (convention 20)."""
+    class _NoPidFor:
+        def snapshot(self):
+            return {}
+
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=_NoPidFor())
+    targeting._pids = frozenset({100})
+    check("a table without pid_for answers False instead of raising",
+          targeting.syn_covers(5000) is False)
+
+
 # -- engine binding ----------------------------------------------------------- #
 def test_engine_binds_targeting_to_the_watcher_when_present():
     eng = BeanEngine()


### PR DESCRIPTION
**F16.** Aiming at a process missed the **first packet of every new connection**.

`ProcessTargeting.__contains__` answers from a frozenset rebuilt on the resolver's thread, so a
socket opened microseconds ago is unknown there - and the first packet of a connection is judged
*before* any rebuild it triggers.

Measured end to end before writing anything: **20 fresh connections against a process target with
`--syn-drop 100` gave 20 established connections and `drop_syn` 0.** So `--syn-drop` combined with
`--target` was a complete no-op, and every other impairment missed one packet per connection.

## This is not the 0.02 ms

The SOCKET-layer margin measured the same day (#65) is real: `SOCKET_CONNECT` beats the SYN in
10/10 runs. But **nothing consumed it** - the live map fed the *rebuild*, not the packet-path test.
Order in our favour is worth nothing until something reads it at the right moment. `syn_covers()` is
that reader: a lock-free `pid_for` checked against `_pids`, called from step 1 **for a TCP SYN
only** - once per connection, not once per packet.

## It drags a second fix with it, and that is the part that would have been missed

Step 4 arms a reset on the first in-scope TCP packet. With SYNs in scope, that becomes the SYN - and
the RST forged from a SYN copies its `ack_num` as the sequence, which a SYN does not have, so it
goes out with `seq=0` and no ACK. RFC 793 lets a stack in SYN_SENT ignore that, and **it was
measured doing exactly that** (the client hung until its own timeout while `rst_sent` reported 1).

So a reset is no longer *armed* from a SYN, while a SYN arriving inside an existing cooldown is
still held down. Without this, F16 would have traded a working reset for a hang.

## What users will notice

With loss (or blocking, or a link outage) aimed at a process, **connections now take longer to
open** - the SYN can be lost and TCP has to retransmit - and a minority fail to open at all. Before,
every connection opened at full speed and only then started suffering. Anyone measuring "time to
first byte" under impairment will see it move. That is in `CHANGELOG.md`, not buried here.

## Known limits, all deliberate and all in the docstrings

- A process with **no socket yet** is not in `_pids`, so the **first connection of a freshly started
  target still slips through**. Covering it needs the matcher plus a name lookup in the packet path,
  which is what convention 20 forbids.
- `_pids` is up to one resolver cycle (0.30 s) stale, so a recycled PID can pull one packet of an
  unrelated socket into scope - a **different** false positive from the stale `_ports` this code
  already lived with, so it is named rather than implied.
- **UDP has no SYN** and is not covered.
- `pid_for` joins the documented table contract (`snapshot`/`name_of`/`ancestors`/`refresh`), read
  through `getattr` so a table without it answers False instead of raising **on the capture thread**.

## Verification

- `python -m pytest tests` -> **715 passed, 0 failed**. `python smoke_gui.py` -> OK.
- **Hot path measured** against a worktree of master (150k 1500 B packets, median of 5):

  | path | master | this branch |
  |---|---|---|
  | no targeting | 135.9k pkt/s | 140.3k |
  | targeting on, every packet a miss (**the common path**) | 164.0k / 164.7k | 164.5k / 170.4k |

  No regression either way: the added cost is one boolean that short-circuits on `is_syn`.
- Six new guards, **six mutants, every one caught - after a repair worth recording.** Two mutants
  first pointed at `test_core.py`, which drives a local fake rather than `ProcessTargeting`, so the
  real `getattr` guard was covered by **nothing**. It has its own test now.
- `test_an_armed_gate_wins_over_every_later_step` drove every gate with `is_syn=True`; the rst gate
  now needs an ordinary packet. The test says why rather than being quietly relaxed.

**Acceptance still owed:** the same 20-connection probe. Expected **1 escaped, 19 blocked** - not
0/20: the probe has no socket when the tool starts, so its very first connection is the documented
"unknown process" case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
