### PR TITLE
perf(engine): recompute checksums only for packets the tool actually edited

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -184,6 +184,70 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   is the same trap F16 recorded, hit again from a different direction; the portless guard above
   exists because of it, and the core test now says which half it actually pins.
 
+### Changed: checksums are recomputed only for packets this tool actually edited (handoff point 2)
+
+- **The rule:** `_inject_loop` now calls `send(packet, recalculate_checksum=modified)`, where
+  `modified` is set in `_capture_loop` when `core.corrupt_packet` reports it changed the bytes, and
+  rides through the release queue with the entry. `_send_rst` passes `recalculate_checksum=True`
+  explicitly - that packet was BUILT, never captured, so nothing has ever computed a checksum for it.
+- **Correctness first, because this one can fail silently.** WinDivert delivers each packet with
+  its checksum-valid flags in `WINDIVERT_ADDRESS`, and pydivert exposes them
+  (`packet.ip_checksum` / `.tcp_checksum` / `.udp_checksum`). MEASURED here, sniff-only:
+  `udp_checksum` was **0 on 120 of 120 packets** on loopback AND over a real interface - outbound
+  traffic carries a PSEUDO checksum for the hardware to finish. Re-injecting the same bytes with
+  the same address hands that flag back to the stack, which then does what it would have done
+  anyway. Verified end to end where it can actually differ (loopback is a special path and lenient
+  about checksums it never had to compute): 24 MiB of TCP through the engine to a sink inside a WSL
+  guest, over 192.168.48.1, **25 165 824 B received, SHA-256 match, `drop_send` 0**, with
+  recalculation on and off alike. A bad checksum does not corrupt data quietly - the receiver
+  discards the segment - so the byte count is the guard.
+- **Worth 1.122x end to end** (8 of 8 paired windows, spread 1.087-1.156, toggled mid-session with
+  the order swapped every pair), `send()` itself 54.5 -> 45.9 us.
+  🔴 **The prediction going in was ~1.00x and it was wrong, for a reason worth keeping.** The
+  release heap sits at depth 0-2 since PR #74, so the inject thread has slack, and making a thread
+  with slack faster should buy nothing. The gain does not come from the injector's throughput - it
+  comes from the work no longer competing with the CAPTURE thread, which is what sets the rate.
+  Same shape as the earlier "send() is slow" misreading: the unit that matters is the PAIR of
+  threads, not either one of them.
+- **A side effect that is really the point:** with nothing configured, the tool now passes traffic
+  through byte for byte in the literal sense. Recomputing meant an untouched packet went out with
+  different bytes than it came in - a pseudo checksum turned into a real one.
+- 🔴 **`send()` on the divert protocol gained a keyword, and that was the deliberate choice.**
+  It touches `SyntheticDivert` plus seven test doubles (`tests/fakes.py`,
+  `test_engine.py`, `test_failsafe.py` x2, `test_rst_local.py`, `test_concurrency_chaos.py`,
+  `test_socketwatch_wiring.py`). The smaller alternative - wrapping the real handle in
+  `_start_locked` so the protocol stays one-argument - was rejected: with it, `_send_rst` would
+  silently inherit "never recalculate" and inject RSTs the local stack drops, and the symptom
+  ("RST does not reset anything") points nowhere near the cause. The explicit keyword puts the
+  decision at the call site where the next reader meets it.
+- **Tests** (all verified by mutation - five mutants, five deaths):
+  `tests/test_checksums.py::test_an_untouched_packet_is_re_injected_without_recomputing_its_checksums`,
+  `::test_a_corrupted_packet_IS_recomputed`,
+  `::test_a_duplicate_of_a_corrupted_packet_is_recomputed_too` (the duplicate release is a separate
+  queue entry, and the mutant that dropped `modified` from it died here with `[True, False]`), and
+  `tests/test_rst_local.py::test_an_injected_rst_is_always_recomputed`. The RST guard lives with
+  the RST fixtures on purpose: a `FakePacket` has no TCP layer, so a "reset" test written next to
+  the others would have passed without ever building one.
+
+### Measured and NOT changed: the locks, the connection log and the address conversion
+
+- With the handoff cheap (PR #74), the three obvious remaining targets were re-measured the same
+  paired way, inside one session. **All three are noise:** nulling `_slock` 1.011x (6/6 pairs),
+  nulling `_clock` 1.002x (4/6 - a coin toss), both together 1.011x, and the watchdog's per-tick
+  work (`refresh_if_stale` + `warm_names`) 1.003x. The 1.71x / 1.25x those same ablations gave at
+  the 5 ms switch interval was the handoff showing up ON the locks, not the cost of the locks.
+- **Memoising pydivert's per-packet `inet_ntop`** (`packet/ip.py:43-66` converts the address to a
+  string on EVERY read and caches nothing): 1.017x, 6/6 pairs. Real but small, and the change would
+  either duplicate pydivert internals or make the engine read raw address bytes and reshape
+  `_flowkey`, whose string keys are consumed by the connection log, the CSV, the repro report and
+  the NDJSON schema. Not worth it at 1.7%.
+- **The whole connection log removed**: 1.012x. There is nothing to win by optimising it.
+- 🔴 **Sending inline on the capture thread (zero handoffs) is 0.72x - 28% SLOWER, 0 of 8 pairs.**
+  Worth recording because it is counter-intuitive and cheap to try again: `recv` really does get
+  faster (32.6 -> 25.2 us) once nothing competes with it, but one thread then has to do both jobs.
+  The two threads genuinely overlap, and what looks like "handoff overhead" in the budget is the
+  price of that overlap, not waste.
+
 ### Fixed: the engine's ceiling was CPython's thread-switch interval, not any stage (handoff point 1)
 
 - **The question.** The previous session narrowed the bottleneck by elimination - not the read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Changed
 
