### PR TITLE
fix(engine): a divert that will not open fails the start, with the real reason

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -164,6 +164,48 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
   the watchdog call removed, `owner_targeted` returning False) - all nine RED.
 - Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+- **`BeanEngine._start_locked` swallowed a failed `divert.open()` (audit F1).** The `except` did
+  `crashlog.note(_exc, "engine")` and fell through, so `_running` went True, three workers were
+  spawned, and the capture thread's first `recv()` raised
+  `RuntimeError("WinDivert handle is not open")`. THAT became `self.fault`, the log line, the event
+  log and the repro report; the real cause never left crashlog at `severity=debug`.
+  MEASURED against the real driver with a filter it rejects - before: `start()` returned normally,
+  `is_running=True`, `fault='WinDivert handle is not open'`, 3 swallowed crashlog records, and the
+  log printed START *after* STOP. After: `start()` raises `OSError [WinError 87] Parametr jest
+  niepoprawny`, `is_running=False`, `fault=None` (there was no session to fault), **0 crashlog
+  records**.
+  - Both callers already handled this and NEITHER could be reached: `cli._run_session`
+    ([cli.py](beantester/cli.py)) wraps `start()` to `_fail(RUNTIME, "cannot start the capture:
+    {e}")`, and the GUI's `_finish_start` shows `dialogs.start_failed` WITH
+    `dialogs.run_as_admin` - the hint a non-elevated user needs. The exit code was right anyway
+    (via `if engine.fault` further down), but the message was the symptom.
+  - `except BaseException` and a bare `raise`, so the original exception object reaches the caller
+    unwrapped. `self._divert = None` first: `_running` is still False here and the engine never
+    reached `_LIVE_ENGINES`, so dropping the reference is the whole cleanup. Deliberately NO
+    `close()` - a pydivert handle that never opened raises from `close()` too (measured), which
+    would replace the real error with a second meaningless one.
+  - `session_info()['driver_queue']` stops lying as a side effect: it documents `None` as "the
+    simulate path, which has no driver queue", and an unopened handle used to produce exactly that
+    on a REAL session. Residual, NOT fixed here: a real handle whose `get_param` fails for some
+    other reason still reports `None` and still reads as "simulate".
+- **The START banner moved ABOVE the thread spawn (audit F6).** `self.log(log.start_filter)` and
+  `log_event("START", ...)` sat below the `except` block, so an early fault printed the live log
+  BACKWARDS (measured: recv error, fault, *then* "Start. Filter: ...", then Stop). The event log was
+  always ordered correctly - a worker-initiated stop blocks on `_stop_lock` until `start()` returns
+  - so only the log a tester actually watches was lying. Announcing first also reads correctly when
+  the spawn itself fails: START, fault, STOP.
+- **New tests.** `tests/test_failsafe.py::test_a_divert_that_cannot_open_fails_the_start_instead_of_faulting_later`
+  (the real cause reaches the caller; the engine is not left "running"; no fault is recorded because
+  there was no session; the handle is dropped; and a later START still works) and
+  `::test_the_start_banner_is_logged_before_a_worker_can_fault`, with a new `UnopenableDivert`
+  double whose `recv()` still "works" - like the real thing, where an unopened handle fails at recv
+  with a message naming nothing. `tests/test_cli_runtime.py::test_exit_code_runtime_without_pydivert`
+  gained one assertion: the REASON must survive the trip to stderr, not just the exit code - that
+  branch was unreachable before this fix.
+  The banner test matches on the seed and on the interpolated exception text, NOT on translated
+  words: an earlier version looked for "fault" and passed or failed by the machine's UI language
+  (green on an English CI runner, red on this Polish one), which is a test reporting the locale.
+  Mutation-checked: restoring the swallow -> RED; moving the banner back below the spawn -> RED.
 - **`_watchdog_loop` read `self._socketwatch` TWICE per tick** - once for the `is not None` guard,
   once to call `reconcile`, with `self._ports.collected()` in between. A concurrent `stop()`
   landing in that gap made an ordinary STOP raise `AttributeError` into the tick's `except`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
   from a socket event lost under heavy load.
 
