### PR TITLE
fix(engine): close the last three audit findings - the age window, the eviction floor and Duplicated

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -164,6 +164,54 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
   the watchdog call removed, `owner_targeted` returning False) - all nine RED.
 - Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+### Fixed: the last three audit findings (F3, F4, F5)
+
+- **`_FlowTable.keep_for` could only ever RAISE the age window (F3/T5).** The rotation deadline was
+  cached as an absolute `_next_rotate` and `keep_for` changed `_rotate_s` without touching it, so
+  once `set_nat(>0)` had pushed the window to infinity, `set_nat(0)` could not bring it down for the
+  rest of the session and `_flow_last` was freed only by its SIZE ceiling. Every GUI "Apply" runs
+  every setter, so one round trip through the NAT field was enough. **Fixed by removing the class,
+  not the symptom**: the table now stores `_last_rotate` (when the last rotation HAPPENED) and
+  derives the deadline live, so any change to `_rotate_s` takes effect on the very next call - no
+  reset to remember, in either direction. Impact was memory only: a retired record reads back as
+  "never seen", which the NAT check treats as "pass", so it can lose an impairment and never invent
+  one. Guard: `test_the_flow_table_age_window_can_be_lowered_again_not_only_raised` (both the unit
+  and the real `set_nat` path).
+- **`_trim_conns` could empty the connection log instead of trimming it (F4/T6).** The cutoff is a
+  SAMPLED estimate compared inclusively (`c["last"] <= cutoff`), so rows sharing a timestamp all
+  land on the same side of it; with every row on one stamp it takes the whole table. Measured
+  against a 1000-row cap: **1200 rows trimmed to 0 instead of 900**. Not reachable from ordinary
+  traffic here - `time.monotonic()` resolves to ~100 ns on this machine (26 204 ties in 200 000
+  reads), and a 1200-row burst still produced 865 distinct stamps and trimmed correctly - but the
+  clock's resolution is a platform property this code should not lean on. **Fixed with a floor**:
+  never evict more than `len(conns) - MAX_CONNS * EVICT_KEEP`, whatever the estimate says. Guard:
+  `test_evicting_the_connection_log_can_never_empty_it`, which also asserts the SURVIVORS are the
+  newest rows, so the floor cannot be satisfied by keeping the wrong ones.
+- **BREAKING: `duplicated` counted the DECISION to duplicate, not the copy (F5/T8).** `tips.stat_duplicated`
+  says "Packets sent twice"; the counter was bumped whenever `decide()` returned a second release,
+  whatever `_enqueue` then did with it. Measured with a queue too small to hold the copy: **seen=40,
+  duplicated=40, and ZERO packets sent** - a session that put nothing on the wire reporting forty
+  duplicates.
+  - **Decision: fix the COUNTER, not the tooltip.** The project's own convention is that counters
+    report what happened - `corrupted` counts "successful payload flips only", and `rst_reset` /
+    `rst_sent` were deliberately SPLIT because they answer different questions. `duplicated` was the
+    exception. And "Packets sent twice" is the sentence a tester actually wants; rewording it to
+    "packets the tool decided to duplicate" would be accurate and less useful.
+  - `_enqueue` now returns **whether it QUEUED the packet**, which is a different question from
+    whether an overflow was counted - the two part company for a copy, since a refused copy is
+    deliberately not an overflow. The capture loop counts one duplicate per copy the queue accepted.
+  - Counted at ENQUEUE, not at send, which is the same standard `corrupted` is held to: the work was
+    really done, though a STOP can still strand the copy afterwards.
+  - `duplicated` is part of the NDJSON `sample` schema (`cli._sample_record`), hence BREAKING:
+    reports across this line are not comparable on that field.
+  - `test_overflow_counts_packets_lost_not_queue_entries` had `duplicated == n` as a SETUP sanity
+    check pinning the old meaning; it now asserts the new one (`queue // 2`, five copies fitting in
+    ten slots) with a note saying why. Its actual subject - `drop_overflow` never exceeding `seen` -
+    is untouched and still passes unchanged.
+  - New guard: `test_duplicated_counts_copies_that_were_queued_not_decisions`.
+- **Mutation-checked**: caching the rotation deadline again, removing the eviction floor, counting
+  duplicates per decision again, and making `_enqueue` report overflow instead of queued - all RED.
+
 ### Added: the port -> pid collapse stops being silent (ADR, no behaviour change)
 
 `portmap`'s map is keyed by the port NUMBER alone and merges four tables (tcp/v4, tcp/v6, udp/v4,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
   from a socket event lost under heavy load.
 
