### PR TITLE
feat(targeting): say when the target shares a local port, instead of silently picking an owner

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -164,6 +164,70 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
   the watchdog call removed, `owner_targeted` returning False) - all nine RED.
 - Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+### Added: the port -> pid collapse stops being silent (ADR, no behaviour change)
+
+`portmap`'s map is keyed by the port NUMBER alone and merges four tables (tcp/v4, tcp/v6, udp/v4,
+udp/v6) in that order, so a port with several rows keeps the LAST: UDP overwrites TCP, v6
+overwrites v4, and within one table the winner is whatever `iphlpapi` returned.
+
+- **MEASURED 2026-07-30** (Win11, 50 samples, reading RAW rows - an earlier probe counted 2 of 91
+  because `_table` collapses inside itself and hid the rest): **4 of 127 port numbers had
+  conflicting owners** - 68 (DHCP, two svchosts), 1900 (SSDP, svchost + Spotify), **5353 (mDNS,
+  FIVE at once**: svchost, Spotify, adb, msedge twice) and 49664 (RPC: TCP lsass vs UDP svchost).
+  Under load (600 extra sockets, 718 port numbers) **no new ephemeral collision appeared**; 66
+  ports >= 49152 had exactly one owner.
+- **Consequences DEMONSTRATED through `ProcessTargeting`, not reasoned:** target `Spotify.exe` ->
+  1900 and 5353 OUT of its port set (its own traffic escapes); target `msedge.exe` -> 5353 IN,
+  together with svchost's, Spotify's and adb's traffic; target `lsass.exe` -> its TCP 49664 escapes
+  because UDP svchost won the row. The connection log shows one arbitrary owner for every row on
+  those ports. On 5353 the winner is not even stable: 40 walks 0.25 s apart gave Spotify x32, adb
+  x6, msedge x2, so scope flickers at the resolver's rebuild rate.
+- **REJECTED - a `(proto, port)` key** (two frozensets rather than a tuple, so no per-packet
+  allocation): fixes 1 of the 4, because three are several processes on the SAME protocol and
+  family (`SO_REUSEADDR`), where the local port does not carry the answer at all. Packet-path work
+  for one port in 127, in a budget where disabling the WHOLE connection log is 1.012x.
+- **REJECTED - `port -> {pids}` matching any owner**: not a fix, a POLICY change from "one
+  arbitrary owner" to "all of them". On 5353 that means targeting msedge also impairs svchost,
+  Spotify and adb - trading a coin-toss false negative for a guaranteed false positive, exactly
+  where the OS multiplexes.
+- **TAKEN: behaviour unchanged, silence removed.** New `portmap._put(out, owners, port, pid)` -
+  ONE source for the row-installing rule, used by the native walk and the psutil fallback, so the
+  two cannot drift about which ports are shared. It records the owner a row evicts and allocates
+  nothing unless a port really has two. `PortTable._shared` is installed beside `_ports`, under the
+  same lock and the same generation guard (a shared list from an older walk beside a newer map
+  would name processes that own nothing), and read via `shared_ports()`.
+  `targeting.ports_shared_with_others(pids, table)` intersects that with the TARGET's pids and
+  names the OTHERS; `settings._warn_about_shared_ports` says it once from `apply_targeting`'s
+  announcing path (never per resolver tick), via the new `log.targeting_shared_ports` key in both
+  language files. It asks the POLLING table on purpose even in a session where targeting resolves
+  against the `SocketWatcher`: the question is about the OS socket table, not about how the tool
+  learned a mapping.
+- A **global** "N ports are shared" counter was considered and dropped: a number about the machine,
+  not about the user's test, and nothing they can act on.
+- **New tests** in `tests/test_processes.py`:
+  `test_a_port_several_processes_hold_is_recorded_instead_of_silently_collapsed` (the flat map is
+  UNCHANGED - last row still wins - while every evicted owner is recorded; drives the REAL `_put`,
+  because the first version gave its fake table a copy of the rule and a mutant deleting the
+  recording SURVIVED), `test_shared_ports_are_published_with_the_map_they_belong_to`,
+  `test_only_ports_the_TARGET_holds_are_reported_as_shared` (a port shared between two strangers is
+  not reported; a table that cannot answer degrades to silence),
+  `test_a_target_sharing_a_port_is_said_out_loud_once` (and a target that shares nothing stays
+  quiet), and `test_the_shared_port_warning_is_actually_wired_into_apply_targeting` - written
+  because deleting the call site left the direct-call test green, which is a diagnostic nobody
+  invokes.
+  Mutation-checked: `_put` not recording, `_shared` not installed, the warning not filtered by
+  target, the target named among "the others", the call site deleted, and the warning firing with
+  nothing to say - all RED.
+- `_Native.port_pid_map` / `_psutil_port_pid_map` / `_Native._table` take an optional `owners`
+  dict. Four test doubles updated to match: with the old signature the call RAISED, the `except` in
+  `refresh()` swallowed it, and the whole collection fell through to the real system - the tests
+  caught exactly that.
+- **NOT measured**: the `SocketWatcher` side has the same shape (`_ports[port] = pid`, last event
+  wins) and was seen holding ports 138 and 1900 with two pids at once, but was not swept as
+  thoroughly as the poller.
+
+### Fixed
+
 - **`BeanEngine._start_locked` swallowed a failed `divert.open()` (audit F1).** The `except` did
   `crashlog.note(_exc, "engine")` and fell through, so `_running` went True, three workers were
   spawned, and the capture thread's first `recv()` raised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
   from a socket event lost under heavy load.
 
