### PR TITLE
fix(socketwatch): a stale poller snapshot no longer overwrites a newer SOCKET event

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -97,6 +97,74 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 - Help text and the flag tables in both READMEs now state that the flag is valid on its own.
 - Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
+### Fixed
+
+- **`SocketWatcher.reconcile()` let a STALE poller snapshot overwrite a newer SOCKET event
+  (audit F2).** The merge was unconditional (`merged[port] = pid`) and the docstring called the
+  snapshot "authoritative" - reading "complete" as "newest". It is collected up to
+  `portmap.REFRESH_S` (0.30 s) before it is handed over and applied up to a watchdog tick (0.20 s)
+  later; **measured: 10 of 20 ticks hand over a snapshot the previous tick already applied**,
+  because those two intervals interleave that way. Consumers of the damage: `engine._pid_for`
+  (connection-log `proc`/`pid`), `engine._process_for`, `targeting.owner_targeted` - the gate for a
+  TCP SYN and for EVERY UDP datagram - and `ProcessTargeting.refresh` via `table.snapshot()`.
+  - **Fix: every map entry carries the time of the evidence behind it.** New `_evidence`
+    (`local_port -> monotonic`), written by `apply()` on both branches, including CLOSE, where it is
+    a TOMBSTONE: without a mark, "closed a moment ago" and "never seen" are the same absence, which
+    is what let an older snapshot resurrect a closed port. A snapshot entry is applied only when the
+    snapshot was COLLECTED after that stamp.
+  - **The stamp gates the PRUNE too**, not only the merge: a port an event touched after the
+    collection does not count as absent, because that snapshot never had a chance to see it.
+    Previously its survival rested on `WATCHDOG_TICK_S` (0.2) and `portmap.REFRESH_S` (0.3)
+    interleaving so two stale reconciles never ran back to back - arithmetic nothing stated or
+    tested. The two-pass grace SURVIVES alongside it (the collection itself takes time).
+  - **`_evidence` is rebuilt in `reconcile`**, keeping a tombstone only while it can still veto a
+    snapshot. Steady state is (open sockets + one refresh interval of churn), not every socket the
+    session ever saw.
+  - **Rejected: "events always win"** (the smaller change). With a missed CLOSE *and* a missed new
+    CONNECT the map would keep a dead pid that the prune can never take, since the port is in every
+    snapshot. Guarded by `test_a_snapshot_taken_after_the_event_still_heals_a_stale_entry`.
+  - **New `portmap.PortTable.collected()` -> `(dict(ports), _last)` from ONE lock hold.**
+    `_last` is when the collection STARTED (`refresh()` reads `now` before the `iphlpapi` calls),
+    so it under-states freshness - the safe direction. Taking the map and the stamp separately
+    would let a refresh land between them and stamp OLD data with a NEW time, which is the one
+    error direction that silently reintroduces this bug. `snapshot()` is unchanged, so the shared
+    read surface (`snapshot`/`name_of`/`ancestors`/`refresh`/`pid_for`) that `ProcessTargeting`
+    resolves against does not grow a value only one of its two implementations could fill.
+  - **`collected_at` has no default, deliberately.** Both call sites sit inside exception handlers
+    (`crashlog.quiet` at bootstrap, the watchdog's per-tick `except`), so a missing argument would
+    become "the safety net silently stopped running" against a session that looks healthy. This is
+    not hypothetical: it happened during verification to a diagnostic script left on the old
+    signature, which reported 0 reconciles for a whole run.
+  - **`pid_for` is untouched** - `_evidence` is read only by `reconcile`, under `_lock`. The
+    lock-free capture-thread read stays a plain int->int dict lookup, so the hot path pays nothing
+    by construction, not by measurement.
+  - MEASURED on a live session (2026-07-29, real SOCKET handle, 887 connections / 5232 events /
+    123 reconciles in 25 s): **919 writes the old rule would have made are refused**, each for a
+    port an event touched 0-170 ms after that snapshot was walked; **0 stale writes survive**. An
+    earlier count of "1394 resurrections + 11 reverts" is superseded - that detector could not tell
+    a resurrected socket from the same process reopening a recycled port and over-reported by about
+    a third. A separate check confirmed the socket table drops a port immediately on `close()`
+    (pid `None` at +0.0 s), so lingering TCP teardown is NOT an explanation for what remains.
+- **New tests.** `tests/test_socketwatch.py`: `test_a_newer_event_is_not_undone_by_an_older_snapshot`,
+  `test_a_port_known_only_from_a_connect_still_outranks_an_older_snapshot` (written because a
+  MUTANT SURVIVED - the handover test is carried by the CLOSE tombstone, so the ADD branch's stamp
+  had no guard), `test_a_closed_port_is_not_resurrected_by_an_older_snapshot`,
+  `test_a_snapshot_taken_after_the_event_still_heals_a_stale_entry` (guards against over-fixing),
+  `test_a_port_an_event_touched_after_the_collection_is_never_counted_absent` (the prune gate),
+  `test_the_evidence_map_does_not_grow_with_every_connection_ever_seen` (tombstone bound), plus a
+  hand-driven `_Clock` so the event/collection ordering is a fact of the test rather than a race
+  against the real `time.monotonic()`. `tests/test_socketwatch_wiring.py::test_the_watchdog_keeps_reconciling_the_live_map`
+  (the safety net is seen running, since both call sites are inside handlers).
+  `tests/test_processes.py::test_collected_hands_over_the_map_and_when_it_was_gathered_together`
+  (the stamp is never newer than the moment the collection began).
+  `test_reconcile_bootstraps_and_prunes_only_after_a_two_pass_grace` now states that its snapshots
+  are collected AFTER the event on purpose - that is the residual case the grace is for; the
+  before-the-event case is a different scenario with its own test.
+  **Mutation-checked**: nine mutants (merge gate, prune gate, both `apply` stamps, tombstone
+  expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
+  the watchdog call removed, `owner_targeted` returning False) - all nine RED.
+- Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+
 ### Tests: the recycled-PID window is measured and bounded, not just asserted (handoff point C)
 
 - The last "known edge, never reproduced" from the handoff. `owner_targeted` trusts the pid the live

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -164,6 +164,56 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
   the watchdog call removed, `owner_targeted` returning False) - all nine RED.
 - Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+- **`_watchdog_loop` read `self._socketwatch` TWICE per tick** - once for the `is not None` guard,
