### PR TITLE
perf(engine): the bottleneck was CPython's thread-switch interval, not any stage

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -184,6 +184,81 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   is the same trap F16 recorded, hit again from a different direction; the portless guard above
   exists because of it, and the core test now says which half it actually pins.
 
+### Fixed: the engine's ceiling was CPython's thread-switch interval, not any stage (handoff point 1)
+
+- **The question.** The previous session narrowed the bottleneck by elimination - not the read
+  (a sniff-only loop does 92 944 pkt/s), not `decide()` (~800 ns) - and asked for a PER-STAGE
+  budget rather than another throughput benchmark, because this rig's absolute numbers are not
+  reproducible (see "What this actually sustains" in `engine.py`).
+- **Method: measure in place, never re-implement the loop.** A proxy on the divert timed `recv`
+  and `send` (and the interval between them, which IS the loop body); a proxy on the packet timed
+  every attribute the loop reads BY NAME, so pydivert's parsing was measured where it happens; the
+  four engine methods were wrapped. `engine.start(divert=...)` is the only seam that needed to
+  exist, and it already did.
+- **What the split showed, in one run:** the Python stages are small and not where the time goes -
+  `decide()` 6.2 us, `src_port` (which pulls the whole transport header) 5.5 us, `dst_addr`
+  (an `inet_ntop` per packet, uncached) 2.8 us, `_log_conn` 1.8 us, `_enqueue` 2.4 us. The two
+  syscall-bracketed stages were 3x their uncontended cost, on BOTH threads at once.
+- 🔴 **The cause, isolated by ablation** (paired against a minimal 2-thread reference, drift canary
+  1.03x): not the shared handle - a separate `SEND_ONLY` injection handle made it WORSE (send
+  1.71x, recv 1.97x, rate 1.26x instead of 1.59x). Not the locks - nulling `_slock` bought 1.71x
+  and `_clock` 1.25x, both partial. **`sys.setswitchinterval` bought 2.38x at 0.5 ms and 2.68x at
+  0.05 ms**, and collapsed `peak_queue` from 253 to 8-62. The capture and inject threads hand every
+  packet to each other and both leave the interpreter for a syscall, so each packet costs two waits
+  for the interpreter lock - and CPython lets a waiter sleep up to the switch interval, 5 ms by
+  default, before it insists.
+- **The number that is trustworthy, and the one that is not.** A phase-to-phase throughput ratio is
+  worthless here: the 5 ms canary alone ranged 10 370 to 15 450 pkt/s inside one run. So the final
+  measurement flips the interval INSIDE one session, counts packets over alternating windows and
+  swaps the order every pair: **median 1.35x (loopback), 1.33x (loopback, repeat), 1.36x (real
+  interface to a WSL guest) - 24 of 24 pairs**. The per-call readings repeat exactly and are the
+  same finding without a stopwatch: recv 41.7 -> 19.9 us, send 56.7 -> 32.0 us.
+- **Priced, not assumed.** Process CPU per packet FELL, 103.1 -> 92.9 us. Delay accuracy (the thing
+  the tool actually promises) is unchanged: against a configured 10 ms, lateness held a median of
+  0.73 vs 0.76 ms and a p95 of 1.71 vs 1.65 ms, the shorter interval ahead in 3 pairs of 6. 0.5 ms
+  is the KNEE, not the floor - 1 ms still behaves like 5 ms, and 0.1 / 0.05 / 0.01 buy nothing.
+- **NOT measured:** GUI smoothness at 0.5 ms, TCP traffic (this was UDP), and machines with fewer
+  than 16 cores.
+- **Implementation:** `winenv.request_fast_thread_switch()` / `release_fast_thread_switch()` plus
+  `THREAD_SWITCH_S = 0.0005`, taken in `BeanEngine._start_locked` beside `request_fine_timers` and
+  given back in `_stop_locked` after the workers are joined - the same session-scoped shape, for
+  the same reason. It carries its OWN refcount and saved value: unlike `timeBeginPeriod` the OS
+  does not count these, so two overlapping sessions would otherwise let the first one to stop
+  restore a value out from under the second. Guarded by `_SWITCH_LOCK`, taken on start/stop only.
+  This is the one function in `winenv.py` that is not Windows-specific - it tunes CPython - and the
+  module docstring now says so.
+- **Tests** (`tests/test_failsafe.py`, all four verified by mutation):
+  `test_the_shortened_switch_interval_is_in_force_only_while_a_session_runs`,
+  `test_the_switch_interval_is_restored_on_every_session_path` (clean stop, double stop, failed
+  start), `test_two_overlapping_sessions_do_not_restore_each_other_s_interval` (the refcount), and
+  `test_releasing_a_switch_interval_nobody_took_changes_nothing`.
+- 🔴 **The mutation run found the hole in the TESTS, not in the code, and it is worth recording.**
+  The deleted-release mutant survived at first. Two reasons, both the same shape: the four tests
+  share one process-global holder count, so a leak in one made the next one's `start()` a no-op;
+  and "the interval came back to what it was when I started" is a TAUTOLOGY once anything leaks -
+  with the release deleted every engine session in the file leaks, so the process was already
+  sitting at the shortened value and "restored" was true by accident. The fix is `_switch_baseline`
+  / `_switch_restore`: assert against a sentinel value chosen by the test (0.004 - neither the
+  CPython default nor `THREAD_SWITCH_S`), and read the post-stop value INSIDE the try, before the
+  cleanup can paper over it. A second miss on the way: the first mutation run used `-k switch`,
+  which silently skipped the one test whose name says "interval" - the only guard on the refcount -
+  so that mutant came back green.
+
+### Corrected: "the bottleneck is INJECTION" and the batched injector's shallow-heap premise
+
+- **`PROJECT_NOTES` hot-paths section said the constraint was the `send()` side**, on the evidence
+  that the release heap grew ~1100 entries/s. The premise is right and the inference was wrong:
+  `send()` costs 26.9 us with nobody to contend with, and the 56.7 us it showed in the engine was
+  the wait for the interpreter lock. Both threads were inflated by the same factor, which is what
+  should have been the tell - a slow `send()` cannot slow down `recv()` on another thread.
+- **The batching ADR below records `peak_queue` 30 and a mean batch of 2.13** and forbids
+  re-opening the topic without re-measuring the mean batch size under the workload in question.
+  Re-measured: under a saturating flood the heap sits 15-320 deep and reaches `max_queue` (20 000)
+  over a real interface, so a `SendEx` call would have been handed tens of packets, not two. That
+  condition IS met - and the topic still should not be re-opened, because the switch interval takes
+  `peak_queue` back down to 8-62. The ADR's conclusion survives; the reason under it changes from
+  "the injector keeps up" to "the injector keeps up ONCE THE HANDOFF IS CHEAP".
+
 ### ADR 2026-07-29: the batched injector was BUILT, measured and REVERTED
 
 - **What was built.** `_inject_loop` taking every already-due packet (cap 32) and sending them with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Changed
 
