### PR TITLE
docs(engine): say that the throughput rig is not reproducible

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -184,6 +184,29 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   is the same trap F16 recorded, hit again from a different direction; the portless guard above
   exists because of it, and the core test now says which half it actually pins.
 
+### Docs: the throughput rig is not reproducible, and the prose now says so (audit F18, follow-up)
+
+- Re-measuring the same bare `recv`+`send` loop over the same loopback flood, same machine, three
+  times, gave **14 488 -> 30 189 -> 15 004 pkt/s**. A factor of two, unexplained. Ratios moved too:
+  batched-vs-unbatched ran from 1.23x to 3.65x, and "real NIC vs loopback" **changed sign** between
+  runs (0.67x -> 1.32x). One run produced a physically impossible ordering - a strategy doing
+  strictly LESS work measured slower - which is itself a reading of the noise floor.
+- `engine.py`'s "What this actually sustains" section now carries a **HOW MUCH OF THIS TO TRUST**
+  paragraph: a number from this rig is evidence only against another number from the SAME run.
+- **Withdrew a derived claim that was never sound:** the section previously divided a sniff-only
+  reader's 92 944 pkt/s by the engine's ~14k, concluded "five sixths of the per-packet budget is
+  spent after the read", and pointed at the inject side. Those two figures come from different
+  runs. What remains is the release heap growing under ZERO configured delay within one run
+  (`peak_queue` 4080 -> 7020) - a direction, not a proportion.
+- **Kept, with the distinction made explicit:** direct OBSERVATIONS survive where timings do not -
+  a loss percentage against a control that lost 0.00%, a queue depth, `scoped_seen`, and the 1.4
+  packets per `RecvEx` call that carries the batching ADR. The ADR is amended in place rather than
+  reversed, because its argument never rested on the timing.
+- The measurement-method lesson went into PROJECT_NOTES rule 5 (third variant of the same trap):
+  repeat the WHOLE run before believing a number; interleave strategies instead of running each in
+  a block; carry a drift canary that makes the script REFUSE a conclusion rather than print a
+  median; report spread, not just the median.
+
 ### ADR 2026-07-28: batched WinDivert I/O MEASURED and REJECTED (audit F18, part c)
 
 - **The question.** The engine does one `recv()` and one `send()` syscall per packet, and WinDivert
@@ -207,6 +230,11 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   under a saturating flood against a full queue. There is no batch there to exploit, so the syscall
   count is not what to attack. **Do not reopen this without new evidence that the driver will
   actually fill a batch.**
+- **AMENDED 2026-07-28 (same day):** the packets-per-call figure is a direct observation and
+  stands; the 1.29x / 1.30x TIMINGS in the table came from a rig later shown to be unreliable -
+  the same bare loop re-measured 14 488 / 30 189 / 15 004 pkt/s across three runs. The conclusion
+  does not depend on them (1.4 packets per call is the whole argument), but do not quote those
+  ratios. See the "HOW MUCH OF THIS TO TRUST" paragraph in `engine.py`.
 - **What the run redirected the question to.** A sniff-only reader sustains 92 944 packets/s while
   the whole engine manages ~14k - **6.6x**. Reading is not the ceiling; roughly five sixths of the
   per-packet budget goes to `decide()`, the connection log, the release heap and the inject

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -45,22 +45,39 @@ the same figure on an idle machine, on a real NIC, or with full-size frames
 (14k packets/s is ~7 Mbit/s at 64 B but ~170 Mbit/s at 1500 B - the limit is
 packets, not bits).
 
-Reading packets is NOT where that ceiling comes from, and this is measured, not
-reasoned. A sniff-only loop doing nothing but reading the same flood sustains
-**92 944 packets/s** through ``pydivert``'s ``recv()`` - 6.6x what the whole
-engine manages. So roughly five sixths of the per-packet budget is spent after
-the read: ``decide()``, the connection log, the release heap and the inject
-thread's ``send()``. Which of those dominates is NOT measured; the release heap
-growing under zero configured delay (``peak_queue`` 4080 -> 7020 across the three
-loads) says the inject side trails the capture side, and that is as far as the
-evidence goes.
+🔴 **HOW MUCH OF THIS TO TRUST, and it is less than the digits suggest.** The
+figures above are internally consistent - three loads inside ONE run - and that
+is the only kind of comparison this rig supports. Absolute throughput on it is
+NOT reproducible: a bare ``recv``+``send`` loop over the same loopback flood was
+re-measured three times on this machine and gave **14 488, then 30 189, then
+15 004 packets/s**. Same code, same machine, a factor of two apart, unexplained.
+Ratios are not safe either - the batched-versus-unbatched ratio moved between
+1.23x and 3.65x across those runs.
 