+### Added
+
+- **The tool now warns when your target shares a port with another program.** Windows lets several
+  programs hold the same local port at once - that is how mDNS, SSDP and DHCP work - and this tool
+  decides what to break from the port number, so on those ports it genuinely cannot tell whose
+  traffic it is looking at. On this machine, four port numbers out of 127 were like that, and one
+  of them (5353, used for local device discovery) had **five** owners at the same time. The
+  consequence is real in both directions: aiming at one program could leave its own traffic on such
+  a port untouched, or sweep three other programs' traffic in with it. Nothing about that changed -
+  it cannot be fixed, because the port number simply does not say who sent the packet - but the
+  tool no longer keeps it to itself. Applying a target now says which port is shared and with whom,
+  so you know that part of the result is a coin toss. Ports that are not shared, which is where
+  your application's own traffic lives, are unaffected.
+
+### Fixed
+
 - **When the capture could not start, the tool told you the wrong reason.** If the WinDivert handle
   failed to open - no Administrator rights, a driver blocked or held at a different version by
   another tool, a filter the driver rejects - the tool went ahead and started the session anyway,

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -40,6 +40,26 @@ _UDP_TABLE_OWNER_PID = 1
 _ERROR_INSUFFICIENT_BUFFER = 122
 
 
+def _put(out, owners, port, pid):
+    """Install one socket row into the flat map, remembering the owner it evicts.
+
+    The flat ``port -> pid`` map keeps the LAST row (see ``port_pid_map``), and
+    ``owners`` collects the losers so that collapse can be reported instead of
+    happening in silence. ONE function, called by both the native walk and the
+    psutil fallback: written inline in both, the rule would drift the first time
+    somebody edited one of them - and the two would then disagree about which
+    ports are shared depending on which path the machine took.
+
+    Nothing is allocated unless a port really has two owners, so the common row
+    costs one extra ``dict.get``.
+    """
+    if owners is not None:
+        previous = out.get(port)
+        if previous is not None and previous != pid:
+            owners.setdefault(port, {previous}).add(pid)
+    out[port] = pid
+
+
 def _swap16(value):
     """The socket tables store ports in network byte order inside a DWORD."""
     return ((value & 0xFF) << 8) | ((value >> 8) & 0xFF)
@@ -93,8 +113,12 @@ class _Native:
         }
         self._sizes = {}            # (proto, family) -> bytes the table needed last time
 
-    def _table(self, proto, family, out):
-        """Append ``(port, pid)`` pairs of one table to ``out``."""
+    def _table(self, proto, family, out, owners=None):
+        """Append ``(port, pid)`` pairs of one table to ``out``.
+
+        ``owners`` (optional) collects ``port -> {pid, ...}`` for the ports where
+        more than one row claims the same number, which ``out`` cannot represent.
+        """
         import ctypes
         from ctypes import wintypes
 
@@ -136,13 +160,35 @@ class _Native:
             port = _swap16(row.dwLocalPort & 0xFFFF)
             pid = int(row.dwOwningPid)
             if port and pid:
-                out[port] = pid
+                # LAST ROW WINS, and that is unchanged - see port_pid_map for what
+                # it costs and _put for how the discarded owner is remembered.
+                _put(out, owners, port, pid)
         return True
 
     FAMILY_NAMES = {_AF_INET: "v4", _AF_INET6: "v6"}
 