+  once to call `reconcile`, with `self._ports.collected()` in between. A concurrent `stop()`
+  landing in that gap made an ordinary STOP raise `AttributeError` into the tick's `except`,
+  filing a crash record for a clean shutdown. Now read ONCE into a local, the idiom `_live_pid`
+  already uses for the same attribute and the same reason.
+  Guard: `tests/test_socketwatch_wiring.py::test_a_stop_landing_mid_tick_does_not_fault_the_watchdog`
+  - the window is a few instructions wide, so it is STAGED rather than raced: the port-table double
+  clears the engine's reference from inside `collected()`. The first version of that test staged
+  nothing and a mutant restoring the double read SURVIVED, because `_start_socketwatch` bootstraps
+  through the same method while `_socketwatch` is still `None` and consumed the one shot; the
+  double now only fires once the watchdog is the caller. Mutation-checked RED afterwards.
+
+### Tests: the audit's coverage gaps, the ones whose subject already works
+
+Gaps T2/T4/T7 from the engine stability audit. T1/T5/T6/T8 are deliberately NOT here: their
+subjects (F1 swallowed `open()`, F3 `_FlowTable.keep_for`, F4 `_trim_conns` on tied stamps, F5 the
+`duplicated` counter) are still defective, and a test written now would either be red or would pin
+a bug as expected behaviour. They land with their fixes.
+
+- **T2 `tests/test_engine.py::test_every_captured_packet_is_accounted_for_under_every_impairment`**
+  (parametrised over 19 combinations). The only balance test was
+  `test_inject_batch.py::test_the_balance_holds_across_an_ordinary_session`, which drives a
+  PASS-THROUGH session and sums four of the twelve loss counters - the other eight being zero when
+  nothing is configured. So `seen == delivered + losses` was guarded exactly where it is hardest to
+  break. This arms every gate in turn (loss, corrupt, dup, latency+jitter, bandwidth,
+  bandwidth+dup, schedule, SYN, MTU, NAT, RST, flap, LAN, block, destination target) plus two
+  all-at-once runs, over mixed TCP/SYN/UDP/ICMP traffic in both directions. Delivered is counted as
+  DISTINCT packet objects, not sends, so duplication does not confuse the question; the test also
+  asserts `drop_overflow == 0`, because an overflowed original whose duplicate still got through is
+  a documented double-count (see `_enqueue`) and a different subject.
+- **T4 `::test_a_dropped_packet_is_always_in_impairment_scope`** - the premise
+  `impairment_loss_pct`'s docstring rests on ("cannot exceed 100%"), which nothing checked. Sweeps
+  400 randomised core configurations x 6 packets and asserts no `Decision` is ever
+  `drop=True, scoped=False`, plus that the sweep really armed several gates. A new impairment placed
+  ABOVE the targeting gates would break the FIGURE rather than the pipeline - silently, because the
+  number would still look like a percentage.
+  **`::test_the_loss_figure_stays_a_percentage_with_a_target_set`** is the end-to-end half, and its
+  docstring says plainly that it is the weaker of the two: mutation shows the unscoped-LAN-drop
+  mutant is caught by the structural test and NOT by this one.
+- **T7 `::test_nat_and_rst_survive_being_switched_off_and_on_mid_session`** - every GUI "Apply"
+  re-runs every setter, so a live session toggles these constantly, and nothing exercised the second
+  and third call. Covers NAT off->on (the flow table must not be stranded) and an RST cooldown
+  shortened mid-session (a flow reset after the change gets the SHORT hold; one already held keeps
+  the deadline it was given). An earlier version of the RST half could not tell "still held" from
+  "hit again", because `rst_prob=100` re-arms the flow the instant its cooldown lapses.
+- **Mutation-checked**: stranded packets uncounted at STOP -> RED (3 combos); a drop placed outside
+  targeting scope -> RED; `set_nat` made sticky -> RED; `set_rst` cooldown made sticky -> RED. One
+  mutant (removing the `drop_send` bump) survived the balance test because `FakeDivert` never fails
+  a send - checked, and it is already guarded by
+  `::test_a_packet_the_tool_could_not_re_inject_is_counted_as_a_drop`, so no gap.
 
 ### Tests: the recycled-PID window is measured and bounded, not just asserted (handoff point C)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
   from a socket event lost under heavy load.
 
+- **Stopping a session could file a crash report for nothing.** If STOP landed inside the
+  half-second housekeeping pass that keeps the socket map fresh, the tool tripped over its own
+  shutdown and wrote an entry into `crashes/`. Nothing was broken - the session stopped correctly
+  and traffic returned to normal - but anyone checking that folder after a run would find a report
+  for an ordinary STOP. It no longer happens.
+
 - **Aiming at a process did not touch the first packet of a UDP exchange - and for DNS and QUIC
   that meant it did not touch them at all.** Working out which connections belong to your target
   means keeping a set of its ports, rebuilt in the background, and a brand-new port is not in it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The live "which app owns this port" map could be dragged backwards by a stale reading, so a
+  connection was briefly credited to the wrong application.** The tool learns who owns a socket
+  two ways: from the driver, the instant a socket opens or closes, and from a periodic sweep of
+  the system's socket table. The sweep is complete but always a little behind - it is taken up to
+  0.3 s before it is used - and it was being applied on top of the live signal, so it could undo
+  what the driver had just reported: put back a port that had already been closed, or name the
+  previous owner of a port that had just changed hands. Measured over 25 seconds of ordinary
+  traffic on a test machine, that happened **919 times**. Each one is a short window (up to about
+  0.4 s) in which the Connections table shows the wrong process for a flow - and, if you are aiming
+  at a process, in which a brand-new UDP exchange or a fresh connection can be judged against the
+  wrong application: either your target's traffic slips through, or somebody else's gets impaired.
+  Readings are now weighed by when they were actually taken, so the older one no longer wins. The
+  sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
+  from a socket event lost under heavy load.
+
 - **Aiming at a process did not touch the first packet of a UDP exchange - and for DNS and QUIC
   that meant it did not touch them at all.** Working out which connections belong to your target
   means keeping a set of its ports, rebuilt in the background, and a brand-new port is not in it

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -1032,7 +1032,10 @@ class BeanEngine:
         # session are known from the first packet (events only announce NEW sockets).
         with crashlog.quiet("engine.socketwatch.bootstrap"):
             self._ports.refresh(force=True)
-            watcher.reconcile(self._ports.snapshot())
+            # collected(), not snapshot(): the watcher weighs this data against what
+            # its own events say, so it needs to know WHEN the data was gathered.
+            ports, collected_at = self._ports.collected()
+            watcher.reconcile(ports, collected_at)
         try:
             watcher.start()
             self._socketwatch = watcher
@@ -1275,8 +1278,14 @@ class BeanEngine:
                 # missed CLOSE ages out and a connection open before the watcher (or
                 # dropped under load) is still picked up. The events are the live
                 # signal; this is the belt to their braces.
+                #
+                # Half of these ticks hand over a snapshot the PREVIOUS tick already
+                # applied (measured: 10 of 20, because refresh_if_stale rebuilds every
+                # 0.30 s while this loop runs every 0.20 s), so the collection time
+                # travels with the data - see SocketWatcher.reconcile.
                 if self._socketwatch is not None:
-                    self._socketwatch.reconcile(self._ports.snapshot())
+                    ports, collected_at = self._ports.collected()
+                    self._socketwatch.reconcile(ports, collected_at)
             except Exception as _exc:
                 crashlog.note(_exc, "engine.ports")
             try:

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -1283,9 +1283,15 @@ class BeanEngine:
                 # applied (measured: 10 of 20, because refresh_if_stale rebuilds every
                 # 0.30 s while this loop runs every 0.20 s), so the collection time
                 # travels with the data - see SocketWatcher.reconcile.
-                if self._socketwatch is not None:
+                #
+                # Read ONCE into a local, like _live_pid does: stop() clears this
+                # attribute from another thread, and reading it twice lets the
+                # second read be None. The AttributeError landed in the tick's
+                # except and left a crash record for an ORDINARY stop.
+                watcher = self._socketwatch
+                if watcher is not None:
                     ports, collected_at = self._ports.collected()
-                    self._socketwatch.reconcile(ports, collected_at)
+                    watcher.reconcile(ports, collected_at)
             except Exception as _exc:
                 crashlog.note(_exc, "engine.ports")
             try:

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -467,6 +467,29 @@ class PortTable:
         with self._lock:
             return dict(self._ports)
 