+- **A packet you did not ask to change now goes back on the wire exactly as it arrived - and the
+  session moves about 12% more traffic because of it.** The tool used to recompute every packet's
+  checksums before re-injecting it, including packets it had not touched at all. That was wasted
+  work, and it also meant a session with nothing configured did not quite pass traffic through
+  unchanged: modern network cards leave the checksum for the hardware to finish, so recomputing it
+  put different bytes on the wire than the ones that came in. Checksums are now recomputed only
+  when the tool actually edited the packet - which today means corruption - and for the reset (RST)
+  packets it builds itself. Measured comparing both behaviours inside the same session:
+  **1.12x more packets a second, in 8 comparisons out of 8**. Verified over a real network card,
+  not just loopback: 24 MiB of TCP through the tool arrived byte for byte, with a matching SHA-256.
+
 - **A session now moves noticeably more traffic - about a third more packets a second.** The tool
   handles your packets on two threads: one takes them from the driver, the other puts them back on
   the wire. Python makes those two take turns, and by default a thread that is ready to work can be

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -54,6 +54,14 @@ re-measured three times on this machine and gave **14 488, then 30 189, then
 Ratios are not safe either - the batched-versus-unbatched ratio moved between
 1.23x and 3.65x across those runs.
 
+MEASURED SINCE, and deliberately NOT folded into the figures above: two changes
+moved this by paired ratios - a shorter interpreter thread-switch interval
+(median 1.33-1.36x, 24 pairs of 24) and skipping the checksum recomputation for
+packets this tool did not edit (1.122x, 8 pairs of 8). The absolute numbers here
+have NOT been re-taken, because on this rig they cannot be re-taken in a way that
+would mean anything; multiplying them by those ratios would produce a figure that
+looks measured and is not.
+
 So: **a number from this rig is evidence only against another number taken in
 the SAME run.** Do not quote the absolutes as the tool's ceiling, do not derive
 a budget breakdown by dividing one run's figure by another's, and do not tune