+### BREAKING
+
+- **BREAKING:** **"Duplicated" now counts packets that were actually sent twice, not packets the
+  tool decided to duplicate.** With duplication on and the tool under enough load to fill its
+  internal queue, the copy was quietly thrown away while the counter went up anyway. Measured on a
+  deliberately tiny queue: 40 packets in, **"Duplicated" read 40 while nothing at all reached the
+  wire**. The tile sits next to "Corrupted", which has always counted only the packets it really
+  changed, so this brings the two into line. Reports and NDJSON output from before and after this
+  change are not comparable on that field. Nothing else moved: the same packets are duplicated,
+  and the "Buffer overflow" tile already told you when the queue was the bottleneck.
+
 ### Added
 
 - **The tool now warns when your target shares a port with another program.** Windows lets several
@@ -240,6 +251,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   ..." line was written after the capture had already begun, so a session that failed in its first
   moments printed the error and the fault *above* its own start line. Anyone reading the log to work
   out what happened when was reading it out of order. It is now announced first.
+
+- **Turning NAT expiry off did not fully turn it off.** Switching it on tells the tool to remember
+  every connection for as long as the session lasts - it has to, or an expired mapping would quietly
+  reopen. Switching it back off was supposed to restore the normal "forget idle connections after
+  half a minute" behaviour, and did not: the tool kept every record for the rest of the run and only
+  released them when it ran out of room. Since every "Apply changes" re-sends all your settings, one
+  round trip through the NAT field was enough. Memory only - nothing was impaired differently.
+
+- **The Connections tab could empty itself instead of dropping its oldest rows.** Once the table is
+  full the tool discards roughly the oldest tenth, working from a sampled estimate of "old". If a
+  lot of rows carried the same timestamp, they all fell on the same side of that estimate and far
+  more went than intended - in the extreme, everything. It now refuses to drop below the level it
+  is trimming to, whatever the estimate says.
 
 - **Stopping a session could file a crash report for nothing.** If STOP landed inside the
   half-second housekeeping pass that keeps the socket map fresh, the tool tripped over its own