+    def collected(self):
+        """The port map AND the moment its data was collected, from ONE lock hold.
+
+        ``snapshot()`` answers "what does the table say". This answers "what did it
+        say, and how old is that" - which is a different question, asked by exactly
+        one caller: :meth:`beantester.socketwatch.SocketWatcher.reconcile` uses the
+        stamp to decide whether this data is allowed to overwrite something it
+        learned from a live SOCKET event.
+
+        The two values MUST come from one lock hold. Taking the map and then asking
+        for the timestamp separately lets a refresh land in between, which stamps
+        OLD data with a NEW time - and given what the caller does with the stamp,
+        that is the one error direction that silently reintroduces the bug.
+
+        ``_last`` is the moment the collection STARTED, not the moment it was
+        installed: ``refresh()`` reads ``now`` before the ``iphlpapi`` calls and
+        only assigns it at the end. So this UNDER-states how fresh the map is
+        rather than over-stating it, which is the safe direction here - a tie, or
+        a doubt, resolves in favour of the live event stream.
+        """
+        with self._lock:
+            return dict(self._ports), self._last
+
     def pid_for(self, port):
         if port is None:
             return None

--- a/beantester/socketwatch.py
+++ b/beantester/socketwatch.py
@@ -57,6 +57,35 @@ What it is NOT
   signal, the snapshot is the safety net. ``reconcile`` prunes a port the snapshot
   no longer lists only after it has been absent for TWO passes, so a socket opened
   microseconds before the snapshot was taken is not evicted by it.
+
+  **The snapshot is COMPLETE, not CURRENT, and the difference is load-bearing.**
+  It is collected up to ``portmap.REFRESH_S`` before it is handed over and applied
+  up to a watchdog tick later, so it always describes a slightly older world than
+  the event stream does. An earlier version of this module merged it
+  unconditionally and called it "authoritative", which read "complete" as "newest"
+  and let it undo work the events had already done.
+
+  MEASURED on a live session (2026-07-29, real SOCKET handle, 887 connections in
+  25 s, 123 reconciles): **919 writes the old rule would have made are refused by
+  this one**, each a snapshot entry for a port an event had touched 0-170 ms AFTER
+  that snapshot was walked. Some put back a port a CLOSE had removed, some named
+  the previous owner of a port that had changed hands (port 67 was seen going
+  ``3040 -> 4616`` and being reverted). Every one is a window in which
+  ``engine._pid_for`` and ``targeting.owner_targeted`` answer with a pid that is
+  not the owner - the second of those being the gate for a TCP SYN and for every
+  UDP datagram. The count is the difference between the two rules, taken directly;
+  an earlier attempt to count "resurrections" by watching ports come back was
+  discarded because it cannot tell a resurrected socket from the same process
+  reopening a recycled port, and it over-reported by roughly a third.
+
+  So every entry carries the time of the evidence behind it (``_evidence``), and a
+  snapshot entry is applied only when the snapshot was COLLECTED after that. The
+  three cases fall out of the one rule instead of being tuned: a newer event beats
+  an older snapshot, a CLOSE is not undone by an older snapshot, and a snapshot
+  taken *after* the last event still heals an entry whose CLOSE we missed - which
+  is the reason the simpler rule ("events always win") was rejected. ``_evidence``
+  also holds TOMBSTONES for closed ports, because "closed just now" and "never
+  seen" are only distinguishable if the close left a mark.
 """
 import threading
 import time
@@ -78,6 +107,12 @@ _ADD = frozenset({BIND, CONNECT, LISTEN, ACCEPT})
 # a packet cannot tell us is the owning pid, which is exactly what is left here.
 SocketEvent = namedtuple("SocketEvent", "kind pid local_port")
 
+# "no event has ever touched this port". Deliberately -inf and not 0.0: a
+# ``PortTable`` that has never refreshed reports a collection time of 0.0, and
+# with 0.0 as the default the bootstrap reconcile would compare 0.0 < 0.0, decide
+# its own snapshot was too old, and seed nothing at all.
+_NEVER = float("-inf")
+
 
 class SocketWatcher:
     """A live ``local_port -> pid`` map maintained from socket-layer events."""
@@ -94,6 +129,11 @@ class SocketWatcher:
         self.clock = clock
         self._lock = threading.RLock()
         self._ports = {}                 # local_port -> pid (the live map)
+        # local_port -> when an EVENT last said something about this port. Held for
+        # ports in the map AND for recently closed ones (tombstones), so reconcile
+        # can tell "closed since your snapshot" from "never seen". Read and written
+        # under _lock only - never by pid_for, so the packet path pays nothing.
+        self._evidence = {}
         self._suspect = set()            # ports absent from the last snapshot (grace)
         self._source = None
         self._thread = None
@@ -110,23 +150,57 @@ class SocketWatcher:
         with self._lock:
             if ev.kind in _ADD:
                 self._ports[port] = pid
+                self._evidence[port] = self.clock()
             elif ev.kind == CLOSE:
                 # pid-checked: a late CLOSE for a port the OS has already handed to
                 # a DIFFERENT process must not evict the new owner. Windows reuses
                 # both PIDs and ports, so "same port" is not "same socket".
                 if self._ports.get(port) == pid:
                     del self._ports[port]
+                # Stamped even when the pid did NOT match, and even though the map
+                # did not change: the driver still told us something current about
+                # this port, and the stamp is about how fresh our knowledge is, not
+                # about whether it moved. It is what stops an older snapshot from
+                # resurrecting the socket this event just closed - the tombstone.
+                self._evidence[port] = self.clock()
+            # An event kind this map does not model leaves no evidence: blocking a
+            # snapshot on the strength of something we did not act on would be
+            # claiming knowledge we do not have.
             self._events += 1
 
-    def reconcile(self, port_pid):
+    def reconcile(self, port_pid, collected_at):
         """Merge a socket-table snapshot in (bootstrap + safety net).
 