@@ -1394,8 +1402,15 @@ class BeanEngine:
                 self._log_conn(key, remote_ip, remote_port, local_port, is_out, size,
                                now, proto, dropped=True, scoped=dec.scoped)
                 continue
+            # Whether this packet's BYTES were changed decides whether the
+            # injector has to recompute its checksums - see _enqueue. Corruption
+            # is the only thing in this tool that edits a captured packet
+            # (core.corrupt_packet, via the payload setter); everything else
+            # either drops it, delays it or duplicates it unchanged.
+            modified = False
             if dec.corrupt and self.core.corrupt_packet(packet, rng):
                 self._bump("corrupted")
+                modified = True
             # releases[0] is the packet itself; anything after it is a duplicate
             # copy (step 12). Kept as an explicit first call plus a branch rather
             # than a loop over an enumerate: all but the duplicating sessions have
@@ -1409,10 +1424,11 @@ class BeanEngine:
             self._log_conn(key, remote_ip, remote_port, local_port, is_out, size,
                            now, proto, scoped=dec.scoped)
             rels = dec.releases
-            refused = self._enqueue(rels[0], packet, key=key)
+            refused = self._enqueue(rels[0], packet, key=key, modified=modified)
             if len(rels) > 1:
                 for rel in rels[1:]:
-                    self._enqueue(rel, packet, copy=True, key=key)
+                    self._enqueue(rel, packet, copy=True, key=key,
+                                  modified=modified)
                 self._bump("duplicated")
             if refused:
                 # A packet the QUEUE threw away used to count nowhere in its row:
@@ -1431,7 +1447,13 @@ class BeanEngine:
         if rst is None:
             return
         try:
-            self._divert.send(rst)
+            # ALWAYS recalculated, and explicitly so. Unlike everything on the
+            # injector's path this packet was never captured - it was BUILT here,
+            # header by header, so nothing has ever computed its checksums and no
+            # offload flag applies to it. Sending it as-is would produce a segment
+            # the local stack drops on arrival, and the failure would look like
+            # "RST does not reset anything" rather than like a checksum bug.
+            self._divert.send(rst, recalculate_checksum=True)
             self._bump("rst_sent")
         except Exception as e:
             if self._running:
@@ -1606,7 +1628,7 @@ class BeanEngine:
         if first:
             self.log_event("WARN", "events.driver_wait")
 