-    def port_pid_map(self):
+    def port_pid_map(self, owners=None):
         """``{local port: pid}`` from all four socket tables, or ``None``.
+
+        🔴 **The key is the port NUMBER ALONE, and that loses information.** The
+        four tables (tcp/v4, tcp/v6, udp/v4, udp/v6) are merged into one flat dict
+        in that order, so a port claimed by several rows keeps only the LAST one:
+        UDP overwrites TCP, v6 overwrites v4, and within one table the winner is
+        whatever order ``iphlpapi`` returned. This is not a corner case on a real
+        machine - MEASURED 2026-07-30 (Win11, 50 samples): **4 of 127 port numbers
+        had conflicting owners**, and udp/v4:5353 (mDNS) had FIVE at once -
+        svchost, Spotify, adb and msedge twice. Also 68 (DHCP), 1900 (SSDP) and
+        49664, where TCP lsass and UDP svchost collide across protocols.
+
+        Most of that is NOT fixable by a richer key: three of the four are genuine
+        ``SO_REUSEADDR`` sharing inside ONE table, where the local port simply does
+        not identify the owner. See the ADR in PROJECT_NOTES ("Zachowania
+        ZAMIERZONE") for the options measured and rejected.
+
+        So the collapse stays, and ``owners`` (optional) is how it stops being
+        SILENT: pass a dict and it collects ``port -> {pid, ...}`` for exactly the
+        ports where a winner had to be picked. Callers turn that into the warning a
+        user can act on (see ``targeting.ports_shared_with_others``).
 
         A PARTIAL result is still returned. Dropping to psutil because one table
         of four stopped answering would trade a possible gap for a certain
@@ -159,7 +205,7 @@ class _Native:
         failed = []
         for proto in ("tcp", "udp"):
             for family in (_AF_INET, _AF_INET6):
-                if not self._table(proto, family, out):
+                if not self._table(proto, family, out, owners):
                     failed.append(f"{proto}/{self.FAMILY_NAMES[family]}")
         if len(failed) == 4:
             return None                  # nothing answered at all: let psutil try
@@ -180,7 +226,8 @@ def _make_native():
 
 
 # -- fallback (psutil) --------------------------------------------------------- #
-def _psutil_port_pid_map():
+def _psutil_port_pid_map(owners=None):
+    """Same shape - and the same collapse - as the native path. See port_pid_map."""
     try:
         import psutil
     except Exception:
@@ -193,7 +240,7 @@ def _psutil_port_pid_map():
                 continue
             port = laddr.port if hasattr(laddr, "port") else laddr[1]
             if port:
-                out[int(port)] = int(pid)
+                _put(out, owners, int(port), int(pid))
         return out
     except Exception:
         return None
@@ -352,6 +399,9 @@ class PortTable:
         self.clock = clock
         self._lock = threading.RLock()
         self._ports = {}                 # port -> pid
+        # port -> frozenset(pids), ONLY for the ports where _ports had to pick a
+        # winner. Diagnostics, never a decision input - see port_pid_map.
+        self._shared = {}
         self._info = {}                  # pid -> (name, ppid, created, written_at)
         self._bulk_at = 0.0              # last full process_iter (fallback path)
         self._last = 0.0                 # last successful refresh
@@ -414,15 +464,21 @@ class PortTable:
         # ---- outside the lock: everything that is O(number of sockets) ---------- #
         ports = None
         native_broke = False
+        # Collected alongside the map, from the same walk, so the two can never
+        # describe different moments. Empty on any ordinary machine minute - it only
+        # gains an entry where a port number really has two owners (see
+        # port_pid_map), so this costs nothing until there is something to say.
+        owners = {}
         if native is not None:
             try:
-                ports = native.port_pid_map()
+                ports = native.port_pid_map(owners)
             except Exception:                        # pragma: no cover
                 ports = None
             if ports is None:
                 native_broke = True                  # it stopped answering
         if ports is None:
-            ports = _psutil_port_pid_map()
+            owners.clear()                           # belongs to the walk that failed
+            ports = _psutil_port_pid_map(owners)
         # A PID that has just lost every socket is a PID whose process is probably
         # gone - and a PID can only be handed to somebody else AFTER its owner exits.
         # So this is the moment to forget its name, before the OS can hand the number
@@ -449,6 +505,10 @@ class PortTable:
                 return False
             self._installed_gen = gen
             self._ports = ports
+            # Installed with the map it belongs to, under the same lock and the same
+            # generation guard: a shared-port list from an older walk beside a newer
+            # map would name processes that no longer own anything.
+            self._shared = {port: frozenset(pids) for port, pids in owners.items()}
             self._last = now
             for pid in departed:
                 self._info.pop(pid, None)
@@ -466,6 +526,17 @@ class PortTable:
     def snapshot(self):
         with self._lock:
             return dict(self._ports)
+
+    def shared_ports(self):
+        """``{port: frozenset(pids)}`` for the ports ``snapshot()`` had to collapse.
+
+        Empty on most machines and most minutes. When it is not, it names exactly
+        what the flat map threw away, so the tool can warn instead of silently
+        attributing a shared port to one of its owners. Diagnostics only: nothing
+        in the decision pipeline reads this, and adding it changed no behaviour.
+        """
+        with self._lock:
+            return dict(self._shared)
 
     def collected(self):
         """The port map AND the moment its data was collected, from ONE lock hold.

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -8,11 +8,13 @@ import json
 
 from . import crashlog
 from . import fields as F