-        The snapshot (``portmap`` -> ``GetExtendedTcp/UdpTable``) is the complete,
-        current list of OPEN sockets, so it is authoritative for what should be in
-        the map; the events keep it live between snapshots. Ports the snapshot no
-        longer lists are pruned only after being absent for TWO reconciles running,
-        which spares a socket opened microseconds before the snapshot was taken
-        (present via its event, not yet in that snapshot) from being evicted by it.
+        ``collected_at`` is when the snapshot's DATA was gathered - not when this
+        call happens. Ask ``portmap.PortTable.collected()`` for the pair; the two
+        must come from one lock hold, or the stamp can run ahead of its own data.
+        There is deliberately NO default: a caller that forgets it must fail loudly
+        at the call, because both call sites sit inside exception handlers
+        (``crashlog.quiet`` at bootstrap, the watchdog's ``except`` per tick) that
+        would otherwise turn a missing argument into "the safety net silently
+        stopped running" - which looks exactly like a healthy session.
+
+        The snapshot (``portmap`` -> ``GetExtendedTcp/UdpTable``) is the COMPLETE
+        list of open sockets as of ``collected_at``. Complete is not current: see
+        the module docstring for what merging it unconditionally cost (1394
+        resurrections and 11 owner reverts in 25 s, measured on a live session). So
+        a snapshot entry is applied only when the snapshot was collected AFTER
+        whatever an event last told us about that port, and a port an event touched
+        since then does not count as "absent" either - the snapshot never had a
+        chance to see it, so its silence says nothing.
+
+        The two-pass grace SURVIVES that rule rather than being replaced by it. The
+        collection itself takes time, so a socket opened during it can be newer than
+        ``collected_at`` by microseconds and still be missing from the result; the
+        grace is the belt to the stamp's braces. Ports the snapshot no longer lists
+        are therefore pruned only after being absent - and legitimately absent - for
+        TWO reconciles running.
+
+        ``_evidence`` is rebuilt here rather than growing forever: a tombstone is
+        kept while it can still veto a snapshot (its stamp is newer than this one),
+        and dropped once a snapshot collected after the close has agreed the port is
+        gone. Its size is therefore (open sockets + the churn of one refresh
+        interval), not (every socket this session ever saw).
 
         The new state is built to the side and PUBLISHED BY REASSIGNMENT rather than
         mutated in place, because ``pid_for`` reads this map WITHOUT a lock from the
@@ -135,14 +209,22 @@ class SocketWatcher:
         """
         with self._lock:
             merged = dict(self._ports)
+            evidence = self._evidence
             for port, pid in port_pid.items():
-                if port and pid and pid > 0:
+                if (port and pid and pid > 0
+                        and evidence.get(port, _NEVER) < collected_at):
                     merged[port] = pid
-            absent = set(merged) - set(port_pid)
+            # Absent AND stale: a port an event touched after this snapshot was
+            # collected is not missing from it, it is younger than it.
+            absent = {port for port in merged
+                      if port not in port_pid
+                      and evidence.get(port, _NEVER) < collected_at}
             doomed = absent & self._suspect          # absent twice running
             for port in doomed:
                 merged.pop(port, None)
             self._suspect = absent - doomed          # first-time absentees wait one pass
+            self._evidence = {port: at for port, at in evidence.items()
+                              if port in merged or at >= collected_at}
             self._ports = merged                     # atomic swap for lock-free readers
             self._reconciles += 1
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,14 +4,19 @@ Ported 1:1 from the original monolithic suite; every ``check(...)`` from the
 270-assertion baseline is preserved as a pytest assertion.
 """
 import os
+import random
 import re
 import time
 
+import pytest
+
 from beantester import BeanEngine
+from beantester.core import BeanCore
 from beantester.engine import (DROP_BY_REASON, IMPAIRMENT_DROP_KEYS, TOOL_DROP_KEYS,
                                impairment_loss_pct)
+from beantester.settings import DEFAULT_SETTINGS, apply_settings
 from beantester.synthetic import SyntheticDivert
-from fakes import FakeDivert, FakePacket, check
+from fakes import FakeDivert, FakePacket, FakeTCP, check
 
 
 
@@ -541,6 +546,238 @@ def test_every_drop_counter_and_drop_reason_is_classified():
     check("every drop reason decide() can give routes to a counter",
           not (reasons - set(DROP_BY_REASON)),
           f"(unrouted: {sorted(reasons - set(DROP_BY_REASON))})")
+
+
+MIXED_TRAFFIC_COMBOS = {
+    "passthrough": {},
+    "loss": dict(loss=50),
+    "corrupt": dict(corrupt=100),
+    "duplication": dict(dup=100),
+    "duplication+loss": dict(dup=100, loss=30),
+    "latency+jitter": dict(latency=5, jitter=3),
+    "bandwidth": dict(down=8, up=8),
+    "bandwidth+duplication": dict(down=8, up=8, dup=100),
+    "schedule": dict(rate_schedule="1:8:8,1:64:64"),
+    "syn drop": dict(syn_drop=100),
+    "mtu": dict(max_size=200),
+    "nat": dict(nat_timeout=0.001),
+    "rst": dict(rst_prob=100, rst_cooldown=0.5),
+    "flap": dict(flap_period=0.02, flap_down=50),
+    "lan mode": dict(lan_mode=True),
+    "block": dict(block_ip="8.8.8.8", block_port="443"),
+    "destination target": dict(dst_ip="1.1.1.1", loss=100),
+    "everything at once": dict(loss=20, corrupt=20, dup=20, latency=3, jitter=2,
+                               spike_prob=20, spike_ms=5, down=32, up=32,
+                               syn_drop=50, max_size=1200, nat_timeout=0.01,
+                               rst_prob=20, rst_cooldown=0.2, flap_period=0.05,
+                               flap_down=30, block_port="8080"),
+    "everything + lan": dict(loss=20, dup=20, latency=2, lan_mode=True,
+                             rst_prob=20, syn_drop=50, max_size=1200),
+}
+
+
+def _mixed_traffic(n):
+    """TCP (some of it SYN), UDP and ICMP, both directions, several peers and sizes.
+
+    A single-protocol stream cannot reach most of the pipeline: SYN dropping needs
+    a SYN, the RST path needs TCP, LAN mode needs a public *and* a private peer,
+    and the MTU gate needs sizes on both sides of the limit.
+    """
+    peers = ["8.8.8.8", "1.1.1.1", "192.168.0.5", "10.0.0.9"]
+    out = []
+    for i in range(n):
+        proto = ("tcp", "tcp", "tcp", "udp", "icmp")[i % 5]
+        syn = proto == "tcp" and i % 11 == 0
+        p = FakePacket(size=64 + (i % 7) * 300, is_outbound=(i % 3 != 0),
+                       src_port=5000 + (i % 4), dst_port=(443, 53, 80, 8080)[i % 4],
+                       dst_addr=peers[i % 4], src_addr="10.0.0.2", syn=syn)
+        if proto == "tcp":
+            p.tcp = FakeTCP(syn=syn)
+            p.tcp.ack, p.tcp.seq_num, p.tcp.ack_num = not syn, 1000, 2000
+            p.udp = p.icmp = None
+        elif proto == "udp":
+            p.tcp = p.icmp = None
+            p.udp = object()
+        else:
+            p.tcp = p.udp = None
+            p.icmp = object()
+        out.append(p)
+    return out
+
+
+@pytest.mark.parametrize("name", sorted(MIXED_TRAFFIC_COMBOS))
+def test_every_captured_packet_is_accounted_for_under_every_impairment(name):
+    """seen == delivered + everything that killed a packet, with the impairments ON.
+
+    The existing balance test (test_inject_batch.py) drives a PASS-THROUGH session:
+    it sums four of the twelve loss counters, because the other eight are zero when
+    nothing is configured. So the invariant was guarded exactly where it is hardest
+    to break. Here every gate in the pipeline is armed in turn, plus one run with
+    all of them at once.
+
+    Delivered is counted as DISTINCT packet objects, not sends: duplication puts
+    the same packet on the wire twice, and the question this asserts is what became
+    of each CAPTURED packet. The queue is left at its default so nothing overflows
+    - an overflowed original whose duplicate still got through is a known,
+    documented double-count (see _enqueue) and a different subject.
+    """
+    n = 200
+    engine = BeanEngine()
+    engine.set_seed(4242)                 # random gates; unseeded this flakes on CI
+    apply_settings(engine, dict(DEFAULT_SETTINGS, **MIXED_TRAFFIC_COMBOS[name]))
+    divert = FakeDivert(_mixed_traffic(n))
+    engine.start("test", divert=divert)
+    deadline = time.time() + 15
+    while time.time() < deadline and engine.stats_snapshot()["seen"] < n:
+        time.sleep(0.01)
+    time.sleep(0.3)                       # let the delayed releases drain
+    engine.stop()                         # ...and account for whatever is still parked
+
+    s = engine.stats_snapshot()
+    delivered = len({id(p) for _, p in divert.sent})
+    killed = sum(s[k] for k in IMPAIRMENT_DROP_KEYS) + sum(s[k] for k in TOOL_DROP_KEYS)
+    check(f"[{name}] everything offered was captured", s["seen"] == n, f"({s['seen']})")
+    check(f"[{name}] no packet vanished from the books",
+          delivered + killed == s["seen"],
+          f"(delivered={delivered} killed={killed} seen={s['seen']} "
+          f"dup={s['duplicated']} overflow={s['drop_overflow']})")
+    check(f"[{name}] and nothing was counted twice", s["drop_overflow"] == 0,
+          "(the queue overflowed - this run cannot answer the question)")
+
+
+def test_a_dropped_packet_is_always_in_impairment_scope():
+    """The premise the loss figure rests on, asserted instead of assumed.
+
+    ``impairment_loss_pct`` divides every drop by ``scoped_seen`` and its docstring
+    says the result "cannot exceed 100%". That is only true because every drop in
+    ``decide()`` happens AFTER the targeting gates, so a dropped packet is always a
+    scoped one. Nothing checked it, and a new impairment placed ABOVE the gates
+    would break the figure rather than the pipeline - silently, because the number
+    would still look like a percentage.
+    """
+    rng = random.Random(7)
+    seen = set()
+    for trial in range(400):
+        core = BeanCore()
+        core.reset_buckets(0.0)
+        core.set_params(rng.choice([0, 50, 100]), 0, rng.choice([0, 100]),
+                        0, 0, rng.choice([0, 8]), rng.choice([0, 8]))
+        core.set_advanced(rng.choice([0, 100]), rng.choice([0, 200]))
+        core.set_nat(rng.choice([0, 0.001]))
+        core.set_rst(rng.choice([0, 100]), 0.5)
+        core.set_flap(True, 0.02, rng.choice([0, 50]))
+        core.set_lan(rng.random() < 0.5)
+        core.set_block(True, rng.choice(["", "8.8.8.8"]), rng.choice(["", "443"]))
+        core.set_target(rng.random() < 0.5, {5000})
+        core.set_dest(rng.random() < 0.5, rng.choice(["", "8.8.8.8"]),
+                      rng.choice(["", "443"]))
+        for step in range(6):
+            d = core.decide(rng.choice([64, 1400]), rng.random() < 0.5,
+                            rng.choice([5000, 5001]), trial + step * 0.5, rng,
+                            remote_ip=rng.choice(["8.8.8.8", "192.168.0.5"]),
+                            remote_port=rng.choice([443, 8080]),
+                            is_syn=rng.random() < 0.2, is_tcp=rng.random() < 0.7)
+            if d.drop:
+                seen.add(d.reason)
+            check("a dropped packet is never out of scope",
+                  not (d.drop and not d.scoped),
+                  f"(reason={d.reason!r})")
+    check("the sweep actually armed several gates", len(seen) >= 4,
+          f"(reasons hit: {sorted(seen, key=str)})")
+
+
+@pytest.mark.parametrize("name", ["loss", "bandwidth", "everything at once"])
+def test_the_loss_figure_stays_a_percentage_with_a_target_set(name):
+    """The other half: end to end, with targeting narrowing the denominator.
+
+    Targeting is what made this worth guarding - ``scoped_seen`` is smaller than
+    ``seen``, so an unscoped drop would push the figure straight past 100%.
+
+    MEASURED by mutation, and worth saying plainly: this test is the weaker of the
+    two. Marking the LAN gate's drop unscoped is caught by
+    ``test_a_dropped_packet_is_always_in_impairment_scope`` and NOT by this one -
+    an out-of-scope drop shrinks the denominator without necessarily pushing the
+    ratio over 1.0 on any given traffic mix. So the structural test is the guard;
+    this is the end-to-end sanity check that the two agree in a real session.
+    """
+    n = 200
+    engine = BeanEngine()
+    engine.set_seed(99)
+    engine.set_target(True, {5000, 5001})          # half the traffic is out of scope
+    apply_settings(engine, dict(DEFAULT_SETTINGS, **MIXED_TRAFFIC_COMBOS[name]))
+    engine.set_target(True, {5000, 5001})          # apply_settings clears it: re-arm
+    divert = FakeDivert(_mixed_traffic(n))
+    engine.start("test", divert=divert)
+    deadline = time.time() + 15
+    while time.time() < deadline and engine.stats_snapshot()["seen"] < n:
+        time.sleep(0.01)
+    time.sleep(0.3)
+    engine.stop()
+
+    s = engine.stats_snapshot()
+    pct = impairment_loss_pct(s)
+    check(f"[{name}] the denominator really was narrowed",
+          0 < s["scoped_seen"] < s["seen"], f"({s['scoped_seen']}/{s['seen']})")
+    check(f"[{name}] the loss figure is a percentage", 0.0 <= pct <= 100.0,
+          f"(pct={pct} scoped_seen={s['scoped_seen']} "
+          f"drops={ {k: s[k] for k in IMPAIRMENT_DROP_KEYS if s[k]} })")
+
+
+def test_nat_and_rst_survive_being_switched_off_and_on_mid_session():
+    """Every GUI "Apply" re-runs every setter, so a live session toggles these
+    constantly - and both keep state (a flow table of last-seen stamps, a table of
+    cooldown deadlines) that a naive toggle could strand. Nothing exercised the
+    second and third call.
+    """
+    core = BeanCore()
+    core.reset_buckets(0.0)
+    flow = dict(remote_ip="8.8.8.8", remote_port=443)
+    rng = random.Random(0)
+
+    def inbound(t):
+        return core.decide(100, False, 5000, t, rng, is_tcp=True, **flow)
+
+    def outbound(t):
+        return core.decide(100, True, 5000, t, rng, is_tcp=True, **flow)
+
+    core.set_nat(5.0)
+    outbound(0.0)                                   # the mapping is created here
+    check("NAT expires the mapping while it is on", inbound(10.0).reason == "nat")
+
+    core.set_nat(0.0)                               # switched OFF mid-session
+    check("with NAT off the direction is open again", inbound(20.0).drop is False)
+
+    core.set_nat(5.0)                               # ...and ON again
+    outbound(30.0)
+    check("NAT still expires after being toggled off and on",
+          inbound(40.0).reason == "nat", "(the flow table was stranded by the toggle)")
+
+    # RST: the cooldown is a deadline held per flow, so shortening it must be felt
+    core2 = BeanCore()
+    core2.reset_buckets(0.0)
+    core2.set_nat(0.0)
+    core2.set_rst(100, 3600)                        # an hour-long hold
+    old = core2.decide(100, True, 6000, 0.0, rng, is_tcp=True, remote_ip="1.1.1.1",
+                       remote_port=80)
+    check("the reset fired", old.emit_rst is True and old.reason == "rst")
+
+    core2.set_rst(100, 0.5)                         # shortened mid-session
+    fresh = core2.decide(100, True, 6001, 1.0, rng, is_tcp=True, remote_ip="1.1.1.1",
+                         remote_port=81)
+    check("a new flow gets the reset too", fresh.reason == "rst")
+
+    # Stop new resets from firing, or the probability would re-arm the flow the
+    # instant its cooldown lapsed and the next check could not tell "still held"
+    # from "hit again" - which is exactly what an earlier version of this test did.
+    core2.set_rst(0, 0.5)
+    check("a flow reset AFTER the change is held for the SHORT cooldown",
+          core2.decide(100, True, 6001, 2.0, rng, is_tcp=True, remote_ip="1.1.1.1",
+                       remote_port=81).drop is False,
+          "(1.5 s deadline ignored - the toggle stranded the cooldown table)")
+    check("...while one already held keeps the deadline it was given",
+          core2.decide(100, True, 6000, 2.0, rng, is_tcp=True, remote_ip="1.1.1.1",
+                       remote_port=80).reason == "rst",
+          "(shortening retroactively released a connection already cut)")
 
 
 class IcmpPacket:

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -627,6 +627,35 @@ def test_the_socket_table_is_collected_without_holding_the_lock():
           probed.get("free") is True, f"({probed})")
 
 