+- **A session now moves noticeably more traffic - about a third more packets a second.** The tool
+  handles your packets on two threads: one takes them from the driver, the other puts them back on
+  the wire. Python makes those two take turns, and by default a thread that is ready to work can be
+  left waiting up to 5 milliseconds for its turn. That waiting, not the work itself, was the limit:
+  putting a packet back took 57 microseconds while the same call takes 27 with nothing else in the
+  way. A session now asks Python for shorter turns while it runs, and hands that setting back when
+  it stops. Measured on a real capture, comparing both settings inside the same session, on
+  loopback and over a real network card: **1.33x to 1.36x more packets a second, in 24 comparisons
+  out of 24** - and with slightly *less* processor time per packet, not more. The queue of packets
+  waiting to be re-injected stops backing up, which is what that number looks like from the other
+  side. **Nothing changes in what you configure or see**, and the delay you ask for is delivered
+  just as accurately as before: against a configured 10 ms, packets were late by 0.73 ms before
+  and 0.76 ms after, which is the same number twice.
+
 - **Targeting a process no longer competes with the traffic it is measuring.** Working out which
   connections belong to your target means asking Windows about its sockets, and that used to
   happen on the same thread that handles your packets - dozens of times a second, because every

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -246,6 +246,11 @@ class BeanEngine:
         # Tracked rather than released blindly: the OS refcounts the requests per
         # process, so releasing one we were never granted unbalances the count.
         self._fine_timers = False
+        # True while this session holds a shortened interpreter thread-switch
+        # interval (see start()). Tracked for the same reason as the tick above:
+        # the give-back is refcounted in winenv, and releasing one we never took
+        # would let another session's stop restore the wrong value.
+        self._fast_switch = False
         self.stop_reason = None     # "user" | "duration" | "fault" | "exit"
         self.fault = None           # last fatal worker error, if any
         self.reset_stats()