--- a/beantester/core.py
+++ b/beantester/core.py
@@ -84,7 +84,7 @@ class _FlowTable:
     older, never bigger.
     """
 
-    __slots__ = ("_new", "_old", "_limit", "_half", "_rotate_s", "_next_rotate",
+    __slots__ = ("_new", "_old", "_limit", "_half", "_rotate_s", "_last_rotate",
                  "_retired")
 
     def __init__(self, limit=MAX_FLOWS, rotate_s=FLOW_ROTATE_S):
@@ -93,7 +93,14 @@ class _FlowTable:
         self._rotate_s = float(rotate_s)
         self._new = {}
         self._old = {}
-        self._next_rotate = 0.0
+        # WHEN the last rotation happened, not when the next one is DUE. The
+        # deadline used to be cached as an absolute time, and ``keep_for`` changed
+        # the window without touching it - so a window that had been RAISED could
+        # never be lowered again for the life of the session. Measured: set_nat(5)
+        # (which raises the window to infinity) followed by set_nat(0) left the
+        # table with no age rotation at all, freed only by the SIZE ceiling. Derived
+        # live, a change to _rotate_s takes effect on the very next call.
+        self._last_rotate = 0.0
         # Retired generations wait here to be freed by the WATCHDOG, not by the
         # capture thread. Dropping the last reference to a dict is O(1) in Python
         # but O(n) in CPython's teardown: freeing a 200 000-entry generation costs
@@ -138,7 +145,16 @@ class _FlowTable:
             self._rotate()
 
     def keep_for(self, seconds):
-        """Raise the AGE window so a record survives at least ``seconds``.
+        """Set the AGE window so a record survives at least ``seconds``.
+
+        Takes effect at once, in BOTH directions. It used to only ever raise: the
+        rotation deadline was cached as an absolute time and this never touched it,
+        so once ``set_nat`` had pushed the window to infinity, ``set_nat(0)`` -
+        which plainly means "back to the default" - could not bring it down again
+        for the rest of the session, and the table was then freed only by its SIZE
+        ceiling. Every GUI "Apply" runs these setters, so toggling NAT off was
+        enough. See ``_last_rotate``.
+
 
         A record lives through one rotation and dies at the next, so the window is
         the MINIMUM lifetime: with the default 30 s an entry survives 30-60 s. That
@@ -156,10 +172,10 @@ class _FlowTable:
 
     def maybe_rotate(self, now):
         """Retire a generation on AGE. O(1): the old dict is handed to the watchdog."""
-        if len(self._new) < self._half and now < self._next_rotate:
+        if len(self._new) < self._half and (now - self._last_rotate) < self._rotate_s:
             return False
         self._rotate()
-        self._next_rotate = now + self._rotate_s
+        self._last_rotate = now
         return True
 
     def drain_retired(self):
@@ -176,7 +192,7 @@ class _FlowTable:
             self._retired.append(self._old)
         self._new = {}
         self._old = {}
-        self._next_rotate = 0.0
+        self._last_rotate = 0.0
 
     def __len__(self):
         return len(self._new) + len(self._old)

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -596,7 +596,19 @@ class BeanEngine:
         # ---- lock again, only for the cheap part -----------------------------
         with self._clock:
             doomed = [k for k, c in self._conns.items() if c["last"] <= cutoff]
-            for key in doomed:
+            # The cutoff is a SAMPLED estimate and the comparison is inclusive, so
+            # rows sharing one timestamp all fall on the same side of it. With
+            # enough ties that is far more than the estimate intended - and with
+            # every row on one stamp it is the WHOLE table. Measured against a
+            # 1000-row cap: 1200 rows trimmed to 0 instead of 900.
+            #
+            # Not reachable from ordinary traffic on this machine (time.monotonic()
+            # resolves to ~100 ns here, so a 1200-row burst still produced 865
+            # distinct stamps and trimmed correctly), but it costs one max() to
+            # make the estimate incapable of emptying the log, and a coarser clock
+            # is a platform property this code should not have to rely on.
+            allowed = max(0, len(self._conns) - int(self.MAX_CONNS * self.EVICT_KEEP))
+            for key in doomed[:allowed]:
                 self._conns.pop(key, None)
 
     # kept under its old name: the capture path no longer evicts, but callers
@@ -1478,13 +1490,23 @@ class BeanEngine:
             self._log_conn(key, remote_ip, remote_port, local_port, is_out, size,
                            now, proto, scoped=dec.scoped)
             rels = dec.releases
-            refused = self._enqueue(rels[0], packet, key=key, modified=modified)
+            queued = self._enqueue(rels[0], packet, key=key, modified=modified)
             if len(rels) > 1:
-                for rel in rels[1:]:
-                    self._enqueue(rel, packet, copy=True, key=key,
-                                  modified=modified)
-                self._bump("duplicated")
-            if refused:
+                # Counted per copy that the queue ACCEPTED, not per decision to
+                # duplicate. The tile says "Packets sent twice", and it used to be
+                # bumped whatever happened to the copy: with a full queue the copy
+                # was silently discarded and the number rose anyway. Measured with
+                # a tiny queue - seen=40, duplicated=40, and ZERO packets sent -
+                # a session that put nothing on the wire claiming 40 duplicates.
+                # Counted at ENQUEUE, deliberately, which is the same standard
+                # `corrupted` is held to: the work was really done, even though a
+                # STOP can still strand the copy before it leaves.
+                copies = sum(1 for rel in rels[1:]
+                             if self._enqueue(rel, packet, copy=True, key=key,
+                                              modified=modified))
+                if copies:
+                    self._bump("duplicated", copies)
+            if not queued:
                 # A packet the QUEUE threw away used to count nowhere in its row:
                 # `dropped` was recorded from `dec.drop` alone, one step too early.
                 # Measured drop_overflow=5500 against `dropped=0` in the row it
@@ -1685,8 +1707,11 @@ class BeanEngine:
     def _enqueue(self, release, packet, copy=False, key=None, modified=False):
         """Queue one release of ``packet`` for delayed injection.
 
-        Returns True when the queue refused it, so the caller can record the loss
-        against the flow's row. ``key`` rides along in the queue entry: the
+        Returns True when the packet was actually QUEUED - not whether an overflow
+        was counted, which is a different question and the two part company for a
+        duplicate. The caller uses it twice: to record the loss against the flow's
+        row when an ORIGINAL was refused, and to count a duplicate only when its
+        copy really went into the queue. ``key`` rides along in the queue entry: the
         injector needs it to credit the DELIVERED bytes to the right row, and
         ``stop()`` needs it to charge whatever is still parked here to the rows
         that will never receive it.
