### PR TITLE
docs(targeting): record what a target restart actually costs

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,28 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Docs: what a target restart actually costs, and one README claim it falsifies (audit F17)
+
+- `targeting.py::syn_covers` documented the `_pids` limit with 19/20 (holding sockets) and 6/20
+  (closing them), but said nothing about a RESTART, which is the same mechanism from the other
+  side. Measured 2026-07-28 (elevated, real WinDivert, `--target beanprobe.exe --dst-ip 8.8.8.8
+  --dst-port 53 --syn-drop 100`, three lives of four held connections): `OK FAIL FAIL FAIL` in
+  **3 of 3** lives, so a restart costs exactly ONE connection and then recovers by itself. Same
+  probe by PID, killed and restarted: **5 of 5** untouched, because the number no longer exists.
+  The recovery belongs to the EXPRESSION, not to `syn_covers`, and the docstring now says which.
+- **The "cannot be closed" claim is now argued rather than asserted** (rule 6): the SOCKET event
+  leads the SYN by 0.018-0.027 ms, covering a brand-new process needs pid -> name plus the matcher
+  inside that window, and a COLD name resolve is milliseconds. Moving it to the watcher thread does
+  not change the window. The only design that closes it holds the SYN until the answer is in, which
+  is added delay in a tool that exists to inject a precise amount of it. Named so the next session
+  does not re-derive it - and so the alternative that WOULD work is on record.
+- **A README sentence measured false and fixed in both languages.** "A connection is in scope the
+  moment it opens - for an outbound connection, before its first packet even leaves" is true for a
+  process already in `_pids` and false for that process's first connection, which is precisely the
+  case the measurement isolates. Both READMEs now state the exception and carry a new bullet on
+  name-vs-pid under restart. `test_readme_guards.py` / `test_cli_docs.py` green (this touches
+  neither the pipeline order nor the flag tables).
+
 ### Tests: the GUI target banner is pinned to the PROCESS, not to the field (audit F17)
 
 - **The gap.** `test_gui_state.py::test_a_gui_session_keeps_the_target_banner_honest` only ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Docs
 
+- **Both READMEs claimed slightly more than the tool does about brand-new connections.** They said
+  a connection is in scope "the moment it opens", which holds for a program the tool already
+  recognises but not for that program's *first* connection: until it owns at least one socket there
+  is nothing to recognise it by, so that one connection goes through untouched. Measured, so the
+  exception is now stated rather than implied, next to a new note on what to do about it - if the
+  program under test restarts, aim by **name** rather than by process id.
+
 - **The process field's exclusions are now documented properly.** Writing `!chrome` means "impair
   everything except chrome" - and "everything" includes any connection whose owning process could
   not be identified yet, which every brand-new connection passes through. If you want one

--- a/README.md
+++ b/README.md
@@ -968,12 +968,19 @@ seeded).
   explicit exclusion wins: `chrome, !chromedriver` will not pull in `chromedriver` via a parent.
 - **Process targeting is driven by socket events, not a slow poll.** WinDivert hands us a packet,
   not a PID, so we map a packet to its process by **local port**. On Windows the tool watches the
-  system's socket events (connect / bind / accept / close) as they happen, so a connection is in
-  scope the moment it opens - for an outbound connection, before its first packet even leaves.
-  Without real WinDivert (the test / simulation path) it falls back to scanning the socket table a
-  few times a second, where the first packet of a brand-new connection can slip through. Either way
-  the watching runs on its own thread, never on the one handling your packets, so it can never turn
-  into lost traffic.
+  system's socket events (connect / bind / accept / close) as they happen, so a new connection of a
+  program that is **already** in scope is impaired from its very first packet. The exception is the
+  program's *first* connection: until it owns at least one socket there is nothing to recognise it
+  by, so that one connection goes through untouched. Without real WinDivert (the test / simulation
+  path) it falls back to scanning the socket table a few times a second, where the first packet of
+  any brand-new connection can slip through. Either way the watching runs on its own thread, never
+  on the one handling your packets, so it can never turn into lost traffic.
+- **If the program under test restarts, aim by NAME, not by process id.** Measured: a target that
+  exits and comes back under a new process id is picked up again by itself, and the restart costs
+  exactly one connection - the one it opens before it owns any socket. Aiming at a **process id**
+  never recovers, because that id no longer exists: everything after the restart is left untouched.
+  From the command line the run says so when it happens, and ends with how much of the captured
+  traffic was actually in scope; in the window it is the red note under the process field.
 - **An exclusion on its own also covers everything the tool cannot identify.** `!chrome` in the
   process field means "impair everything except chrome" - and "everything" includes any connection
   whose owning process could not be determined: protected system processes the tool cannot open,