@@ -904,6 +909,17 @@ class BeanEngine:
         # winenv.request_fine_timers for why querying the system-wide resolution
         # instead would be reading the wrong number.
         self._fine_timers = winenv.request_fine_timers()
+        # ...and ask the INTERPRETER for the same courtesy, also for the life of
+        # the session. The capture and inject threads hand every packet to each
+        # other and both leave the interpreter for a syscall, so each packet
+        # costs two waits for the interpreter lock - and CPython lets a waiter
+        # sleep up to sys.getswitchinterval() (5 ms) before it insists. That
+        # wait, not the driver, is what the syscalls were spending their time on:
+        # send measured 26.9 us with nobody to contend with and 56.7 us here.
+        # Paired, inside one session, this is worth a median 1.33-1.36x end to
+        # end (24 pairs of 24, loopback and a real interface) at LOWER CPU per
+        # packet. Full measurement in winenv.request_fast_thread_switch.
+        self._fast_switch = winenv.request_fast_thread_switch()
         try:
             # The live socket-event map (2b/2c): created FIRST, so the initial
             # targeting resolve below already reads it instead of the poller.
@@ -1118,6 +1134,14 @@ class BeanEngine:
         if self._fine_timers:
             self._fine_timers = False
             winenv.release_fine_timers()
+        # Same place, same reason: the workers are what the shorter switch
+        # interval is for, so it goes back once they are joined and not before.
+        # An unbalanced release here is invisible from inside the program - the
+        # process would simply keep a 0.5 ms interval (or somebody else's value)
+        # for the rest of its life - which is why the balance has a test.
+        if self._fast_switch:
+            self._fast_switch = False
+            winenv.release_fast_thread_switch()
         with self._cv:
             # PACKETS still queued, not queue entries: a duplicate copy left in the
             # queue means the application got one packet instead of two, and one

--- a/beantester/winenv.py
+++ b/beantester/winenv.py
@@ -1,7 +1,12 @@
 """Windows process environment: Administrator rights, console and DPI.
 
 Everything here is a no-op on other platforms so the engine, the CLI and the
-tests stay portable.
+tests stay portable - with ONE deliberate exception, marked as such where it
+lives: :func:`request_fast_thread_switch` tunes the CPython interpreter, not
+Windows, so it does its work everywhere. It sits here because this is where the
+process-global knobs live - the ones a SESSION takes and must give back
+(:func:`request_fine_timers` is the other one), and having them in one place is
+what keeps the give-back paths symmetrical.
 
 Why this module exists
 ----------------------
@@ -21,6 +26,7 @@ The tool now ships as ONE console-subsystem executable that serves both modes
 """
 import os
 import sys
+import threading
 
 from .paths import is_frozen
 from . import crashlog
@@ -254,6 +260,94 @@ def release_fine_timers(period_ms=TIMER_PERIOD_MS):
     try:
         import ctypes
         return ctypes.WinDLL("winmm").timeEndPeriod(int(period_ms)) == 0