+from . import portmap
 from .jsonfile import write_json
 from .fields import FIELD_DEFS, FIELDS
 from .i18n import T, translate
 from .matchers import KIND_PROCESS, parse_matcher, port_expression
 from .processes import TARGET_FIELD
+from .targeting import ports_shared_with_others
 from .validators import parse_number, parse_seed
 
 DEFAULT_SETTINGS = dict(
@@ -127,6 +129,35 @@ def validate_settings(s, lang=None):
     return True
 
 
+def _warn_about_shared_ports(targeting, log):
+    """Say so when the target holds a port other programs hold at the same time.
+
+    The tool decides what to impair from the LOCAL PORT, and the operating
+    system's socket table lets several processes own one (``SO_REUSEADDR``: mDNS,
+    SSDP, DHCP). On those ports the answer is a coin toss - measured, targeting
+    Spotify left its own port 5353 out of scope while targeting msedge pulled
+    svchost, Spotify and adb in. Nothing here can fix that; what it can do is stop
+    the tool from reporting a clean result over it.
+
+    Said ONCE, on the announcing path (an explicit "apply"), never per resolver
+    tick. Best-effort throughout: a diagnostic that raised would break the very
+    thing it is describing.
+    """
+    with crashlog.quiet("settings.shared_ports"):
+        # The POLLING table, whatever targeting itself resolves against: the
+        # question is about the OS socket table, not about how we learned a port.
+        table = portmap.default_table()
+        table.refresh_if_stale()
+        shared = ports_shared_with_others(targeting.pids(), table)
+        if not shared:
+            return
+        others = sorted({table.name_of(pid) or str(pid)
+                         for pids in shared.values() for pid in pids})
+        log(T("log.targeting_shared_ports", n=len(shared),
+              ports=", ".join(str(p) for p in sorted(shared)),
+              who=", ".join(others)))
+
+
 def apply_targeting(engine, target, log=lambda *_: None, announce=True):
     """Resolve the target-process expression and point the engine at its ports.
 
@@ -184,6 +215,7 @@ def apply_targeting(engine, target, log=lambda *_: None, announce=True):
             log(f"{T('log.targeting')}: {targeting.describe()} "
                 f"({len(targeting.pids())} {T('log.processes')}, "
                 f"{len(targeting)} {T('log.ports')})")
+            _warn_about_shared_ports(targeting, log)
         else:
             # Loud on purpose: an unmatched target means NOTHING is impaired,
             # and a run in which nothing broke used to look exactly like a run

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -338,6 +338,50 @@ class ProcessTargeting:
 NO_PROCESS = "(none)"
 
 
+def ports_shared_with_others(pids, table=None):
+    """``{port: frozenset(other pids)}`` - target ports that other processes hold too.
+
+    Why this exists, and why it only WARNS. A socket table row is ``(protocol,
+    family, local port) -> pid``, and :mod:`beantester.portmap` collapses all four
+    tables into ``port -> pid``, so a port several processes hold keeps one of them.
+    That is not a rounding error, it decides what gets impaired - MEASURED
+    2026-07-30 against the real table:
+
+    * targeting ``Spotify.exe`` left port 1900 (SSDP) and 5353 (mDNS) OUT of its
+      port set, so its own traffic there was never touched;
+    * targeting ``msedge.exe`` put 5353 IN, together with svchost's, Spotify's and
+      adb's traffic on the same port - three processes impaired that nobody asked
+      for;
+    * and on 5353 the winner is not even stable: across 40 walks 0.25 s apart it
+      was Spotify 32 times, adb 6, msedge 2, so scope flickers at the resolver's
+      rebuild rate.
+
+    It is not fixable by a better key. Three of the four shared ports found were
+    several processes on the SAME protocol and family (``SO_REUSEADDR`` multicast:
+    DHCP, SSDP, mDNS), where the local port genuinely does not identify the owner -
+    see the ADR in PROJECT_NOTES. What CAN be fixed is the silence, which is this.
+
+    ``table`` defaults to the polling table on purpose, even in a session where
+    targeting resolves against the live ``SocketWatcher``: this asks about the
+    OPERATING SYSTEM's socket table, not about how the tool learned a mapping.
+    Returns ``{}`` for a table that cannot answer (a test double, a non-Windows
+    fallback) - a missing diagnostic must never break the thing it describes.
+    """
+    if not pids:
+        return {}
+    table = table if table is not None else portmap.default_table()
+    getter = getattr(table, "shared_ports", None)
+    if getter is None:
+        return {}
+    targeted = set(pids)
+    out = {}
+    for port, owners in getter().items():
+        others = frozenset(owners) - targeted
+        if others and (set(owners) & targeted):
+            out[port] = others
+    return out
+
+
 def resolve_ports(matcher, table=None):
     """One-shot resolution: ``(ports, description)`` for a compiled matcher.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -285,6 +285,7 @@
   "log.targeting": "Targeting",
   "log.targeting_error": "Targeting error",
   "log.targeting_none": "Targeting: NO matching process - traffic is NOT being impaired.",
+  "log.targeting_shared_ports": "Heads up: other processes have port(s) {ports} open too ({who}). The tool decides what to break from the port number, so on those it cannot tell whose traffic it is: it may break theirs as well, or miss the target's. All other ports are unaffected.",
   "log.targeting_requires_psutil": "Targeting requires psutil:  pip install psutil",
   "log.ui_error": "Internal error: {e} (the session keeps running; see the log).",
   "log.ui_state_problem": "Window-state file problem",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -285,6 +285,7 @@
   "log.targeting": "Celuję w",
   "log.targeting_error": "Błąd celowania",
   "log.targeting_none": "Celowanie: BRAK pasującego procesu - ruch NIE jest modyfikowany.",
+  "log.targeting_shared_ports": "Uwaga: port(y) {ports} mają otwarte także inne procesy ({who}). Narzędzie decyduje o psuciu po numerze portu, więc na nich nie rozróżni, czyj to ruch: może popsuć także im albo pominąć ruch celu. Pozostałe porty są bez zmian.",
   "log.targeting_requires_psutil": "Celowanie wymaga psutil:  pip install psutil",
   "log.ui_error": "Błąd wewnętrzny: {e} (sesja działa dalej; sprawdź log).",
   "log.ui_state_problem": "Problem z plikiem stanu okna",

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -303,7 +303,7 @@ def test_a_partial_socket_table_is_reported_not_silently_trusted(monkeypatch):
     recorded = _spy_on_crashlog(monkeypatch)
     seen = []
 
-    def fake_table(proto, family, out):
+    def fake_table(proto, family, out, owners=None):
         seen.append((proto, family))
         if proto == "udp" and family == _AF_INET6:
             return False                     # this one stops answering
@@ -318,6 +318,205 @@ def test_a_partial_socket_table_is_reported_not_silently_trusted(monkeypatch):
     check("the gap was recorded", len(recorded) == 1, f"({recorded})")
     check("the record names the table that failed",
           "udp/v6" in str(recorded[0].get("subsystem", "")), f"({recorded})")
+
+
+def test_a_port_several_processes_hold_is_recorded_instead_of_silently_collapsed():
+    """The flat ``port -> pid`` map keeps ONE owner. Now it says which it dropped.
+
+    MEASURED on a real machine (2026-07-30, 50 samples): 4 of 127 port numbers had
+    conflicting owners, and udp/v4:5353 had FIVE at once. The map cannot represent
+    that - three of those four were several processes on the same protocol and
+    family (SO_REUSEADDR: DHCP, SSDP, mDNS), where the local port genuinely does
+    not identify the owner. So the collapse stays and stops being SILENT.
+    """
+    from beantester.portmap import _AF_INET, _AF_INET6, _Native, _put
+
+    # Driven through the REAL row-installing rule. An earlier version of this test
+    # gave the fake table its own copy of that rule, so it asserted its own
+    # reimplementation: deleting the recording from portmap left it green.
+    rows = {("tcp", _AF_INET): [(80, 10), (5353, 11)],
+            ("udp", _AF_INET): [(5353, 12), (5353, 13)],   # two owners, one table
+            ("udp", _AF_INET6): [(5353, 14), (443, 15)]}   # ...and a third across
+
+    def fake_table(proto, family, out, owners=None):
+        for port, pid in rows.get((proto, family), ()):
+            _put(out, owners, port, pid)
+        return True
+
+    native = _Native.__new__(_Native)
+    native._sizes = {}
+    native._table = fake_table
+    owners = {}
+    flat = native.port_pid_map(owners)
+
+    check("the flat map is UNCHANGED - last row still wins", flat[5353] == 14,
+          f"({flat.get(5353)})")
+    check("every owner of the shared port was recorded",
+          owners.get(5353) == {11, 12, 13, 14}, f"({owners.get(5353)})")
+    check("a port with one owner is not reported as shared",
+          80 not in owners and 443 not in owners, f"({sorted(owners)})")
+
+    # ...and the same rule is what the psutil fallback uses, so the two paths
+    # cannot disagree about which ports are shared.
+    out, seen = {}, {}
+    for port, pid in [(7000, 1), (7000, 2), (7001, 3)]:
+        _put(out, seen, port, pid)
+    check("the shared rule keeps the last owner", out == {7000: 2, 7001: 3}, f"({out})")
+    check("...and remembers the one it evicted", seen == {7000: {1, 2}}, f"({seen})")
+    check("a caller that does not ask for collisions still gets the map",
+          [_put(out, None, 8000, 9), out.get(8000)][1] == 9)
+
+
+def test_shared_ports_are_published_with_the_map_they_belong_to():
+    """A shared-port list from an older walk beside a newer map would name
+    processes that no longer own anything, so it is installed under the same lock
+    and the same generation guard as ``_ports``."""
+    from beantester import portmap
+
+    table = portmap.PortTable()
+
+    class _Native:
+        def port_pid_map(self, owners=None):
+            if owners is not None:
+                owners[5353] = {11, 12}
+            return {5353: 12, 80: 10}
+
+    table._native = _Native()
+    table.native = True
+    table.refresh(force=True)
+
+    check("the map is the flat one", table.snapshot() == {5353: 12, 80: 10},
+          f"({table.snapshot()})")
+    check("and the collisions it hid are readable",
+          table.shared_ports() == {5353: frozenset({11, 12})},
+          f"({table.shared_ports()})")
+    check("shared_ports hands out a copy, not the live dict",
+          table.shared_ports() is not table._shared)
+
+
+def test_only_ports_the_TARGET_holds_are_reported_as_shared():
+    """The warning has to be about the user's target, not about the machine.
+
+    A global "4 ports are shared" tells a tester nothing they can act on. What
+    matters is "the process you aimed at shares one, so the result there is a coin
+    toss" - measured: targeting Spotify left its own 5353 out of scope, while
+    targeting msedge pulled svchost, Spotify and adb in with it.
+    """
+    from beantester.targeting import ports_shared_with_others
+
+    class _Table:
+        def shared_ports(self):
+            return {5353: frozenset({11, 12, 13}),   # the target is one of three
+                    1900: frozenset({77, 78})}        # nothing to do with us
+
+    shared = ports_shared_with_others({11, 99}, _Table())
+    check("the target's shared port is reported", 5353 in shared, f"({shared})")
+    check("...naming the OTHERS, not the target itself",
+          shared[5353] == frozenset({12, 13}), f"({shared.get(5353)})")
+    check("a port shared between two strangers is not our business",
+          1900 not in shared, f"({shared})")
+    check("no target, nothing to say", ports_shared_with_others(set(), _Table()) == {})
+    check("a table that cannot answer degrades to silence, not an error",
+          ports_shared_with_others({11}, object()) == {})
+
+
+def test_a_target_sharing_a_port_is_said_out_loud_once():
+    """...and a target that shares nothing stays quiet, or the line becomes noise."""
+    from beantester import portmap, settings
+
+    class _Table:
+        def __init__(self, shared):
+            self._shared = shared
+
+        def refresh_if_stale(self, now=None, miss=False):
+            return False
+
+        def shared_ports(self):
+            return self._shared
+
+        def name_of(self, pid, cheap=False):
+            return {12: "svchost.exe", 13: "adb.exe"}.get(pid, "")
+
+    class _Targeting:
+        def pids(self):
+            return {11}
+
+    def run(shared, monkey):
+        lines = []
+        monkey.setattr(portmap, "default_table", lambda: _Table(shared))
+        settings._warn_about_shared_ports(_Targeting(), lines.append)
+        return lines
+
+    import pytest as _pytest
+    mp = _pytest.MonkeyPatch()
+    try:
+        noisy = run({5353: frozenset({11, 12, 13})}, mp)
+        quiet = run({1900: frozenset({77, 78})}, mp)
+    finally:
+        mp.undo()
+
+    check("a shared target port is announced", len(noisy) == 1, f"({noisy})")
+    check("and the line names the port and who else has it",
+          "5353" in noisy[0] and "svchost.exe" in noisy[0] and "adb.exe" in noisy[0],
+          f"({noisy})")
+    check("a target that shares nothing says nothing", quiet == [], f"({quiet})")
+
+
+def test_the_shared_port_warning_is_actually_wired_into_apply_targeting():
+    """The unit test above proves the SENTENCE; this proves it is SAID.
+
+    Written because a mutant survived: deleting the call from ``apply_targeting``
+    left the direct-call test perfectly green. A diagnostic nobody invokes is the
+    same as no diagnostic, and it fails exactly the way this project hates - the
+    session looks clean.
+    """
+    from beantester import portmap, settings
+
+    class _Table:
+        def refresh_if_stale(self, now=None, miss=False):
+            return False
+
+        def shared_ports(self):
+            return {5353: frozenset({11, 12})}
+
+        def name_of(self, pid, cheap=False):
+            return {12: "svchost.exe"}.get(pid, "")
+
+    class _Targeting:
+        matched = True
+
+        def pids(self):
+            return {11}
+
+        def describe(self):
+            return "myapp.exe"
+
+        def refresh(self, *a, **k):
+            return frozenset({5353})
+
+        def __len__(self):
+            return 1
+
+    class _Engine:
+        def target_for(self, _matcher):
+            return _Targeting()
+
+        def set_target(self, *_a, **_k):
+            pass
+
+    import pytest as _pytest
+    mp = _pytest.MonkeyPatch()
+    lines = []
+    try:
+        mp.setattr(portmap, "default_table", lambda: _Table())
+        settings.apply_targeting(_Engine(), "myapp.exe", lines.append)
+    finally:
+        mp.undo()
+
+    check("applying a target announced what it matched",
+          any("myapp.exe" in ln for ln in lines), f"({lines})")
+    check("...and warned that one of its ports is shared",
+          any("5353" in ln and "svchost.exe" in ln for ln in lines), f"({lines})")
 
 
 def test_every_socket_table_failing_falls_back_to_psutil(monkeypatch):
@@ -382,7 +581,8 @@ class _World:
         from beantester import portmap
         # the bulk fallback must use this fake table, not the real toolhelp snapshot
         monkeypatch.setattr(portmap, "_ALLOW_NATIVE_PROCESSES", False)
-        monkeypatch.setattr(portmap, "_psutil_port_pid_map", lambda: dict(self.ports))
+        monkeypatch.setattr(portmap, "_psutil_port_pid_map",
+                            lambda owners=None: dict(self.ports))
         monkeypatch.setattr(portmap, "_psutil_created",
                             lambda pid: self.created.get(int(pid)))
         monkeypatch.setattr(portmap, "_psutil_process_info", lambda pid: (
@@ -608,7 +808,7 @@ def test_the_socket_table_is_collected_without_holding_the_lock():
     probed = {}
 
     class _Native:
-        def port_pid_map(self):
+        def port_pid_map(self, owners=None):
             def probe():
                 got = table._lock.acquire(timeout=1.0)
                 probed["free"] = got
@@ -671,12 +871,12 @@ def test_an_older_collection_does_not_overwrite_a_newer_map():
     stale, fresh = {1111: 11}, {2222: 22}
 
     class _Slow:
-        def port_pid_map(self):
+        def port_pid_map(self, owners=None):
             gate.wait(timeout=5.0)
             return dict(stale)
 
     class _Fast:
-        def port_pid_map(self):
+        def port_pid_map(self, owners=None):
             return dict(fresh)
 
     table._native = _Slow()


### PR DESCRIPTION
## What and why

The shared-local-port question from the engine stability audit. **Behaviour is unchanged on purpose** - the finding is that most of this cannot be fixed, and the deliverable is an ADR plus the removal of the silence.

### The problem

`portmap`'s map is keyed by the port **number alone** and merges four socket tables (tcp/v4, tcp/v6, udp/v4, udp/v6) in that order, so a port claimed by several rows keeps the **last** one. UDP overwrites TCP, v6 overwrites v4, and inside one table the winner is whatever `iphlpapi` returned.

**Measured** (Win11, 50 samples, reading raw rows — an earlier probe reported 2 of 91 because `_table` collapses inside itself and hid the rest): **4 of 127 port numbers had conflicting owners**.

| port | owners |
|---|---|
| 68 (DHCP) | two svchost instances |
| 1900 (SSDP) | svchost + Spotify |
| 5353 (mDNS) | **five at once** — svchost, Spotify, adb, msedge ×2 |
| 49664 (RPC) | TCP lsass **vs** UDP svchost |

Under load — 600 extra sockets, 718 port numbers — **no new ephemeral collision appeared**, and 66 ports ≥49152 had exactly one owner.

### What it costs, demonstrated rather than reasoned

Asked of `ProcessTargeting` exactly the way the engine asks it:

- target `Spotify.exe` → ports 1900 and 5353 **out of scope**: its own traffic there is never touched
- target `msedge.exe` → 5353 **in scope together with svchost's, Spotify's and adb's traffic** — three processes impaired that nobody asked for
- target `lsass.exe` → its TCP 49664 escapes, because UDP svchost won the row
- the connection log shows one arbitrary owner for every row on those ports
- on 5353 the winner is not even stable: 40 walks 0.25 s apart gave Spotify ×32, adb ×6, msedge ×2, so scope **flickers** at the resolver's 0.30 s rebuild rate

### Why it is not fixed

Three of the four are several processes on the **same protocol and family** (`SO_REUSEADDR` multicast). The local port genuinely does not identify the owner — there is no key that recovers information the OS never gave us.

- **Rejected — a `(proto, port)` key** (two frozensets rather than a tuple, so no per-packet allocation): fixes **1 of 4**. Packet-path work for one port in 127, in a budget where disabling the *entire* connection log measures 1.012x.
- **Rejected — `port -> {pids}` matching any owner**: not a fix but a **policy change**, from "one arbitrary owner" to "all of them". On 5353 that means targeting msedge also impairs svchost, Spotify and adb — trading a coin-toss false negative for a *guaranteed* false positive, precisely where the OS multiplexes.
- **Rejected — a global "N ports are shared" counter**: a number about the machine, not about the user's test, and nothing they can act on.

### What is taken

The collapse stays; the silence goes.

- `portmap._put(out, owners, port, pid)` — **one** source for the row-installing rule, used by the native walk *and* the psutil fallback so the two cannot drift about which ports are shared. Records the owner each row evicts; allocates nothing unless a port really has two.
- `PortTable._shared` installed beside `_ports`, under the same lock and the same generation guard (a shared list from an older walk beside a newer map would name processes that own nothing), read via `shared_ports()`.
- `targeting.ports_shared_with_others(pids, table)` intersects it with the **target's** pids and names the others. Asks the polling table even in a session where targeting resolves against the `SocketWatcher`: the question is about the OS socket table, not about how the tool learned a mapping.
- `settings._warn_about_shared_ports` says it **once**, from `apply_targeting`'s announcing path — never per resolver tick. New `log.targeting_shared_ports` key in both language files.

**Verified live**: targeting msedge reports port 5353 and who else holds it.

## Reviewer notes

- The warning deliberately says "other **processes**", not "other programs": when a second instance of the target itself holds the port and is not in the resolved pid set, naming it is the useful, true thing. The first draft said "programs" and read like a bug.
- Four test doubles gained the optional `owners` argument. With the old signature the call **raised**, `refresh()`'s `except` swallowed it, and the whole collection fell through to the real system — the existing tests caught exactly that.
- Nothing in the decision pipeline reads `shared_ports()`. It is diagnostics; `_ports` and the hot path are untouched.

## Verification

- Full suite green: **789 tests**
- **Six mutants, all RED**: `_put` not recording, `_shared` not installed, the warning not filtered by target, the target named among "the others", the call site deleted, the warning firing with nothing to say
- **Two mutants survived the first attempt** and forced real corrections: the collision test had reimplemented the rule inside its own fake (so it asserted the fake), and nothing checked the warning was *wired in* rather than merely correct — a diagnostic nobody invokes is no diagnostic
- The ADR lands in PROJECT_NOTES, which is gitignored, so it is not in this diff

## Checklist

- [x] `python -m pytest tests` passes locally.
- [x] New behaviour has tests (see `tests/` for the style).
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