-    def _enqueue(self, release, packet, copy=False, key=None):
+    def _enqueue(self, release, packet, copy=False, key=None, modified=False):
         """Queue one release of ``packet`` for delayed injection.
 
         Returns True when the queue refused it, so the caller can record the loss
@@ -1614,6 +1636,15 @@ class BeanEngine:
         injector needs it to credit the DELIVERED bytes to the right row, and
         ``stop()`` needs it to charge whatever is still parked here to the rows
         that will never receive it.
+
+        ``modified`` says whether this tool edited the packet's BYTES, and it
+        rides along for the injector, which turns it into
+        ``send(recalculate_checksum=...)``. An untouched packet goes back exactly
+        as it arrived, pseudo-checksum and all - see _inject_loop for the
+        measurement and why that is the correct thing to do, not merely the fast
+        one. It is the LAST field of the queue entry on purpose: ``stop()``
+        indexes this tuple POSITIONALLY (entry[3], entry[4]), so appending is the
+        one shape that cannot silently move somebody else's field.
 
         ``copy=True`` marks a DUPLICATE release (pipeline step 12): the same
         packet already has an earlier entry in this queue. Overflow and shutdown
@@ -1642,7 +1673,8 @@ class BeanEngine:
             else:
                 overflowed = False
                 heapq.heappush(self._heap,
-                               (release, next(self._counter), packet, copy, key))
+                               (release, next(self._counter), packet, copy, key,
+                                modified))
                 q = len(self._heap)
                 with self._slock:
                     if q > self.st["peak_queue"]:
@@ -1659,7 +1691,7 @@ class BeanEngine:
                     self._cv.wait()
                 if not self._running:
                     break
-                release, _, packet, _, key = self._heap[0]
+                release, _, packet, _, key, modified = self._heap[0]
                 now = time.monotonic()
                 if release > now:
                     self._cv.wait(timeout=min(release - now, 0.5))
@@ -1678,7 +1710,27 @@ class BeanEngine:
                     self._bump("drop_shutdown")
                     self._charge_flow(key, "dropped")
                 else:
-                    self._divert.send(packet)
+                    # Recompute the checksums only when this tool actually edited
+                    # the bytes. An untouched packet goes back exactly as it
+                    # arrived - and that is the CORRECT thing, not just the cheap
+                    # one: WinDivert hands us the packet with its checksum-valid
+                    # flags in WINDIVERT_ADDRESS, and outbound traffic routinely
+                    # arrives with a PSEUDO checksum for the hardware to finish
+                    # (measured on this machine: udp_checksum was 0 on 120 of 120
+                    # packets, on loopback and over a real interface alike). We
+                    # re-inject the same bytes with the same address, so the flag
+                    # rides along and the stack does what it would have done.
+                    # Recomputing instead meant an unimpaired session did not
+                    # actually pass traffic through byte for byte.
+                    # Verified end to end over a real interface, not on loopback:
+                    # 24 MiB of TCP through the engine to a sink in a WSL guest,
+                    # 25 165 824 B received, SHA-256 match, drop_send 0. A wrong
+                    # checksum does not corrupt data quietly - the receiver
+                    # discards the segment - so the byte count is the guard.
+                    # Worth a median 1.122x end to end (8 of 8 paired windows
+                    # inside one session), because the work removed was competing
+                    # with the CAPTURE thread, which is what sets the rate.
+                    self._divert.send(packet, recalculate_checksum=modified)
                     size = len(packet.raw)
                     is_out = getattr(packet, "is_outbound", True)
                     self._bump("bytes_out" if is_out else "bytes_in", size)

--- a/beantester/synthetic.py
+++ b/beantester/synthetic.py
@@ -136,8 +136,14 @@ class SyntheticDivert:
         """Build the RST packet the engine wants to inject (see build_synthetic_rst)."""
         return build_synthetic_rst(packet, fields)
 
-    def send(self, packet):
-        pass
+    def send(self, packet, recalculate_checksum=True):
+        """Accepted and ignored: there is no wire here and no checksum to fix.
+
+        The argument exists because the engine states it explicitly on every
+        send - it recomputes checksums only for packets this tool actually edited
+        (see BeanEngine._inject_loop) - and a divert that could not accept the
+        word would force the engine to guess which kind of handle it holds.
+        """
 
     def close(self):
         self.closed = True

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -57,6 +57,10 @@ class FakeDivert:
         self.inbox = list(packets)
         self.i = 0
         self.sent = []
+        # What the engine asked for on each send: True only when it edited the
+        # packet. Recorded separately from `sent` so the existing readers of that
+        # list keep their (time, packet) shape.
+        self.recalc = []
         self.closed = False
 
     def open(self):
@@ -71,8 +75,9 @@ class FakeDivert:
             time.sleep(0.003)
         raise OSError("closed")
 
-    def send(self, p):
+    def send(self, p, recalculate_checksum=True):
         self.sent.append((time.monotonic(), p))
+        self.recalc.append(recalculate_checksum)
 
     def close(self):
         self.closed = True

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -1,0 +1,87 @@
+"""Who recomputes a packet's checksums, and who must not.
+
+The rule is one sentence - recompute only when this tool edited the bytes - and
+all three of its cases were unguarded before this file existed.
+
+Why it matters in both directions:
+
+* Recomputing an UNTOUCHED packet is not free and not neutral. WinDivert hands
+  over the packet together with its checksum-valid flags, and outbound traffic
+  routinely arrives carrying a PSEUDO checksum for the hardware to finish
+  (measured on this machine: ``udp_checksum`` was 0 on 120 of 120 packets, over
+  loopback and a real interface alike). Recomputing turned "pass the traffic
+  through unchanged" into "pass it through with different bytes", and cost a
+  measured 1.122x of throughput (8 of 8 paired windows in one session).
+* NOT recomputing an edited one is a silent hole: the receiving stack discards
+  the segment, so corruption would stop arriving at all and the tool would report
+  it as delivered.
+* An injected RST was never captured - it is built here - so nothing has ever
+  computed its checksums and no offload flag applies. Sending it as-is produces a
+  segment the stack drops, which looks like "RST does not reset anything" rather
+  than like a checksum bug.
+"""
+import time
+
+from beantester.engine import BeanEngine
+from fakes import FakeDivert, FakePacket, check
+
+
+def _run(packets, settings=None, expect=None, wait=1.5):
+    """Drive the engine over `packets` and return the divert once `expect` sends
+    have happened. `expect` is separate from len(packets) on purpose: with
+    duplication one packet produces TWO sends, and a wait that stops at
+    len(packets) would read the first one and call the test done."""
+    eng = BeanEngine()
+    eng.set_seed(7)
+    if settings:
+        eng.set_params(*settings)
+    div = FakeDivert(packets)
+    eng.start("test", divert=div)
+    deadline = time.monotonic() + wait
+    want = len(packets) if expect is None else expect
+    while time.monotonic() < deadline and len(div.sent) < want:
+        time.sleep(0.005)
+    time.sleep(0.05)                     # let a stray extra send land, if any
+    eng.stop()
+    return div
+
+
+def test_an_untouched_packet_is_re_injected_without_recomputing_its_checksums():
+    """The default session promises byte-for-byte passthrough; recomputing broke
+    that promise quietly, because the bytes that go out are then not the bytes
+    that came in."""
+    div = _run([FakePacket(size=120, port=4000) for _ in range(4)])
+    check("every untouched packet went out", len(div.sent) == 4, f"({len(div.sent)})")
+    check("and none of them was recomputed",
+          div.recalc == [False] * 4, f"({div.recalc})")
+
+
+def test_a_corrupted_packet_IS_recomputed():
+    """Corruption edits the payload, so the checksum in the packet is now wrong.
+    Left alone, the receiver drops the segment and the corruption never arrives -
+    the tool would count damage it did not deliver."""
+    div = _run([FakePacket(size=120, port=4100, payload=b"abcdefgh")
+                for _ in range(4)],
+               settings=(0, 100, 0, 0, 0, 0, 0))          # corrupt 100%
+    check("the corrupted packets went out", len(div.sent) == 4, f"({len(div.sent)})")
+    check("and every one of them was recomputed",
+          div.recalc == [True] * 4, f"({div.recalc})")
+
+
+def test_a_duplicate_of_a_corrupted_packet_is_recomputed_too():
+    """Duplication (pipeline step 12) queues the SAME packet object a second time.
+    The copy carries the same edited bytes, so it needs the same answer - and it
+    is a separate call, on a separate queue entry, which is exactly where a flag
+    carried per-entry can drift from the packet it describes."""
+    div = _run([FakePacket(size=120, port=4200, payload=b"abcdefgh")],
+               settings=(0, 100, 100, 0, 0, 0, 0),        # corrupt 100%, duplicate 100%
+               expect=2)
+    check("the packet and its duplicate both went out",
+          len(div.sent) == 2, f"({len(div.sent)})")
+    check("both were recomputed", div.recalc == [True, True], f"({div.recalc})")
+
+
+# The RST half of the rule lives in tests/test_rst_local.py
+# (test_an_injected_rst_is_always_recomputed), next to the fixture that can build
+# a real TCP packet and a synthetic RST for it - a FakePacket has no TCP layer,
+# so a "reset" test written here would pass without ever building one.

--- a/tests/test_concurrency_chaos.py
+++ b/tests/test_concurrency_chaos.py
@@ -233,7 +233,7 @@ class FastDivert:
                                 f"93.184.{i % 200}.{i % 251}",
                                 tcp=_SyntheticTCP(ack=True))
 
-    def send(self, packet):
+    def send(self, packet, recalculate_checksum=True):
         pass
 
     def close(self):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -620,7 +620,7 @@ class RefusingDivert(FakeDivert):
     or a driver that refuses the packet. `recv` still works: the tool keeps
     capturing, and every packet it captures it then fails to put back."""
 