+    except Exception as _exc:
+        crashlog.note(_exc, "winenv")
+        return False
+
+
+# How long a thread waiting for the interpreter lock sleeps before it insists.
+# CPython ships 5 ms. MEASURED as the engine's binding constraint - see
+# request_fast_thread_switch - and 0.5 ms is the KNEE, not the floor: 1 ms still
+# behaves like 5 ms, and 0.1 / 0.05 / 0.01 ms buy nothing more.
+THREAD_SWITCH_S = 0.0005
+
+# [saved original, holders]. Not the OS's refcount (there is none for this) -
+# ours, because two engines can live in one process and the second one to stop
+# must not restore a value the first one is still relying on. Guarded: two
+# engines starting at once would otherwise both read 0 holders, and the one that
+# saved SECOND would save the already-shortened interval and "restore" that for
+# the life of the process. Taken on start/stop only, never per packet.
+_SWITCH_STATE = [None, 0]
+_SWITCH_LOCK = threading.Lock()
+
+
+def request_fast_thread_switch(interval_s=THREAD_SWITCH_S):
+    """Shorten the interpreter's thread-switch interval for this SESSION.
+
+    NOT a Windows call - this one tunes CPython and works on every platform. It
+    lives beside :func:`request_fine_timers` because it is the same KIND of
+    thing: a process-global knob a session takes and must give back.
+
+    Why the engine wants it, MEASURED 2026-07-29 (Win11, elevated, real
+    WinDivert, 64 B UDP flood, no impairment configured). The engine runs two
+    threads that hand every packet to each other, and both leave the interpreter
+    for a syscall - capture in ``recv``, injector in ``send``. Whoever comes back
+    first has to re-acquire the interpreter lock, and with the default 5 ms
+    interval it can wait for a slice of that. The syscalls are not slow; the
+    waiting is:
+
+        one thread, no contender      recv 15.3 us   send 26.9 us
+        the engine, 5 ms   (default)  recv 41.7 us   send 56.7 us
+        the engine, 0.5 ms            recv 19.9 us   send 32.0 us
+
+    End to end, measured PAIRED inside one session (the interval flipped
+    mid-run, windows alternating, order swapped every pair, so machine drift
+    passes through both halves): **median 1.33-1.36x more packets a second, 24
+    pairs out of 24**, on loopback AND over a real interface to a WSL guest. The
+    release heap stops backing up with it (``peak_queue`` 253 -> 8-62), which is
+    the same finding read off a counter instead of a clock.
+
+    It is not bought with CPU - 103.1 -> 92.9 us of process CPU per packet - and
+    it does not cost delay accuracy, which is what this tool actually promises:
+    against a configured 10 ms, lateness stayed at a median of 0.73 vs 0.76 ms
+    and a p95 of 1.71 vs 1.65 ms, with the shorter interval ahead in 3 pairs of 6
+    (a coin toss, i.e. no effect either way).
+
+    Every request MUST be matched by a :func:`release_fast_thread_switch`.
+    """
+    try:
+        with _SWITCH_LOCK:
+            if _SWITCH_STATE[1] == 0:
+                # Saved, not assumed to be the CPython default: a test - or an
+                # embedding process - may have set its own, and that is what we
+                # owe them back.
+                _SWITCH_STATE[0] = sys.getswitchinterval()
+                sys.setswitchinterval(interval_s)
+            _SWITCH_STATE[1] += 1
+        return True
+    except Exception as _exc:
+        crashlog.note(_exc, "winenv")
+        return False
+
+
+def release_fast_thread_switch():
+    """Give back one :func:`request_fast_thread_switch`. Only for a granted one.
+
+    Restores the value that was in force before the FIRST holder asked, and only
+    once the last holder has let go. Releasing blindly would let one session's
+    stop pull the interval out from under another session that is still running -
+    the same unbalance hazard as the fine timer tick, minus the OS refcount to
+    catch it.
+    """
+    try:
+        with _SWITCH_LOCK:
+            if _SWITCH_STATE[1] <= 0:
+                return False
+            _SWITCH_STATE[1] -= 1
+            if _SWITCH_STATE[1] == 0 and _SWITCH_STATE[0] is not None:
+                sys.setswitchinterval(_SWITCH_STATE[0])
+                _SWITCH_STATE[0] = None
+        return True
     except Exception as _exc:
         crashlog.note(_exc, "winenv")
         return False

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -348,6 +348,167 @@ def test_the_fine_timer_calls_are_safe_to_make_anywhere():
           winenv.release_fine_timers() in (True, False))
 
 