@@ -1721,11 +1746,13 @@ class BeanEngine:
         """
         with self._cv:
             if len(self._heap) >= self.max_queue:
+                queued = False
+                # A refused COPY is still not an overflow: see above.
                 overflowed = not copy
                 if overflowed:
                     self._bump("drop_overflow")
             else:
-                overflowed = False
+                queued, overflowed = True, False
                 heapq.heappush(self._heap,
                                (release, next(self._counter), packet, copy, key,
                                 modified))
@@ -1736,7 +1763,7 @@ class BeanEngine:
                 self._cv.notify()
         if overflowed:
             self._warn_overflow()       # outside the lock: it logs, and logging waits
-        return overflowed
+        return queued
 
     def _inject_loop(self):
         while self._running:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -418,8 +418,13 @@ def test_overflow_counts_packets_lost_not_queue_entries():
     s = sh.stats_snapshot()
     sh.stop()
 
-    check("overflow/dup: every packet was duplicated",
-          s["duplicated"] == n, f"(duplicated={s['duplicated']}, seen={s['seen']})")
+    # `duplicated` counts copies the queue ACCEPTED, so with ten slots and two
+    # entries per packet it is five - not 200. It used to read 200 here, because
+    # the counter was bumped on the DECISION to duplicate whatever became of the
+    # copy; that is the F5 fix, and this line is where the old meaning was pinned.
+    check("overflow/dup: only the copies that fit are counted as duplicated",
+          s["duplicated"] == queue // 2,
+          f"(duplicated={s['duplicated']}, seen={s['seen']})")
     check("overflow/dup: drops never exceed the packets they are drops OF",
           s["drop_overflow"] <= s["seen"],
           f"(overflow={s['drop_overflow']}, seen={s['seen']})")
@@ -643,6 +648,127 @@ def test_every_captured_packet_is_accounted_for_under_every_impairment(name):
           f"dup={s['duplicated']} overflow={s['drop_overflow']})")
     check(f"[{name}] and nothing was counted twice", s["drop_overflow"] == 0,
           "(the queue overflowed - this run cannot answer the question)")
+
+
+def test_the_flow_table_age_window_can_be_lowered_again_not_only_raised():
+    """Audit F3/T5. ``keep_for`` sets the window; it used to only ever raise it.
+
+    The rotation deadline was cached as an absolute time and ``keep_for`` changed
+    the window without touching it. ``set_nat(>0)`` pushes the window to infinity
+    on purpose (an expired NAT mapping must stay shut until the application sends,
+    so the record has to outlive any timer), and ``set_nat(0)`` plainly means "back
+    to the default" - but it could not bring the deadline back down, so for the
+    rest of the session that table aged out nothing and was freed only by its SIZE
+    ceiling. Every GUI "Apply" runs these setters, so toggling NAT off was enough.
+    """
+    from beantester.core import FLOW_ROTATE_S, _FlowTable
+
+    table = _FlowTable(limit=1000, rotate_s=FLOW_ROTATE_S)
+    table.set("a", 1.0)
+    table.maybe_rotate(100.0)
+
+    table.keep_for(float("inf"))                      # what set_nat(5) does
+    check("an infinite window stops the age rotation",
+          table.maybe_rotate(1e9) is False)
+
+    table.keep_for(0.0)                               # ...and what set_nat(0) does
+    check("lowering the window takes effect at once",
+          table.maybe_rotate(1e9) is True,
+          "(the raised window was never brought back down)")
+
+    # and the same through the real setters, which is how a session reaches it
+    core = BeanCore()
+    core.reset_buckets(0.0)
+    rng = random.Random(0)
+    core.set_nat(5.0)
+    for i in range(10):
+        core.decide(100, True, 5000 + i, float(i), rng, remote_ip="1.2.3.4",
+                    remote_port=80)
+    check("NAT filled the flow table", len(core._flow_last) == 10,
+          f"({len(core._flow_last)})")
+    core.set_nat(0.0)
+    core._prune_next = 0.0
+    core._prune(1e9)
+    core._prune_next = 0.0
+    core._prune(2e9)                                  # two rotations retire both gens
+    check("with NAT off again the records age out",
+          len(core._flow_last) == 0, f"({len(core._flow_last)} left)")
+
+
+def test_evicting_the_connection_log_can_never_empty_it():
+    """Audit F4/T6. The eviction cutoff is a SAMPLED estimate, compared inclusively.
+
+    Rows sharing a timestamp all land on the same side of it, so a tie storm
+    removes far more than the estimate intended - and with every row on one stamp
+    it is the whole table. Measured before the floor: 1200 rows against a 1000 cap
+    trimmed to 0 instead of 900, i.e. the Connections tab silently emptied itself
+    while claiming to drop the oldest tenth.
+
+    Not reachable from ordinary traffic on this machine (``time.monotonic()``
+    resolves to ~100 ns, so a 1200-row burst still produced 865 distinct stamps),
+    which is exactly why it needs a test rather than a demonstration: the clock's
+    resolution is a platform property this code should not depend on.
+    """
+    def rows(engine, stamps):
+        for i, last in enumerate(stamps):
+            engine._conns[i] = dict(remote_ip="1.1.1.1", remote_port=1, local_port=i,
+                                    proto="TCP", packets=1, bytes=1, bytes_in=0,
+                                    bytes_out=0, sent=0, sent_in=0, sent_out=0,
+                                    dropped=0, first=last, last=last, dir="out",
+                                    scoped=False, proc="", pid=None)
+
+    keep = int(1000 * BeanEngine.EVICT_KEEP)
+
+    tied = BeanEngine()
+    tied.MAX_CONNS = 1000
+    rows(tied, [12345.0] * 1200)                      # every row on ONE stamp
+    tied._trim_conns()
+    check("a tie storm trims to the floor instead of wiping the log",
+          len(tied._conns) == keep, f"({len(tied._conns)} left, expected {keep})")
+
+    spread = BeanEngine()
+    spread.MAX_CONNS = 1000
+    rows(spread, [12345.0 + i * 1e-6 for i in range(1200)])
+    spread._trim_conns()
+    check("ordinary rows still trim to about the keep fraction",
+          keep <= len(spread._conns) <= keep + 50,
+          f"({len(spread._conns)} left, expected ~{keep})")
+    check("...and the SURVIVORS are the newest ones",
+          min(c["last"] for c in spread._conns.values()) > 12345.0,
+          "(an old row survived while a newer one was evicted)")
+
+
+def test_duplicated_counts_copies_that_were_queued_not_decisions():
+    """Audit F5/T8. The tile says "Packets sent twice" - so it has to count sends.
+
+    ``duplicated`` was bumped on the DECISION to duplicate, whatever became of the
+    copy. Measured with a queue too small to hold it: seen=40, duplicated=40, and
+    ZERO packets on the wire - a session that delivered nothing claiming forty
+    duplicates. Counted at ENQUEUE rather than at send, which is the same standard
+    ``corrupted`` is held to: the work was really done, though a STOP can still
+    strand the copy afterwards.
+    """
+    n = 40
+    engine = BeanEngine()
+    engine.set_seed(7)
+    engine.max_queue = 4                              # nothing like enough room
+    apply_settings(engine, dict(DEFAULT_SETTINGS, dup=100, latency=60000))
+    divert = FakeDivert([FakePacket(size=100, port=6000 + i) for i in range(n)])
+    engine.start("test", divert=divert)
+    deadline = time.time() + 15
+    while time.time() < deadline and engine.stats_snapshot()["seen"] < n:
+        time.sleep(0.01)
+    s = engine.stats_snapshot()
+    engine.stop()
+
+    check("every packet was seen", s["seen"] == n, f"({s['seen']})")
+    check("the queue was the bottleneck", s["drop_overflow"] > 0,
+          f"(overflow={s['drop_overflow']})")
+    check("duplicates are counted only for copies the queue took",
+          s["duplicated"] == engine.max_queue // 2,
+          f"(duplicated={s['duplicated']}, room for {engine.max_queue // 2})")
+    check("...and never more than the packets they are duplicates OF",
+          s["duplicated"] <= s["seen"], f"({s['duplicated']} > {s['seen']})")
 
 
 def test_a_dropped_packet_is_always_in_impairment_scope():


### PR DESCRIPTION
## What and why

The last three findings from the engine stability audit, plus the test gaps (T5, T6, T8) that were deliberately held back until their subjects worked.

### F3 - the flow table's age window could only ever be raised

`_FlowTable.keep_for` set `_rotate_s` but the rotation deadline was cached as an **absolute** `_next_rotate`, which it never touched. `set_nat(>0)` pushes the window to infinity on purpose - an expired NAT mapping must stay shut until the application sends, so the record has to outlive any timer - and `set_nat(0)` plainly means "back to the default", but could not bring the deadline down again. For the rest of the session that table aged out nothing and was freed only by its SIZE ceiling. Every GUI "Apply" runs every setter, so **one round trip through the NAT field was enough**.

Fixed by removing the class rather than the symptom: the table now stores `_last_rotate` (when the last rotation *happened*) and derives the deadline live, so a change to the window takes effect on the very next call — in either direction, with no reset for anyone to remember.

Impact was memory only. A retired record reads back as "never seen", which the NAT check treats as pass, so this could lose an impairment and never invent one.

### F4 - eviction could empty the connection log instead of trimming it

The cutoff is a **sampled estimate** compared inclusively (`c["last"] <= cutoff`), so rows sharing a timestamp all land on the same side of it. Measured against a 1000-row cap: **1200 rows trimmed to 0 instead of 900** — the Connections tab silently emptying itself while claiming to drop the oldest tenth.

Not reachable from ordinary traffic on this machine: `time.monotonic()` resolves to ~100 ns here (26 204 ties in 200 000 reads), and a 1200-row burst still produced 865 distinct stamps and trimmed correctly. That is exactly why it gets a test rather than a demonstration — the clock's resolution is a platform property this code should not lean on.

Fixed with a floor: never evict below the level being trimmed to, whatever the estimate says.

### F5 (BREAKING) - "Duplicated" counted the decision, not the copy

`tips.stat_duplicated` says **"Packets sent twice"**. The counter was bumped whenever `decide()` returned a second release, whatever `_enqueue` then did with it. Measured with a queue too small to hold the copy: **seen=40, duplicated=40, and ZERO packets on the wire** — a session that delivered nothing reporting forty duplicates.

**Decision: fix the counter, not the tooltip.** The project's own convention is that counters report what happened — `corrupted` counts "successful payload flips only", and `rst_reset` / `rst_sent` were deliberately *split* because they answer different questions. `duplicated` was the exception. And "Packets sent twice" is the sentence a tester actually wants; rewording it to "packets the tool decided to duplicate" would be accurate and less useful.

`_enqueue` now returns **whether it queued the packet**, which is a different question from whether an overflow was counted — the two part company for a copy, since a refused copy is deliberately not an overflow. Counted at *enqueue* rather than at send, the same standard `corrupted` is held to: the work was really done, though a STOP can still strand the copy afterwards.

`duplicated` is part of the NDJSON `sample` schema (`cli._sample_record`), hence **BREAKING** — reports across this line are not comparable on that field. No version bump; that is the owner's call via `VERSION.txt`.

## Reviewer notes

- `test_overflow_counts_packets_lost_not_queue_entries` went red, and the number was **not** adjusted to make it green. Its docstring says its subject is `drop_overflow`; the `duplicated == n` line was a *setup sanity check* pinning the old meaning. It now asserts the new one (`queue // 2` — five copies fitting in ten slots) with a note saying why. Its actual assertions are untouched and still pass unchanged.
- The F4 guard also asserts the **survivors are the newest rows**, so the floor cannot be satisfied by keeping the wrong ones.
- The F3 guard exercises both the unit (`_FlowTable.keep_for`) and the real path a session takes (`set_nat` up, then down, then the records must age out).

## Verification

- Full suite green: **792 tests**
- **Four mutants, all RED**: caching the rotation deadline again, removing the eviction floor, counting duplicates per decision again, and making `_enqueue` report overflow instead of queued
- Three rows added to the PROJECT_NOTES regression surface (that file is gitignored, so it is not in this diff)

With this, every finding from the audit is closed: F1, F2, F3, F4, F5, F6, the watchdog TOCTOU and the shared-port ADR, plus test gaps T1-T8.

## Checklist

- [x] `python -m pytest tests` passes locally.
- [x] New behaviour has tests (see `tests/` for the style).
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. *(no new UI text - the "Duplicated" tooltip was already correct; the counter was not)*
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