+def test_collected_hands_over_the_map_and_when_it_was_gathered_together():
+    """``collected()`` exists because ``SocketWatcher.reconcile`` has to weigh this
+    data against what its own SOCKET events say, and cannot do that without knowing
+    how old the data is.
+
+    Two properties, and the second is the one that matters: the stamp must be the
+    moment the collection STARTED, never later than that. A stamp that ran ahead of
+    its own data would let a stale walk out-rank a fresh event, which is exactly the
+    bug the caller uses this to avoid.
+    """
+    from beantester import portmap
+
+    table = portmap.PortTable(clock=time.monotonic)
+    before = time.monotonic()
+    table.refresh(force=True)
+    after = time.monotonic()
+
+    ports, at = table.collected()
+    check("the map is the same one snapshot() reports", ports == table.snapshot(),
+          f"({len(ports)} vs {len(table.snapshot())})")
+    check("the stamp is not newer than the moment the collection began",
+          before <= at <= after, f"(before={before} at={at} after={after})")
+
+    # ...and it does not drift on a call that decided not to refresh
+    again, at_again = table.collected()
+    check("a second call reports the same collection", at_again == at,
+          f"({at_again} vs {at})")
+
+
 def test_an_older_collection_does_not_overwrite_a_newer_map():
     """Collecting outside the lock lets two refreshes overlap, so a slow one must not
     move the map BACKWARDS when it finishes late.

--- a/tests/test_socketwatch.py
+++ b/tests/test_socketwatch.py
@@ -61,8 +61,29 @@ def _wait(predicate, timeout=5.0):
     return False
 
 
-def _watcher():
-    return SocketWatcher(names=_FakeNames())
+class _Clock:
+    """A hand-driven clock.
+
+    Every reconcile test below turns on WHICH came first - the event or the
+    snapshot's collection - so that ordering has to be a fact of the test, not a
+    race against the real ``time.monotonic()``. (Its resolution here is ~100 ns,
+    but a test that would go red on a coarser clock is a test that reports the
+    machine instead of the code.)
+    """
+
+    def __init__(self, t=1000.0):
+        self.t = float(t)
+
+    def __call__(self):
+        return self.t
+
+    def tick(self, dt=1.0):
+        self.t += dt
+        return self.t
+
+
+def _watcher(clock=None):
+    return SocketWatcher(names=_FakeNames(), clock=clock or time.monotonic)
 
 
 # -- the map ------------------------------------------------------------------ #
@@ -115,31 +136,181 @@ def test_reconcile_bootstraps_and_prunes_only_after_a_two_pass_grace():
     """The snapshot seeds the map and catches missed CLOSEs - but a socket opened
     microseconds before the snapshot was taken (present via its event, absent from
     that snapshot) must survive one miss, or the safety net would evict live