--- a/README.pl.md
+++ b/README.pl.md
@@ -845,12 +845,19 @@ wyznaczonym momencie. Wszystkie losowania idą przez jeden generator (opcjonalni
   pierwszeństwo: `chrome, !chromedriver` nie wciągnie `chromedriver` przez rodzica.
 - **Celowanie w proces napędzają zdarzenia gniazd, nie wolny polling.** WinDivert daje pakiet, nie
   PID, więc pakiet mapujemy na proces po **lokalnym porcie**. Na Windows narzędzie obserwuje
-  zdarzenia gniazd systemu (connect / bind / accept / close) na bieżąco, więc połączenie jest w
-  zasięgu w chwili otwarcia - a dla połączenia wychodzącego jeszcze przed jego pierwszym pakietem.
-  Bez realnego WinDivert (ścieżka testów / symulacji) narzędzie wraca do skanowania tabeli gniazd
-  kilka razy na sekundę, gdzie pierwszy pakiet zupełnie nowego połączenia może się prześliznąć.
-  Tak czy inaczej obserwacja chodzi na osobnym wątku, nigdy na tym, który obsługuje Twoje pakiety -
-  więc nie zamieni się w zgubiony ruch.
+  zdarzenia gniazd systemu (connect / bind / accept / close) na bieżąco, więc nowe połączenie
+  programu, który **już** jest w zasięgu, jest psute od pierwszego pakietu. Wyjątkiem jest
+  *pierwsze* połączenie tego programu: dopóki nie ma ani jednego gniazda, nie ma po czym go poznać,
+  więc to jedno połączenie przechodzi nietknięte. Bez realnego WinDivert (ścieżka testów /
+  symulacji) narzędzie wraca do skanowania tabeli gniazd kilka razy na sekundę, gdzie pierwszy
+  pakiet każdego nowego połączenia może się prześliznąć. Tak czy inaczej obserwacja chodzi na
+  osobnym wątku, nigdy na tym, który obsługuje Twoje pakiety - więc nie zamieni się w zgubiony ruch.
+- **Jeśli testowany program się restartuje, celuj po NAZWIE, nie po PID.** Zmierzone: cel, który
+  znika i wraca z nowym PID-em, zostaje podchwycony sam, a restart kosztuje dokładnie jedno
+  połączenie - to, które program otwiera, zanim ma jakiekolwiek gniazdo. Celowanie po **PID** nie
+  wraca nigdy, bo tego numeru już nie ma: wszystko po restarcie zostaje nietknięte. W wierszu
+  poleceń przebieg mówi o tym w chwili, gdy to zauważy, i na koniec podaje, ile przechwyconego
+  ruchu naprawdę było w zasięgu; w oknie jest to czerwona notka pod polem procesu.
 - **Samo wykluczenie obejmuje też wszystko, czego narzędzie nie rozpozna.** `!chrome` w polu procesu
   znaczy „psuj wszystko oprócz chrome" - a „wszystko" obejmuje każde połączenie, którego właściciela
   nie udało się ustalić: procesy chronione, których nie da się otworzyć, oraz - na ścieżce

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -186,6 +186,26 @@ class ProcessTargeting:
           test - and keeps missing one that opens a connection, closes it and
           pauses. Covering that needs the matcher and a name lookup in the packet
           path, which is what convention 20 forbids.
+
+          A RESTARTING target is the same mechanism from the other side, and it
+          was measured separately (2026-07-28, same probe, three lives of four
+          held connections each, ``--syn-drop 100``): ``OK FAIL FAIL FAIL`` in
+          **3 lives out of 3**. A target that dies and comes back under a new pid
+          therefore costs exactly ONE connection - the one it opens before it
+          owns any socket - and then recovers on its own, with no restart of the
+          session. That recovery belongs to the EXPRESSION, not to this code: by
+          NAME the new pid is matched by the next rebuild, by PID nothing can
+          match again, because the number the user typed no longer exists. Same
+          probe, targeting the pid, killed and restarted: **5 of 5** fresh
+          connections untouched.
+
+          Closing the one-connection gap is not a tuning question. The SOCKET
+          event beats the SYN by 0.018-0.027 ms; covering a brand-new process
+          would mean resolving pid -> name and running the matcher inside that
+          window, and a COLD name resolve is milliseconds. Moving it to the
+          watcher thread does not help - the window is the same. The only design
+          that closes it holds the SYN until the answer is in, i.e. adds delay
+          inside a tool whose job is to inject a PRECISE amount of it.
         * ``_pids`` is up to one resolver cycle stale (0.30 s). If the target
           exits and Windows recycles its PID inside that window, one packet of an
           unrelated new socket can be pulled into scope. That is a DIFFERENT false


### PR DESCRIPTION
## Why

Stacked on #68, which is stacked on #67 - review in that order.

`syn_covers` documented the `_pids` limit with 19/20 (holding sockets) and 6/20 (closing them) but said nothing about a **restart**, which is the same mechanism seen from the other side - and the handoff listed it as the open question for this session.

## Measured 2026-07-28

Elevated, real WinDivert, probe narrowed to `--target ... --dst-ip 8.8.8.8 --dst-port 53 --syn-drop 100`:

| | result |
|---|---|
| by NAME, 3 lives x 4 held connections | `OK FAIL FAIL FAIL` in **3 of 3** |
| by PID, killed and restarted | **5 of 5** fresh connections untouched |

So a restart costs exactly **one** connection and then recovers by itself - and the recovery belongs to the **expression**, not to `syn_covers`. The docstring now says which form survives one.

## The 'cannot be closed' part is argued, not asserted (rule 6)

The SOCKET event leads the SYN by 0.018-0.027 ms. Covering a brand-new process needs `pid -> name` plus the matcher inside that window, and a **cold** name resolve is milliseconds. The watcher thread has the same window, so moving the work there changes nothing. The only design that closes it holds the SYN until the answer is in - added delay inside a tool that exists to inject a *precise* amount of it. Recorded so the next session does not re-derive it, and so the alternative that would actually work is on the record rather than the conclusion alone.

## A README claim the measurement falsifies

Both languages said a connection is in scope "the moment it opens - for an outbound connection, before its first packet even leaves". True for a process already recognised; **false for that process's first connection**, which is exactly the case the probe isolates. Both READMEs now state the exception and carry a name-vs-pid note for programs that restart.

## Verification

- `python -m pytest tests` - **718 passed, 0 failed** (elevated shell).
- `python smoke_gui.py` - OK.
- `test_readme_guards.py` / `test_cli_docs.py` green (touches neither the pipeline order nor the flag tables).
- No em/en dashes, line endings unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)