+# A value nothing else in this process would choose: not CPython's 5 ms default
+# and not winenv.THREAD_SWITCH_S. See _switch_baseline for why it must be neither.
+_SWITCH_SENTINEL = 0.004
+_SWITCH_ORIGINAL = []
+
+
+def _switch_baseline():
+    """Put the process at a KNOWN interval with no holders, and return it.
+
+    Two ways these tests can quietly stop testing anything, both hit during the
+    mutation run for this change:
+
+    1. They share one process-global holder count. A test that leaks a holder
+       leaves the next one's ``start()`` looking at a non-zero count, so it
+       changes nothing, restores nothing, and passes.
+    2. Asserting "the interval came back to whatever it was when I started" is a
+       TAUTOLOGY once anything has leaked - and with the release deleted, every
+       engine session in this file leaks, so by the time these tests run the
+       process is already sitting at the shortened value and "restored" is true
+       by accident. The deleted-release mutant survived exactly this way.
+
+    So the baseline is a value chosen HERE, distinct from both the default and
+    the one the engine installs, and the assertions compare against it.
+    """
+    import sys
+    from beantester import winenv
+
+    if not _SWITCH_ORIGINAL:
+        _SWITCH_ORIGINAL.append(sys.getswitchinterval())
+    winenv._SWITCH_STATE[0] = None
+    winenv._SWITCH_STATE[1] = 0
+    sys.setswitchinterval(_SWITCH_SENTINEL)
+    return _SWITCH_SENTINEL
+
+
+def _switch_restore():
+    """Leave the process as this file found it, holders included."""
+    import sys
+    from beantester import winenv
+
+    winenv._SWITCH_STATE[0] = None
+    winenv._SWITCH_STATE[1] = 0
+    if _SWITCH_ORIGINAL:
+        sys.setswitchinterval(_SWITCH_ORIGINAL[0])
+
+
+def test_the_shortened_switch_interval_is_in_force_only_while_a_session_runs():
+    """The engine shortens CPython's thread-switch interval for the SESSION.
+
+    Measured (2026-07-29, real WinDivert, paired inside one session, 24 pairs of
+    24): a median 1.33-1.36x more packets a second, because the two hot threads
+    hand every packet to each other and CPython lets a thread waiting for the
+    interpreter lock sleep up to 5 ms before it insists.
+
+    Asserted on the VALUE rather than on a call log: a call log stays green if
+    the pair is wired to the wrong knob, and this number is the only thing the
+    rest of the process can actually feel.
+    """
+    import sys
+    from beantester import winenv
+
+    before = _switch_baseline()
+    eng = BeanEngine()
+    try:
+        eng.start("test", divert=QuietDivert())
+        during = sys.getswitchinterval()
+        eng.stop()
+        after = sys.getswitchinterval()          # read BEFORE the cleanup below
+    finally:
+        _switch_restore()
+    check("switch interval: shortened while the session runs",
+          during == winenv.THREAD_SWITCH_S, f"({during})")
+    check("switch interval: the session gives it back",
+          after == before, f"({after})")
+
+
+def test_the_switch_interval_is_restored_on_every_session_path():
+    """Clean stop, double stop and a start that blows up half way - all give it
+    back. An unbalanced pair is invisible from inside the program: the process
+    simply keeps somebody else's interval for the rest of its life, and nothing
+    would ever report it. Same hazard as the fine timer tick, minus the OS
+    refcount that would at least catch it there.
+    """
+    import sys
+    import threading
+
+    before = _switch_baseline()
+    eng = BeanEngine()
+    try:
+        eng.start("test", divert=QuietDivert())
+        eng.stop()
+        eng.stop()                       # idempotent: the second stop gives nothing back
+        check("switch interval: restored after a clean (and doubled) stop",
+              sys.getswitchinterval() == before, f"({sys.getswitchinterval()})")
+
+        real_start = threading.Thread.start
+        attempts = {"n": 0}
+
+        def flaky_start(self, *a, **k):
+            attempts["n"] += 1
+            if attempts["n"] > 1:
+                raise RuntimeError("can't start new thread")
+            return real_start(self, *a, **k)
+
+        threading.Thread.start = flaky_start
+        try:
+            eng.start("test", divert=QuietDivert())
+        except RuntimeError:
+            pass
+        finally:
+            threading.Thread.start = real_start
+        check("switch interval: a failed start gives it back too",
+              sys.getswitchinterval() == before, f"({sys.getswitchinterval()})")
+    finally:
+        _switch_restore()
+
+
+def test_two_overlapping_sessions_do_not_restore_each_other_s_interval():
+    """Two engines in one process is a real shape here - the tests do it, and
+    nothing stops a caller. The second one to stop must restore the value that
+    was in force before the FIRST one asked, and the first one to stop must not
+    pull the shorter interval out from under a session that is still running.
+    """
+    import sys
+    from beantester import winenv
+
+    before = _switch_baseline()
+    a, b = BeanEngine(), BeanEngine()
+    try:
+        a.start("test", divert=QuietDivert())
+        b.start("test", divert=QuietDivert())
+        b.stop()
+        still_short = sys.getswitchinterval()
+        a.stop()
+        after = sys.getswitchinterval()          # read BEFORE the cleanup below
+    finally:
+        _switch_restore()
+    check("switch interval: one session stopping leaves the other one's in place",
+          still_short == winenv.THREAD_SWITCH_S, f"({still_short})")
+    check("switch interval: the last one out restores the original",
+          after == before, f"({after})")
+
+
+def test_releasing_a_switch_interval_nobody_took_changes_nothing():
+    """It runs on every stop, on every platform, so it may never raise - and a
+    release without a matching request must not install a saved value from some
+    earlier, already balanced session."""
+    import sys
+    from beantester import winenv
+
+    before = _switch_baseline()
+    try:
+        first = winenv.release_fast_thread_switch()
+        check("switch interval: releasing without holding is refused, not raised",
+              first is False, f"({first!r})")
+        check("switch interval: and it leaves the value alone",
+              sys.getswitchinterval() == before, f"({sys.getswitchinterval()})")
+    finally:
+        _switch_restore()
+
+
 def test_stop_is_idempotent_and_keeps_the_first_reason():
     eng = BeanEngine()
     eng.start("test", divert=QuietDivert())