-    connections."""
-    w = _watcher()
-    w.reconcile({80: 1, 443: 2})                      # bootstrap
+    connections.
+
+    Both later snapshots are collected AFTER the event on purpose: that is the
+    residual case the grace exists for. A snapshot collected BEFORE the event is a
+    different scenario entirely and is covered by
+    ``test_a_port_an_event_touched_after_the_collection_is_never_counted_absent``.
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    w.reconcile({80: 1, 443: 2}, clock())             # bootstrap
     check("bootstrap added the snapshot", w.snapshot() == {80: 1, 443: 2})
 
     w.apply(ev(CONNECT, 9, 5000))                     # a fresh socket via its event
     check("event added the fresh port", w.snapshot().get(5000) == 9)
 
-    w.reconcile({80: 1, 443: 2})                      # snapshot has not caught 5000 yet
+    # collected a hair AFTER the event, and it still missed the port: the socket
+    # opened while the table walk was in flight
+    w.reconcile({80: 1, 443: 2}, clock.tick())
     check("fresh port survives ONE absent snapshot", w.snapshot().get(5000) == 9,
           f"({w.snapshot()})")
 
-    w.reconcile({80: 1, 443: 2})                      # still absent -> missed-CLOSE case
+    w.reconcile({80: 1, 443: 2}, clock.tick())        # still absent -> missed-CLOSE case
     check("absent-twice port is pruned", 5000 not in w.snapshot(), f"({w.snapshot()})")
     check("snapshot ports are always kept", w.snapshot() == {80: 1, 443: 2})
 
 
 def test_reconcile_grace_resets_when_a_port_reappears():
-    w = _watcher()
+    clock = _Clock()
+    w = _watcher(clock)
     w.apply(ev(CONNECT, 9, 5000))
-    w.reconcile({})                                   # absent once (on watch)
-    w.reconcile({5000: 9})                            # reappears -> cleared
-    w.reconcile({})                                   # absent once again, not twice running
+    w.reconcile({}, clock.tick())                     # absent once (on watch)
+    w.reconcile({5000: 9}, clock.tick())              # reappears -> cleared
+    w.reconcile({}, clock.tick())                     # absent once again, not twice running
     check("a port that reappeared is not pruned on a single later miss",
           w.snapshot().get(5000) == 9, f"({w.snapshot()})")
+
+
+# -- reconcile: the snapshot is COMPLETE, not CURRENT (F2) --------------------- #
+def test_a_newer_event_is_not_undone_by_an_older_snapshot():
+    """The socket table is collected up to REFRESH_S before it is handed over, so
+    it can still name the PREVIOUS owner of a recycled port. Merging it blindly put
+    that owner back - measured 11 times in 25 s on a live session, on ordinary
+    Windows background traffic (137/138/1900/67).
+
+    Consequence if this regresses: engine._pid_for stamps the connection row with a
+    process that does not own the socket, and targeting.owner_targeted - the gate
+    for a TCP SYN and for EVERY UDP datagram - answers about the wrong process.
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    stale = clock()                                   # the table is walked HERE...
+    clock.tick()
+    w.apply(ev(CLOSE, 111, 50000))                    # ...and only then does the
+    w.apply(ev(CONNECT, 222, 50000))                  #    port change hands
+    check("the event stream has the live answer", w.pid_for(50000) == 222)
+
+    w.reconcile({50000: 111}, stale)                  # the stale walk, handed over late
+    check("an older snapshot does not revert the owner", w.pid_for(50000) == 222,
+          f"(pid_for={w.pid_for(50000)})")
+
+
+def test_a_port_known_only_from_a_connect_still_outranks_an_older_snapshot():
+    """The stamp an ADD event leaves is load-bearing on its own.
+
+    Written because a MUTANT SURVIVED: stripping the stamp from the ADD branch left
+    the handover test above green, because that one is carried by the CLOSE's
+    tombstone. This is the case where a CONNECT is the only thing that ever spoke
+    about the port - the watcher saw the socket open while a table walk already in
+    flight still named the previous owner (we never got the CLOSE, which is the
+    documented "events can be missed under load" case).
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    stale = clock()                                   # the walk names the old owner
+    clock.tick()
+    w.apply(ev(CONNECT, 222, 50000))                  # the ONLY event for this port
+
+    w.reconcile({50000: 111}, stale)
+    check("a snapshot that predates the connect does not win",
+          w.pid_for(50000) == 222, f"(pid_for={w.pid_for(50000)})")
+
+
+def test_a_closed_port_is_not_resurrected_by_an_older_snapshot():
+    """The same defect from its commonest side, and it does not need a recycled
+    port - only a close. A CLOSE event removes the port; a snapshot collected
+    before that close still lists it, and used to put it straight back. Measured on
+    a live session: 1394 resurrections in 25 s across 896 connections, each leaving
+    the map naming a pid that had already let the socket go.
+
+    This is what the tombstone in ``_evidence`` is for: without a mark, "closed a
+    moment ago" and "never seen" are the same absence.
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    w.apply(ev(CONNECT, 111, 50000))
+    stale = clock.tick()                              # snapshot walked while it was open
+    clock.tick()
+    w.apply(ev(CLOSE, 111, 50000))
+    check("the close removed the port", w.pid_for(50000) is None)
+
+    w.reconcile({50000: 111}, stale)
+    check("an older snapshot does not resurrect a closed port",
+          w.pid_for(50000) is None, f"(pid_for={w.pid_for(50000)})")
+
+
+def test_a_snapshot_taken_after_the_event_still_heals_a_stale_entry():
+    """The guard against fixing this too hard.
+
+    "Events always win" was the smaller change and it was rejected here: socket
+    events CAN be missed under load, and if we then also miss the new owner's
+    CONNECT, the map keeps a dead pid that the prune will never take (the port is
+    in every snapshot, so it is never absent). The snapshot has to stay able to
+    correct the map - just not with data older than what it is correcting.
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    w.apply(ev(CONNECT, 111, 50000))                  # ...and we miss its CLOSE, and
+    clock.tick()                                      #    the new owner's CONNECT
+    fresh = clock.tick()                              # a walk taken AFTER all that
+
+    w.reconcile({50000: 222}, fresh)
+    check("a snapshot newer than the event still heals the entry",
+          w.pid_for(50000) == 222, f"(pid_for={w.pid_for(50000)})")
+
+
+def test_a_port_an_event_touched_after_the_collection_is_never_counted_absent():
+    """The stamp gates the PRUNE too, not only the merge.
+
+    A snapshot cannot vouch for a socket that did not exist when it was walked, so
+    its silence about that port says nothing and must not spend one of the two
+    grace passes. Before this, the port's survival rested on WATCHDOG_TICK_S (0.2)
+    and portmap.REFRESH_S (0.3) interleaving so that two stale reconciles never ran
+    back to back - arithmetic that nothing stated and nothing tested.
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    stale = clock()                                   # walked before the socket existed
+    clock.tick()
+    w.apply(ev(CONNECT, 9, 5000))
+
+    w.reconcile({}, stale)                            # three passes of the SAME old walk
+    w.reconcile({}, stale)
+    w.reconcile({}, stale)
+    check("a port younger than the snapshot is not pruned by it",
+          w.pid_for(5000) == 9, f"({w.snapshot()})")
+
+    w.reconcile({}, clock.tick())                     # a walk that really did miss it
+    w.reconcile({}, clock.tick())
+    check("...but a snapshot newer than the event still prunes it after two passes",
+          w.pid_for(5000) is None, f"({w.snapshot()})")
+
+
+def test_the_evidence_map_does_not_grow_with_every_connection_ever_seen():
+    """Tombstones are bounded, or a browser would leak one entry per closed socket.
+
+    A tombstone is kept only while it can still veto a snapshot; once a snapshot
+    collected AFTER the close has agreed the port is gone, it is dropped. So the
+    steady state is (open sockets + one refresh interval of churn), not (every
+    socket this session ever saw).
+    """
+    clock = _Clock()
+    w = _watcher(clock)
+    for i in range(500):                              # 500 short-lived connections
+        w.apply(ev(CONNECT, 100, 6000 + i))
+        w.apply(ev(CLOSE, 100, 6000 + i))
+        clock.tick()
+    w.apply(ev(CONNECT, 100, 5000))                   # one that stays open
+    check("tombstones piled up while no snapshot had caught up",
+          len(w._evidence) > 100, f"({len(w._evidence)})")
+
+    w.reconcile({5000: 100}, clock.tick())            # a walk newer than every close
+    check("the map itself holds only the live socket", w.snapshot() == {5000: 100},
+          f"({w.snapshot()})")
+    check("and the evidence map collapsed to it", set(w._evidence) == {5000},
+          f"({len(w._evidence)} entries)")
 
 
 # -- name resolution is delegated, not duplicated ----------------------------- #