+- **When the capture could not start, the tool told you the wrong reason.** If the WinDivert handle
+  failed to open - no Administrator rights, a driver blocked or held at a different version by
+  another tool, a filter the driver rejects - the tool went ahead and started the session anyway,
+  then reported `WinDivert handle is not open`. That is a symptom, and it names nothing. The actual
+  reason (for example `[WinError 5] Access is denied`) was written only to a diagnostic file nobody
+  is asked to read. Worse, the *helpful* messages both interfaces already had could never appear:
+  the command line has an error that quotes the real cause, and the window has a dialog with a "run
+  as Administrator" hint - which is exactly what a non-elevated user needed and never saw. Starting
+  now fails immediately, with the reason, and both of those work.
+
+- **The log could read backwards when a session died right after starting.** The "Start. Filter:
+  ..." line was written after the capture had already begun, so a session that failed in its first
+  moments printed the error and the fault *above* its own start line. Anyone reading the log to work
+  out what happened when was reading it out of order. It is now announced first.
+
 - **Stopping a session could file a crash report for nothing.** If STOP landed inside the
   half-second housekeeping pass that keeps the socket map fresh, the tool tripped over its own
   shutdown and wrote an entry into `crashes/`. Nothing was broken - the session stopped correctly

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -865,8 +865,33 @@ class BeanEngine:
         if hasattr(self._divert, "open"):
             try:
                 self._divert.open()
-            except Exception as _exc:
-                crashlog.note(_exc, "engine")
+            except BaseException:
+                # A handle that will not open is NOT a session. This used to be
+                # swallowed into a debug crash record, and the damage was entirely
+                # in what happened next: `_running` went True, three workers were
+                # spawned, and the capture thread's first `recv()` failed with
+                # `RuntimeError("WinDivert handle is not open")`. That message -
+                # a symptom, naming nothing - became `self.fault`, the log line,
+                # the event log and the repro report, while the actual cause
+                # (measured with a filter the driver rejects: `OSError [WinError
+                # 87] The parameter is incorrect`; `[WinError 5]` when not
+                # elevated) never left crashlog at severity=debug.
+                #
+                # Both callers already handle this properly and neither could ever
+                # reach that code: `cli._run_session` wraps start() to report
+                # "cannot start the capture: {e}" with exit RUNTIME, and the GUI's
+                # `_finish_start` shows the start-failed dialog WITH the "run as
+                # Administrator" hint - which is exactly what a non-elevated user
+                # needs and never saw. Raising is what wires them up.
+                #
+                # Cleared first so the engine is clean for a retry: `_running` is
+                # still False here and this object never reached _LIVE_ENGINES, so
+                # dropping the reference is the whole of the cleanup. No close() -
+                # a WinDivert handle that never opened raises from close() too
+                # (measured), which would replace the real error with a second
+                # meaningless one.
+                self._divert = None
+                raise
         self._running = True
         self._driver_queue = self._read_driver_queue()
         # Only asked for when nobody has supplied one. The QPC pair is an injected
@@ -980,6 +1005,29 @@ class BeanEngine:
             self._t_cap = threading.Thread(target=self._capture_loop, daemon=True)
             self._t_inj = threading.Thread(target=self._inject_loop, daemon=True)
             self._t_wd = threading.Thread(target=self._watchdog_loop, daemon=True)