-    def send(self, p):
+    def send(self, p, recalculate_checksum=True):
         raise OSError("the network is gone")
 
 

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -38,7 +38,7 @@ class ExplodingDivert:
             return FakePacket(size=100, port=1000 + self.i)
         raise OSError("driver went away")
 
-    def send(self, packet):
+    def send(self, packet, recalculate_checksum=True):
         self.sent.append(packet)
 
     def close(self):
@@ -59,7 +59,7 @@ class QuietDivert:
             time.sleep(0.005)
         raise OSError("closed")
 
-    def send(self, packet):
+    def send(self, packet, recalculate_checksum=True):
         pass
 
     def close(self):

--- a/tests/test_rst_local.py
+++ b/tests/test_rst_local.py
@@ -42,8 +42,10 @@ class RecordingTcpDivert:
             time.sleep(0.003)
         raise OSError("closed")
 
-    def send(self, p):
+    def send(self, p, recalculate_checksum=True):
         self.sent.append(p)
+        self.recalc = getattr(self, "recalc", [])
+        self.recalc.append(recalculate_checksum)
 
     def make_rst(self, packet, fields):
         return build_synthetic_rst(packet, fields)
@@ -82,6 +84,32 @@ def test_rst_injection_counts_and_shape():
     assert rst.is_outbound is False                 # aimed at the local end
     # ports are swapped relative to the observed outbound packet
     assert (rst.src_port, rst.dst_port) == (6000, 5000)