### PR DESCRIPTION
## What this is

Handoff point 1 - "what IS the engine's bottleneck" - answered and fixed. It is not a stage of the
packet path. It is the **handoff between the capture and inject threads**: both leave the
interpreter for a syscall and hand every packet to each other, so each packet costs two waits for
the interpreter lock, and CPython lets a waiter sleep up to `sys.getswitchinterval()` - **5 ms by
default** - before it insists.

The tell was there and was misread: `send()` looked slow, but `recv()` on the *other* thread was
inflated by the same factor, and a slow `send()` cannot do that.

| | recv | send |
|---|---|---|
| one thread, no contender | 15.3 us | **26.9 us** |
| the engine, 5 ms (shipped) | 41.7 us | **56.7 us** |
| the engine, 0.5 ms | 19.9 us | 32.0 us |

## How it was measured

A phase-to-phase throughput ratio is worthless on this rig - the 5 ms canary alone ranged
**10 370 to 15 450 pkt/s inside one run**. So the final measurement flips the interval **inside one
session**, counts packets over alternating windows and swaps the order every pair:

| run | result |
|---|---|
| loopback | **8/8 pairs, median 1.35x** |
| loopback (repeat) | **8/8 pairs, median 1.33x** |
| real interface -> WSL guest | **8/8 pairs, median 1.36x** |

Per-call readings (recv/send medians) and queue depth repeat exactly across all three - those are
observations, not stopwatch numbers, which is why they survive where the throughput ratio drifts.
`peak_queue` falls from 253 to 8-62.

**Priced, not assumed:** process CPU per packet **falls** (103.1 -> 92.9 us), and delay accuracy -
the thing the tool actually promises - is unchanged: against a configured 10 ms, lateness held a
median of 0.73 vs 0.76 ms and a p95 of 1.71 vs 1.65 ms, with the shorter interval ahead in 3 pairs
of 6. 0.5 ms is the **knee**, not the floor: 1 ms still behaves like 5 ms, 0.1/0.05/0.01 buy nothing.

**Not measured:** GUI smoothness at 0.5 ms, TCP traffic (this was UDP), machines with fewer than
16 cores.

## Ruled out on the way (measured, so nobody re-opens them)

- **A separate `SEND_ONLY` injection handle is WORSE**, not better: send 1.71x, recv 1.97x.
- **The locks are not the story**: nulling `_slock` bought 1.71x and `_clock` 1.25x - both partial,
  which is the signature of contention rather than of the work removed.
- **Batching (`SendEx`) still stays closed.** Its ADR forbids re-opening without re-measuring the
  mean batch size; re-measured, the heap does sit 15-320 deep under a flood, so that condition was
  met - but the switch interval takes `peak_queue` back to 8-62, so the ADR's conclusion survives
  with a different reason under it.

## The change

`winenv.request_fast_thread_switch()` / `release_fast_thread_switch()` + `THREAD_SWITCH_S =
0.0005`, taken in `_start_locked` beside `request_fine_timers` and given back in `_stop_locked`
once the workers are joined - the same session-scoped shape, for the same reason. They carry their
**own** refcount and saved value: unlike `timeBeginPeriod` the OS does not count these, so two
overlapping sessions would otherwise let the first one to stop restore a value out from under the
second. Nothing in `_capture_loop`, `_inject_loop` or `decide()` was touched.

## Tests

Four new guards in `tests/test_failsafe.py`, **all verified by mutation** (deleted release, deleted
request, ignored refcount, removed underflow guard - each mutant dies with a message that names the
defect).

The mutation run also found a hole in the tests themselves, which is recorded in the internal
changelog: with the release deleted, *every* engine session in the file leaks a holder, so
"the interval came back to what it was when I started" became a tautology and the mutant survived.
The tests now assert against a sentinel value of their own choosing (0.004 - neither the CPython
default nor `THREAD_SWITCH_S`) and read the post-stop value **inside** the try, before cleanup can
paper over it.

`python -m pytest tests` -> **745 passed, 0 failed** (741 before, +4 here), on an ELEVATED shell,
so green means green. `python smoke_gui.py` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