+            # ANNOUNCED BEFORE THE WORKERS EXIST, not after. These lines used to sit
+            # below the except block, so a session that faulted early printed its log
+            # BACKWARDS - measured with a filter the driver rejects:
+            #
+            #     recv error: WinDivert handle is not open
+            #     engine fault: ... - the session was stopped, the network is normal
+            #     Start. Filter: <the filter>  (seed=...)
+            #     Stop.
+            #
+            # A tester reading that cannot tell what happened when, which is the one
+            # thing a log is for. The event log was already ordered correctly (a
+            # worker-initiated stop blocks on _stop_lock until start() returns), so
+            # only the live log lied. Announcing first also reads correctly when the
+            # spawn itself fails: START, then the fault, then STOP.
+            self.log(f"{T('log.start_filter')}: {filt}  (seed={self._effective_seed})")
+            if self._driver_queue:
+                # Said once, at START, because it frames every number that follows: a
+                # queue this deep is latency the tool can add without owning up to it.
+                q = self._driver_queue
+                self.log(T("log.driver_queue", n=q["queue_len"], t=q["queue_time"],
+                           kb=q["queue_size"] // 1024))
+            self.log_event("START", f"filter={filt}, seed={self._effective_seed}"
+                                    + (f", duration={self._duration:g}s" if self._duration else ""))
             self._t_cap.start()
             self._t_inj.start()
             self._t_wd.start()
@@ -992,15 +1040,6 @@ class BeanEngine:
             self.log(T("log.engine_fault", e=str(exc)))
             self.stop(reason="fault")
             raise
-        self.log(f"{T('log.start_filter')}: {filt}  (seed={self._effective_seed})")
-        if self._driver_queue:
-            # Said once, at START, because it frames every number that follows: a
-            # queue this deep is latency the tool can add without owning up to it.
-            q = self._driver_queue
-            self.log(T("log.driver_queue", n=q["queue_len"], t=q["queue_time"],
-                       kb=q["queue_size"] // 1024))
-        self.log_event("START", f"filter={filt}, seed={self._effective_seed}"
-                                + (f", duration={self._duration:g}s" if self._duration else ""))
 
     def _start_socketwatch(self, real_windivert, socket_source):
         """Start the live socket-event map for this session, when one is available.

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -367,6 +367,12 @@ def test_exit_code_runtime_without_pydivert():
           code == exitcodes.RUNTIME, f"(code={code})")
     check("exit: the driver error goes to stderr",
           "error:" in err.getvalue() and out.getvalue() == "")
+    # The REASON has to survive the trip, not just the exit code (audit F1). The
+    # engine used to swallow a failed open() and let the capture thread report
+    # "WinDivert handle is not open" instead - a symptom naming nothing - so this
+    # branch was unreachable and the user never learned it was, say, [WinError 5].
+    check("exit: and it says WHY, not just that something failed",
+          "WinDivert could not be opened" in err.getvalue(), f"({err.getvalue()!r})")
 
 
 def test_exit_code_interrupted_and_terminated():

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -198,6 +198,101 @@ def test_a_dead_capture_thread_fails_open():
           f"({kinds})")
 
 
+class UnopenableDivert(QuietDivert):
+    """A handle that will not open - a rejected filter, a blocked driver, no
+    elevation. Its ``recv()`` still "works", exactly like the real thing: a
+    pydivert handle that never opened raises ``RuntimeError("WinDivert handle is
+    not open")`` from recv, which is a symptom naming nothing."""
+
+    ERROR = OSError("[WinError 87] The parameter is incorrect")
+
+    def open(self):
+        raise self.ERROR
+
+
+def test_a_divert_that_cannot_open_fails_the_start_instead_of_faulting_later():
+    """Audit F1. The real cause has to reach the caller, not just crashlog.
+
+    ``open()``'s exception used to be swallowed into a debug crash record, and the
+    damage was all in what came next: ``_running`` went True, three workers were
+    spawned, and the capture thread's first ``recv()`` failed with a message that
+    names nothing. THAT became ``self.fault``, the log, the event log and the repro
+    report, while the actual cause - measured with a filter the driver rejects,
+    ``OSError [WinError 87]``, or ``[WinError 5]`` when not elevated - never left
+    crashlog at ``severity=debug``.
+
+    Both callers already knew what to do and neither could ever be reached:
+    ``cli._run_session`` wraps start() to report "cannot start the capture: {e}"
+    with exit RUNTIME, and the GUI's ``_finish_start`` shows the start-failed
+    dialog WITH the "run as Administrator" hint - precisely what a non-elevated
+    user needs and never saw.
+    """
+    divert = UnopenableDivert()
+    engine = BeanEngine()
+    raised = None
+    try:
+        engine.start("test", divert=divert)
+    except Exception as exc:
+        raised = exc
+
+    check("the start fails instead of appearing to succeed", raised is not None)
+    check("and it is the REAL cause, not a symptom from the capture thread",
+          raised is UnopenableDivert.ERROR, f"({raised!r})")
+    check("the engine is not left believing it is running",
+          engine.is_running() is False)
+    check("no fault was recorded, because there was no session to fault",
+          engine.fault is None, f"({engine.fault!r})")
+    check("atexit is not left tracking a session that never began",
+          engine not in set(_LIVE_ENGINES))
+    check("the dead handle is dropped", engine._divert is None)
+
+    # ...and the engine is reusable, so the GUI's START button works on the next try
+    recover = QuietDivert()
+    engine.start("test", divert=recover)
+    check("a later START is not refused", engine.is_running() is True)
+    engine.stop()
+    check("and the recovered session releases its divert", recover.closed is True)
+
+
+def test_the_start_banner_is_logged_before_a_worker_can_fault():
+    """Audit F6: the live log used to read BACKWARDS on an early fault.
+
+    The "Start. Filter: ..." line sat BELOW the thread spawn, so a session that
+    died in its first milliseconds printed the recv error and the fault ABOVE its
+    own start line. Measured against the real driver with a rejected filter:
+
+        recv error: WinDivert handle is not open
+        engine fault: ... - the session was stopped, the network is normal
+        Start. Filter: this is not a valid filter  (seed=...)
+        Stop.
+
+    The event log was always ordered correctly (a worker-initiated stop blocks on
+    _stop_lock until start() returns), so only the log a tester actually watches
+    was lying.
+    """
+    lines = []
+    engine = BeanEngine(log_fn=lines.append)
+    engine.start("test", divert=ExplodingDivert(packets=0))   # faults on first recv
+    deadline = time.time() + 5
+    while time.time() < deadline and engine.is_running():
+        time.sleep(0.01)
+    engine.stop()
+
+    # Matched on text the TRANSLATION cannot move: the seed the engine prints and
+    # the exception message it interpolates. An earlier version looked for the word
+    # "fault" and passed or failed by the machine's UI language - green on an
+    # English CI runner, red on this Polish one, which is a test reporting the
+    # locale rather than the code.
+    def first(needle):
+        return next((i for i, ln in enumerate(lines) if needle in ln), None)
+
+    start_at, fault_at = first("seed="), first("driver went away")
+    check("the session announced itself", start_at is not None, f"({lines})")
+    check("the failure was reported", fault_at is not None, f"({lines})")
+    check("and the start line comes FIRST", start_at < fault_at,
+          f"(start at {start_at}, fault at {fault_at}: {lines})")
+
+
 def test_a_failed_start_never_leaves_an_open_divert(monkeypatch):
     """Regression (F1): start() was not atomic.
 


### PR DESCRIPTION
## What and why

Audit findings **F1** and **F6**, both in `BeanEngine._start_locked`.

### F1 - a failed `open()` was swallowed, and the tool then reported the wrong reason

`_start_locked` caught the exception from `divert.open()`, filed it as a `severity=debug` crash record and carried on. `_running` went True, three workers were spawned, and the capture thread's first `recv()` raised `RuntimeError("WinDivert handle is not open")`. **That** became `self.fault`, the log line, the event log and the repro report - a symptom that names nothing - while the actual cause never left crashlog.

This fires on the failures users actually hit: no Administrator rights (`[WinError 5]`), a driver blocked or held at a different version by another tool, a filter the driver rejects.

The damage was worse than a bad message, because **both callers already handled this properly and neither could ever be reached**:

- `cli._run_session` wraps `start()` to report `cannot start the capture: {e}` with exit `RUNTIME`
- the GUI's `_finish_start` shows the start-failed dialog **with the "run as Administrator" hint** - exactly what a non-elevated user needs, and never saw

Raising is what wires them up.

**Measured against the real driver, with a filter it rejects:**

| | before | after |
|---|---|---|
| `start()` | returns normally, `is_running=True` | raises `OSError [WinError 87] Parametr jest niepoprawny` |
| `engine.fault` | `'WinDivert handle is not open'` | `None` - there was no session to fault |
| crashlog | 3 swallowed records | **0** |
| live log | `recv error` → `fault` → **`Start`** → `Stop` | in order |

Cleanup is just dropping the reference: `_running` is still False at that point and the engine never reached `_LIVE_ENGINES`. Deliberately **no `close()`** - a pydivert handle that never opened raises from `close()` too (measured), which would replace the real error with a second meaningless one.

`session_info()['driver_queue']` stops lying as a side effect: it documents `None` as "the simulate path, which has no driver queue", and an unopened handle used to produce exactly that on a real session. **Residual, not fixed here and noted in `CHANGELOG-INTERNAL.md`:** a real handle whose `get_param` fails for some other reason still reports `None`.

### F6 - the live log read backwards on an early fault

The `Start. Filter: ...` banner and the `START` event sat *below* the `except` block, so a session that died in its first milliseconds printed its error and fault **above** its own start line. The event log was always ordered correctly (a worker-initiated stop blocks on `_stop_lock` until `start()` returns), so only the log a tester actually watches was lying. Announcing before the spawn also reads correctly when the spawn itself fails: START, fault, STOP.

Same function, same symptom family - splitting it out would have meant opening this code a second time.

## Reviewer notes

- The new `UnopenableDivert` double keeps a working `recv()` on purpose, like the real thing: an unopened pydivert handle fails at recv with a message naming nothing. That is what makes the test exercise the actual failure shape.
- `test_exit_code_runtime_without_pydivert` gained one assertion - the **reason** must survive the trip to stderr, not just the exit code. That branch was unreachable before this fix.
- The banner test matches on the seed and on the interpolated exception text, **not** on translated words. An earlier version looked for "fault" and would have been green on an English CI runner and red on a Polish one - a test reporting the locale rather than the code.
- `except BaseException` with a bare `raise`, so the caller gets the original exception object unwrapped.

## Verification

- Full suite green: **784 tests**
- **Mutation-checked**: restoring the swallow → RED; moving the banner back below the spawn → RED
- Re-measured end to end against the real WinDivert driver (table above)
- Two rows added to the PROJECT_NOTES regression surface (that file is gitignored, so it is not in this diff)

## Checklist

- [x] `python -m pytest tests` passes locally.
- [x] New behaviour has tests (see `tests/` for the style).
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. *(no new UI text - existing keys only)*
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
