### PR TITLE
test(gui): pin the target banner to the process, not to the field

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,28 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Tests: the GUI target banner is pinned to the PROCESS, not to the field (audit F17)
+
+- **The gap.** `test_gui_state.py::test_a_gui_session_keeps_the_target_banner_honest` only ever
+  moves the EXPRESSION - the user types something that matches nothing, then something that does.
+  The case a tester actually hits moves the other end: the field is left alone and the targeted
+  program exits, or a harness restarts it onto a new pid. Nothing covered that, and a handoff note
+  had concluded from reading the code that the verdict was taken only at session start. It is not:
+  `App._refresh_target` re-reads `targeting.matched` on every tick and only the APPLY half is
+  gated on the expression having changed.
+- New guard: `::test_a_target_that_dies_mid_session_raises_the_banner_without_being_retyped`. Real
+  engine, real resolver, `SyntheticDivert`, injected `FakeTable`; the test empties the socket table
+  under a running session and asserts `_applied_target` did NOT move (otherwise it is the old test
+  again), then that the banner rises, then that it comes back DOWN when the process reappears under
+  a NEW pid with the same name - the recovery measured against a real capture the same day.
+- **Three mutants, all caught, each on its intended assertion.** The one worth recording is the
+  first: `_refresh_target` made to read the verdict ONLY when the expression changed, i.e. exactly
+  the "banner appears at session start" behaviour the note had assumed already existed. It goes
+  red, so the guard really does pin the live re-read. The other two: `ProcessTargeting.matched`
+  forced to `True`, and the banner never taken back down.
+- Test-only chunk, so no `CHANGELOG.md` entry (convention 39): nothing on screen changed, this
+  fixes the fact that nothing was watching it.
+
 ### Added: the CLI reports a target that stops matching, and what share was in scope (audit F17)
 
 - **Symptom, measured before writing anything** (2026-07-28, elevated, real WinDivert, probe

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -417,3 +417,87 @@ def test_a_gui_session_keeps_the_target_banner_honest():
         assert stop_ms < 900, "STOP took %.0f ms" % stop_ms
         assert not app.engine.resolver().is_running(), "resolver outlived the session"
     """)
+
+
+def test_a_target_that_dies_mid_session_raises_the_banner_without_being_retyped():
+    """The banner must follow the PROCESS, not just the text in the field.
+
+    The test above only ever moves the expression: the user types something that
+    matches nothing, then something that does. The case that actually happens to a
+    tester moves the other end - the field is left alone and the targeted program
+    exits, or the harness restarts it and Windows hands it a new pid. Nothing
+    covered that, and a handoff note had already concluded from reading the code
+    that the verdict was only taken at session start. It is not: ``_refresh_target``
+    re-reads it on every tick. This pins that, because prose is what the project
+    keeps getting wrong here, and prose is what nothing tests.
+
+    The recovery half mirrors what was MEASURED against a real capture
+    (2026-07-28): targeting BY NAME picks the restarted program up by itself,
+    while targeting by pid cannot, since the pid is gone. So the banner has to
+    come back DOWN on its own too - a warning that stays up after the program is
+    back is the same lie in the other direction.
+    """
+    run_gui("""
+        import time
+        from beantester import portmap
+        from beantester.synthetic import SyntheticDivert
+
+        class FakeTable:
+            def __init__(self):
+                self.ports = {5001: 200}
+                self.info = {200: ("realapp.exe", 1)}
+            def refresh(self, now=None, force=False): return True
+            def snapshot(self): return dict(self.ports)
+            def name_of(self, pid, cheap=False): return self.info.get(pid, ("", None))[0]
+            def ancestors(self, pid, depth=8): return []
+            def refresh_if_stale(self, now=None, miss=False): return True
+            def process_for_port(self, port, now=None, allow_refresh=True): return ""
+            def pid_for(self, port): return self.ports.get(port)
+
+        table = FakeTable()
+        portmap.default_table = lambda: table
+        app.engine._ports = table
+
+        real_start = app.engine.start
+        app.engine.start = (lambda filt, divert=None, duration=0:
+                            real_start(filt, divert=SyntheticDivert(seed=21),
+                                       duration=duration))
+
+        def settle(seconds=1.0):
+            end = time.monotonic() + seconds
+            while time.monotonic() < end:
+                app._tick()
+                time.sleep(0.02)
+
+        app._start(); app._settle_transition()
+        app.vars["target"].set("realapp")
+        settle(1.0)
+        assert app.engine.targeting().matched is True, "the target never matched"
+        assert app._pending_target_warning == "", app._pending_target_warning
+
+        # The program exits. NOBODY touches the field.
+        typed = app._applied_target
+        table.ports.clear()
+        table.info.clear()
+        settle(1.0)
+        assert app._applied_target == typed, \\
+            "the expression moved, so this is the old test again: %r" % app._applied_target
+        assert app.engine.targeting().matched is False, "the target still matches nothing"
+        assert app._pending_target_warning == bnt.T("fields.target_no_match"), \\
+            "a target that died must raise the banner: %r" % app._pending_target_warning
+        assert app._shown_target_warning == app._pending_target_warning, \\
+            "the verdict was recorded but never rendered"
+
+        # It comes back under a NEW pid, same name - the measured NAME behaviour.
+        table.ports[5002] = 201
+        table.info[201] = ("realapp.exe", 1)
+        settle(1.0)
+        tg = app.engine.targeting()
+        assert tg.matched is True, "the restarted process was not picked up"
+        assert 5002 in tg.ports(), sorted(tg.ports())
+        assert app._pending_target_warning == "", \\
+            "the banner outlived the problem: %r" % app._pending_target_warning
+        assert app._shown_target_warning == "", "the banner was not taken down"
+
+        app._stop(); app._settle_transition()
+    """)


### PR DESCRIPTION
## Why

Stacked on #67 (`--base` is the chunk-1 branch, so review that one first).

`test_a_gui_session_keeps_the_target_banner_honest` only ever moves the **expression**: the user types something that matches nothing, then something that does. The case a tester actually hits moves the other end - the field is left alone and the targeted program exits, or a harness restarts it onto a new pid.

Nothing covered that, and the handoff note had concluded from reading the code that the verdict was taken only at session start. It is not: `App._refresh_target` re-reads `targeting.matched` on every tick, and only the APPLY half is gated on the expression having changed. Correct behaviour, zero guards - which in this project is how a true sentence turns into a false one a few sessions later.

## The guard

Real engine, real resolver, `SyntheticDivert`, injected `FakeTable`. It empties the socket table under a running session and asserts `_applied_target` did **not** move (otherwise it decays into the old test), then that the banner rises, then that it comes back **down** when the process reappears under a new pid with the same name - the name-targeting recovery measured 2026-07-28 against a real capture.

## Mutants

Three, all caught, each on its intended assertion:

| mutant | caught by |
|---|---|
| `_refresh_target` reads the verdict only when the expression changed (**the assumed behaviour**) | `a target that died must raise the banner` |
| `ProcessTargeting.matched` forced to `True` | `a target that died must raise the banner` |
| the banner is never taken back down | `the banner outlived the problem` |

## Verification

- `python -m pytest tests` - **718 passed, 0 failed** (elevated shell).
- `python smoke_gui.py` - OK.
- Test-only, so `CHANGELOG-INTERNAL.md` only (convention 39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)