@@ -255,10 +426,11 @@ def test_pid_for_takes_no_lock_because_the_capture_thread_calls_it():
 def test_reconcile_publishes_a_new_map_instead_of_mutating_in_place():
     """The identity swap is what makes the lock-free read safe across an O(n) pass:
     mutating in place would let a reader observe half a reconcile."""
-    w = _watcher()
+    clock = _Clock()
+    w = _watcher(clock)
     w.apply(ev(CONNECT, 100, 5000))
     before = w._ports
-    w.reconcile({5000: 100, 80: 1})
+    w.reconcile({5000: 100, 80: 1}, clock.tick())
     check("reconcile published a NEW dict", w._ports is not before)
     check("with the merged content", w.snapshot() == {5000: 100, 80: 1},
           f"({w.snapshot()})")
@@ -270,7 +442,8 @@ def test_a_lock_free_reader_survives_writes_in_flight():
     while another inserts, deletes and republishes the whole map underneath it. A torn
     read would surface as an exception, or as a value that is neither the pid nor None.
     """
-    w = _watcher()
+    clock = _Clock()
+    w = _watcher(clock)
     w.apply(ev(CONNECT, 100, 5000))
     errors, values, reads = [], set(), [0]
     stop = threading.Event()
@@ -289,7 +462,9 @@ def test_a_lock_free_reader_survives_writes_in_flight():
         for i in range(300):
             w.apply(ev(CONNECT, 100 + (i % 7), 6000 + i))     # inserts...
             w.apply(ev(CLOSE, 100 + (i % 7), 6000 + i))       # ...and deletes
-            w.reconcile({5000: 100, 80: 1})                   # whole-map republish
+            # the clock advances, so this also drives the tombstone rebuild - the
+            # other O(n) pass a lock-free reader has to survive
+            w.reconcile({5000: 100, 80: 1}, clock.tick())     # whole-map republish
     finally:
         stop.set()
         t.join(timeout=5)

--- a/tests/test_socketwatch_wiring.py
+++ b/tests/test_socketwatch_wiring.py
@@ -63,6 +63,12 @@ class _FakePorts:
     def snapshot(self):
         return dict(self._ports)
 
+    def collected(self):
+        # This fake's map is a fixed dict, so it is always current - "collected
+        # now" is the honest stamp. The engine needs the pair because the watcher
+        # weighs a snapshot against its own events (see SocketWatcher.reconcile).
+        return dict(self._ports), time.monotonic()
+
     def warm_names(self):
         pass
 
@@ -125,6 +131,31 @@ def test_a_watcher_that_cannot_open_degrades_instead_of_killing_the_session():
     try:
         check("the session survived the failed watcher", eng.is_running())
         check("and fell back to no watcher", eng._socketwatch is None)
+    finally:
+        eng.stop()
+
+
+def test_the_watchdog_keeps_reconciling_the_live_map():
+    """The safety net has to be seen RUNNING, not assumed to be.
+
+    Both reconcile call sites sit inside exception handlers - ``crashlog.quiet`` at
+    bootstrap, the watchdog's own ``except`` per tick - so anything that makes the
+    call raise (a signature the caller did not follow, a table double missing a
+    method) turns "the snapshot no longer corrects the map" into a session that
+    looks perfectly healthy: same counters, same log, no warning. That is the one
+    failure mode this wiring cannot report on its own, so it gets a witness.
+    """
+    eng = BeanEngine()
+    eng._ports = _FakePorts({80: 1})
+    src = _FakeSocketSource([ev(CONNECT, 100, 5000)])
+    eng.start("true", divert=FakeDivert([]), socket_source=src)
+    try:
+        w = eng._socketwatch
+        check("a watcher was started", w is not None)
+        first = w.reconciles
+        check("the watchdog reconciles while the session runs",
+              _wait(lambda: w.reconciles > first, timeout=3.0),
+              f"(stuck at {w.reconciles})")
     finally:
         eng.stop()
 

--- a/tests/test_socketwatch_wiring.py
+++ b/tests/test_socketwatch_wiring.py
@@ -12,7 +12,8 @@ socket source, so no WinDivert is needed.
 import threading
 import time
 
-from beantester.engine import BeanEngine
+from beantester import crashlog
+from beantester.engine import WATCHDOG_TICK_S, BeanEngine
 from beantester.socketwatch import BIND, CONNECT, SocketEvent
 from fakes import FakeDivert, FakePacket, check
 
@@ -158,6 +159,55 @@ def test_the_watchdog_keeps_reconciling_the_live_map():
               f"(stuck at {w.reconciles})")
     finally:
         eng.stop()
+
+
+def test_a_stop_landing_mid_tick_does_not_fault_the_watchdog():
+    """``stop()`` clears ``_socketwatch`` while the watchdog is inside a tick.
+
+    The tick used to read that attribute TWICE - once for the ``is not None``
+    guard, once to call ``reconcile`` - with a ``collected()`` call in between. A
+    stop landing in that gap turned an ordinary STOP into an ``AttributeError``,
+    swallowed by the tick's ``except`` and filed as a crash record. Nobody would
+    ever see it; it would just sit in ``crashes/`` making a clean shutdown look
+    like a fault.
+
+    The race is a few instructions wide, so it is not raced here - it is STAGED:
+    the port table clears the engine's reference from inside the very call that
+    sits between the two reads.
+    """
+    crashlog.reset()
+
+    class _ClearsTheWatcher(_FakePorts):
+        def __init__(self, ports, engine):
+            super().__init__(ports)
+            self._engine = engine
+            self.fired = False
+
+        def collected(self):
+            # Exactly where a concurrent stop() would land - but only once the
+            # WATCHDOG is the caller. _start_socketwatch bootstraps through this
+            # same method while _socketwatch is still None, and an earlier version
+            # of this test spent its one shot there: nothing was staged, and a
+            # mutant restoring the double read survived.
+            if not self.fired and self._engine._socketwatch is not None:
+                self.fired = True
+                self._engine._socketwatch = None
+            return super().collected()
+
+    eng = BeanEngine()
+    ports = _ClearsTheWatcher({80: 1}, eng)
+    eng._ports = ports
+    src = _FakeSocketSource([ev(CONNECT, 100, 5000)])
+    eng.start("true", divert=FakeDivert([]), socket_source=src)
+    try:
+        check("the staged stop was reached", _wait(lambda: ports.fired, timeout=3.0))
+        time.sleep(WATCHDOG_TICK_S * 2)     # let the tick finish and one more run
+    finally:
+        eng.stop()
+
+    torn = [r for r in crashlog.recent(50) if r.get("type") == "AttributeError"]
+    check("a stop landing mid-tick leaves no crash record", not torn,
+          f"({[r.get('message') for r in torn]})")
 
 
 class _GatedDivert:

--- a/tests/test_targeting_socketwatch.py
+++ b/tests/test_targeting_socketwatch.py
@@ -74,6 +74,10 @@ class _FakePorts:
     def snapshot(self):
         return dict(self._ports)
 
+    def collected(self):
+        # see the same method on test_socketwatch_wiring._FakePorts
+        return dict(self._ports), time.monotonic()
+
     def warm_names(self):
         pass
 


### PR DESCRIPTION
Audit finding **F2**, plus the watchdog TOCTOU it sat next to, plus three of the audit's test gaps.

## F2 - the live socket map could be dragged backwards

`SocketWatcher.reconcile()` merged the poller snapshot unconditionally, and its docstring called the snapshot *"authoritative"* - reading **complete** as **newest**. It is neither: it is collected up to `portmap.REFRESH_S` (0.30 s) before it is handed over and applied up to a watchdog tick (0.20 s) later.

**Measured: 10 of 20 watchdog ticks hand over a snapshot the previous tick already applied**, because those two intervals interleave that way. So the snapshot could undo what a SOCKET event had just reported - put back a port a CLOSE had removed, or name the previous owner of a port that had changed hands.

That map is read by `engine._pid_for` (the connection log's process/PID) and by `targeting.owner_targeted` - **the gate for a TCP SYN and for every UDP datagram**. So the window is one in which the wrong application gets impaired, or the right one is missed.

### The fix

Every entry carries the time of the evidence behind it (`_evidence`), including **tombstones** on CLOSE - without a mark, "closed a moment ago" and "never seen" are the same absence. A snapshot entry lands only when the snapshot was **collected** after that stamp, and the stamp gates the prune too: a port an event touched after the collection is not absent from that snapshot, it is younger than it. The two-pass grace survives alongside, because the collection itself takes time.

New `portmap.PortTable.collected()` returns `(map, collection time)` from **one lock hold** - taken separately, a refresh landing in between would stamp old data with a new time, which is the one error direction that silently reintroduces the bug. `collected_at` has no default on purpose: both call sites sit inside exception handlers, so a missing argument would read as *"the safety net silently stopped running"*.

`pid_for` is untouched - `_evidence` is read only under `_lock`, so the lock-free capture-thread path pays nothing by construction.

**Rejected: "events always win"** (the smaller change). With a missed CLOSE *and* a missed new CONNECT, nothing would ever heal a dead PID, since the port is in every snapshot and the prune can never take it. Guarded by its own test.

### Measured on a live session

Real SOCKET handle, 887 connections / 5232 events / 123 reconciles in 25 s:

- **919 writes the old rule would have made are refused**, each for a port an event touched 0-170 ms after that snapshot was walked
- **0 stale writes survive**

An earlier count of "1394 resurrections + 11 reverts" is superseded: that detector could not tell a resurrected socket from the same process reopening a recycled port, and over-reported by about a third. A separate check confirmed the socket table drops a port immediately on `close()` (pid `None` at +0.0 s), so lingering TCP teardown is not an explanation for what remains.

## Watchdog TOCTOU

The tick read `self._socketwatch` twice with a call in between, so a concurrent `stop()` landing in that gap turned an ordinary STOP into an `AttributeError` swallowed by the tick's `except` - a crash record filed for a clean shutdown. Read once into a local now.

## Test gaps closed (T2, T4, T7)

- **T2** - `seen == delivered + losses` was guarded only on a pass-through session, summing four of the twelve loss counters. Now parametrised over 19 combinations arming every gate in turn, over mixed TCP/SYN/UDP/ICMP traffic.
- **T4** - `impairment_loss_pct` claims the figure cannot exceed 100%. That rests on every drop happening after the targeting gates; nothing checked it.
- **T7** - every GUI "Apply" re-runs every setter, so a live session toggles NAT and RST constantly. Nothing exercised the second and third call.

T1/T5/T6/T8 are deliberately absent - their subjects are still defective, and a test written now would either be red or would pin a bug as expected behaviour. They land with their fixes.

## Verification

- Full suite green: **782 tests** (749 before this branch)
- **Fourteen mutants, all RED**: both reconcile gates, both `apply` stamps, tombstone expiry, the over-fix, `collected()`'s stamp, the watchdog call removed, `owner_targeted`, the restored double read, stranded packets uncounted at STOP, an unscoped drop, sticky `set_nat`, sticky RST cooldown
- Two mutants **survived on the first attempt** and forced real corrections: the ADD-branch stamp had no guard (the handover test is carried by the CLOSE tombstone), and the first TOCTOU test staged nothing because the bootstrap consumed its one shot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