-Batched driver I/O was measured and REJECTED as the lever (2026-07-28). Bypassing
-``pydivert``'s ``Packet`` object with a raw ``WinDivertRecv`` gives 120 356
-packets/s (1.29x), and a raw ``WinDivertRecvEx`` asking for 64 packets per call
-gives 130 528 (1.40x) - because the driver returns **1.4 packets per call** even
-under a saturating flood with a full queue. There is no batch there to exploit,
-so the syscall count is not the thing to attack. Both figures are medians of 5.
+So: **a number from this rig is evidence only against another number taken in
+the SAME run.** Do not quote the absolutes as the tool's ceiling, do not derive
+a budget breakdown by dividing one run's figure by another's, and do not tune
+anything on a difference smaller than the spread above. What survives is what
+was DIRECTLY OBSERVED rather than timed - a loss percentage against a control
+that lost 0.00%, a queue depth, a packets-per-call count.
+
+An earlier version of this section did exactly what that paragraph forbids: it
+divided a sniff-only reader's 92 944 packets/s by the engine's ~14k, concluded
+"five sixths of the budget is spent after the read", and named the inject side
+as the suspect. Those two numbers come from different runs, so the arithmetic
+was never sound. What is still on solid ground is the release heap growing under
+ZERO configured delay (``peak_queue`` 4080 -> 7020 within one run), which says
+the inject side trails the capture side - a direction, not a proportion.
+
+Batched driver I/O was REJECTED as the lever on the RECEIVE side (2026-07-28),
+and the reason that survives is a direct observation, not a timing: a raw
+``WinDivertRecvEx`` asking for 64 packets per call gets **1.4 packets per call**
+even under a saturating flood against a full queue. The driver simply does not
+fill a batch, so there is nothing there to amortise. (The accompanying 1.29x /
+1.40x timings came from this rig and carry the caveat above.) The SEND side is
+different in kind - there WE assemble the batch - and batching there was the
+fastest strategy in every run and on every path, though by anything from 1.2x to
+3.6x. Direction: real. Size: not established.
 """
 import atexit
 import heapq


### PR DESCRIPTION
## Why

Re-measuring the **same** bare `recv`+`send` loop over the **same** loopback flood on the **same** machine, three times:

| run | pkt/s |
|---|---|
| 1 | 14 488 |
| 2 | 30 189 |
| 3 | 15 004 |

A factor of two, unexplained. Ratios did not survive either: batched-vs-unbatched ran **1.23x to 3.65x**, and "real NIC vs loopback" **changed sign** between runs (0.67x -> 1.32x). One run ordered a strategy doing strictly *less* work as slower, which is a reading of the noise floor rather than a result.

The figures in `engine.py` were written as if they were the tool's ceiling. They are internally consistent within one run, and that is all they are.

## What this changes

- **New "HOW MUCH OF THIS TO TRUST" paragraph**: a number from this rig is evidence only against another number taken in the SAME run. Do not quote the absolutes as a ceiling, do not derive a budget by dividing across runs, do not tune on a difference smaller than the spread.
- **Withdraws a claim that was never sound.** The section divided a sniff-only reader's 92 944 pkt/s by the engine's ~14k and concluded "five sixths of the per-packet budget is spent after the read", naming the inject side as the suspect. Those two numbers come from different runs. What remains is the release heap growing under **zero** configured delay within one run (`peak_queue` 4080 -> 7020) - a direction, not a proportion.
- **Amends the RecvEx ADR in place rather than reversing it.** Its argument was always the **1.4 packets per call** - a direct observation of what the driver hands back, not a timing. The accompanying 1.29x / 1.40x now carry the caveat.
- **Records the send side honestly**: batching was the fastest strategy in every run and on every path, by anything from 1.2x to 3.6x. Direction real, size not established.

## The distinction that came out of this

Direct **observations** survived every repetition - a loss percentage against a control that lost 0.00%, a queue depth, `scoped_seen`, packets-per-call. **Timings** did not. That line is now drawn explicitly in the docstring and in PROJECT_NOTES rule 5, together with the method that was missing: repeat the whole run before believing a number, interleave strategies instead of running each in a block, carry a drift canary that makes the script refuse a conclusion rather than print a median, and report spread.

## Verification

- `python -m pytest tests` - **721 passed, 0 failed** (elevated shell). Prose only, no behaviour change.
- `python smoke_gui.py` - OK. `check_notes.py` - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)