+
+
+def test_an_injected_rst_is_always_recomputed():
+    """An RST is BUILT here, not captured, so nothing has ever computed its
+    checksums and no hardware-offload flag applies to it.
+
+    The engine skips the recomputation for packets it did not edit - that is
+    worth a measured 1.122x and is what makes an unimpaired session pass traffic
+    through byte for byte (see tests/test_checksums.py). This packet is the
+    exception, and the failure mode if it is ever folded into the same rule is
+    nasty to read: the local stack drops the segment on arrival, so the symptom
+    is "RST does not reset the connection", with `rst_sent` happily counting up.
+    """
+    pkts = [_tcp_packet(5100, 6100, is_outbound=True)]
+    div = RecordingTcpDivert(pkts)
+    eng = BeanEngine()
+    eng.set_rst(100, 3.0)
+    eng.start("test", divert=div)
+    _drain(eng, 1)
+    eng.stop()
+
+    assert div.sent, "no RST was injected"
+    assert getattr(div, "recalc", []), "nothing recorded the recalculation flag"
+    # the dropped packet never reaches send(), so every send here IS an RST
+    assert all(p.tcp is not None and p.tcp.rst for p in div.sent), div.sent
+    assert all(div.recalc), div.recalc
 
 
 def test_rst_cooldown_sends_once_then_drops_silently():

--- a/tests/test_socketwatch_wiring.py
+++ b/tests/test_socketwatch_wiring.py
@@ -155,7 +155,7 @@ class _GatedDivert:
             time.sleep(0.003)
         raise OSError("closed")
 
-    def send(self, packet):
+    def send(self, packet, recalculate_checksum=True):
         self.sent.append(packet)
 
     def close(self):


### PR DESCRIPTION
## What this is

Handoff point 2, and it turned out to be a **correctness** fix that happens to be fast, not the
other way round.

The injector recomputed every packet's checksums before re-injecting it, including packets nothing
had touched. WinDivert hands each packet over with its checksum-valid flags in
`WINDIVERT_ADDRESS`, and outbound traffic routinely carries a **pseudo checksum** for the hardware
to finish - measured here, `udp_checksum` was **0 on 120 of 120 packets**, on loopback and over a
real interface alike. Recomputing turned it into a real one, so a session with nothing configured
did **not** pass traffic through byte for byte, which is the first thing this tool promises.

## The rule

Recompute only when the tool actually edited the bytes.

- `_capture_loop` sets `modified` when `core.corrupt_packet` reports it changed the payload -
  verified as the **only** place anything edits a captured packet.
- The flag rides in the release-queue entry, appended as the **last** field, because `stop()`
  indexes that tuple positionally (`entry[3]`, `entry[4]`).
- `_inject_loop` sends with `recalculate_checksum=modified`.
- `_send_rst` passes `True` **explicitly**: that packet was BUILT, never captured, so nothing has
  ever computed a checksum for it.

## Evidence

**Correctness, verified where it can differ from loopback** (loopback is a special path in
WinDivert and lenient about checksums it never had to compute): 24 MiB of TCP through the engine
to a sink inside a WSL guest, over 192.168.48.1 -> 192.168.57.74:

| recalculate | received | hash |
|---|---|---|
| True (old) | 25 165 824 B | SHA-256 match |
| False (new, for untouched packets) | 25 165 824 B | **SHA-256 match** |

`drop_send` 0 in both. A wrong checksum does not corrupt data quietly - the receiver discards the
segment - so the byte count is the guard.

**Speed:** median **1.122x end to end, 8 of 8 paired windows** (spread 1.087-1.156), toggled
mid-session with the order swapped every pair; `send()` itself 54.5 -> 45.9 us.

🔴 **The prediction going in was ~1.00x and it was wrong.** The release heap sits at depth 0-2
since #74, so the inject thread has slack, and a thread with slack does not get faster by doing
less. The gain comes from that work no longer competing with the **capture** thread, which is what
sets the rate. Same shape as the earlier "send() is slow" misreading: the unit that matters is the
pair of threads, not either one alone.

## Also measured, and deliberately NOT changed

With the handoff cheap, the obvious remaining targets were re-measured the same paired way:

| candidate | result |
|---|---|
| null `_slock` | 1.011x (6/6) |
| null `_clock` | 1.002x (4/6 - a coin toss) |
| both, and the watchdog's per-tick work | 1.011x / 1.003x |
| memoise pydivert's per-packet `inet_ntop` | 1.017x |
| remove the **entire** connection log | 1.012x |
| **send inline on the capture thread (zero handoffs)** | **0.72x - 28% slower, 0/8** |

The 1.71x / 1.25x those lock ablations gave before #74 was the GIL handoff showing up *on* the
locks, not the cost of the locks. And the inline-send result is worth keeping: `recv` really does
get faster (32.6 -> 25.2 us) once nothing competes with it, but one thread then has to do both
jobs - the two threads genuinely overlap.

## The protocol change

`send()` on the divert protocol gained a keyword, which touches `SyntheticDivert` and seven test
doubles. The smaller alternative - wrapping the real handle in `_start_locked` so the protocol
stays one-argument - was rejected: `_send_rst` would silently inherit "never recalculate" and
inject RSTs the local stack drops, with the symptom reading as "RST does not reset anything".

## Tests

`tests/test_checksums.py` (3) + `tests/test_rst_local.py::test_an_injected_rst_is_always_recomputed`.
The RST guard lives with the RST fixtures because a `FakePacket` has no TCP layer - written next to
the others it would have passed without ever building a reset.

**Five mutants, five deaths**, including the one that drops the flag from the DUPLICATE release
only (dies with `[True, False]`).

`python -m pytest tests` -> **749 collected, exit 0, zero failures** on an elevated shell.
`python smoke_gui.py` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
