### PR TITLE
feat(profiles): widen the profile scope to 12 fields, derived from the field registry

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -56,6 +56,25 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   - `presets.py` gained module-level imports of `fields` and `settings`. No cycle: nothing in
     `settings`'s dependency chain imports `presets` (checked), and `test_layering.py` is green.
 
+- **BREAKING:** **`--preset` applies a preset through the shared mapping** (`cli.py`), instead of
+  the copy of it that hand-wrote the seven classic keys. The GUI has always used
+  `preset_to_settings`, so the two front ends applied different subsets of the same preset name;
+  the only guard, `test_cli.py::test_cli_english`, asserts `latency` and `down` and nothing else.
+  With the profile scope widened this also stopped being a silent difference: the copy indexed
+  `p["corrupt"]` directly, so the first preset naming only the fields it means would have taken the
+  CLI down with a `KeyError` (reproduced against the future `presets.leo` shape before the fix).
+  Documented precedence is unchanged (defaults < file < preset < flags), but a preset now carries
+  five more keys, so `--config f.json --preset presets.3g` resets `buffer`, `spike_*` and `flap_*`
+  to their defaults where it previously left the file's values in place - the same rule that has
+  always applied to `loss` and `down`.
+  Tests: `test_cli.py::test_a_preset_carries_every_profile_field_into_the_settings` (new) drives a
+  PROBE preset whose every profile field is non-default, because run against the twelve real
+  presets the check is vacuous - none of them names a buffer, a spike or a flap, so the old copy
+  left exactly the defaults the shared mapping fills in, and the test would pass against the code
+  it exists to reject. `::test_a_preset_that_names_only_some_fields_does_not_break_the_cli` (new)
+  covers the partial-preset `KeyError`. Both verified by mutation: reverting `cli.py` turns them
+  red with `buffer 1000 != 1007` and `KeyError: 'corrupt'` respectively.
+
 - **BREAKING:** the effective-loss figure is redefined at both ends (audit F4). `gui/pages/stats.py`
   and `repro.py` computed `100 * drop_loss / seen`. The numerator was the configured Loss alone,
   ignoring `drop_rate`, `drop_flap`, `drop_block`, `drop_syn`, `drop_mtu`, `drop_nat`, `drop_rst`

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -19,6 +19,43 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### BREAKING
 
+- **BREAKING:** **the profile scope grew from 7 fields to 12**, and the shape a profile is stored
+  in is now DERIVED from the field registry instead of a second hand-written table. `spike_prob`,
+  `spike_ms`, `flap_period`, `flap_down` and `buffer` are marked `in_profile=True` in
+  `fields.FIELD_DEFS`; `presets.PRESET_TO_SETTING` is built from `Field.in_profile` +
+  the new `Field.preset_key` (the frozen short keys `lat`/`jit` are now declared by the registry,
+  not translated by a second table). This reverses the "Variant A" decision that deliberately kept
+  a profile to the seven classic preset fields - flapping is PERIODIC and phase-locked to the
+  session start (`BeanCore.decide` step 5), so it is the one impairment that lets a profile
+  describe a link that drops out on a cadence, which no other profile field can express.
+  Consequences worth naming:
+  - `PROFILE_FIELDS` had **no production consumer** before this (only `test_field_registry.py`);
+    what a profile actually stored came from `PRESET_TO_SETTING` in another module, so the two
+    could drift with nothing to notice. `in_profile` is now the only switch.
+  - `preset_to_settings()` is **always complete**: a preset names only the fields it means, and
+    every other profile field comes back at its `DEFAULT_SETTINGS` value. A partial answer would
+    leave the previous profile's flapping on screen after picking a clean link.
+  - The fill is the field's **default, not zero**. `buffer` defaults to 1000 ms and 0 means
+    UNBOUNDED there, so a blanket zero-fill would have quietly reinstated the runaway token bucket
+    (`BeanCore.decide` step 11) on every preset pick. `settings_to_preset()` lost its hardcoded
+    `0` fallback for the same reason.
+  - `buffer` is the only profile field that cannot impair anything on its own: both of its readers
+    sit inside `if rate > 0` (`decide` steps 11 and 12), so with no speed limit it touches no
+    packet. It is in the profile because `down`/`up` are - the buffer is what decides whether that
+    same limit shows up as DELAY or as LOSS.
+  - Visible effect for existing presets: none of the twelve names a buffer, so picking one now sets
+    the buffer to 1000 ms explicitly where it previously left the widget alone.
+  - Tests: `test_field_registry.py::test_the_stored_profile_shape_follows_the_registry` (new - the
+    stored shape covers exactly `PROFILE_FIELDS`, the short keys stay short, every stored field has
+    a default); `test_validators_settings.py::test_a_preset_always_yields_every_profile_field`
+    (new - unnamed fields come back as defaults, not zero and not missing);
+    `test_passthrough.py::PRESET_OFF` is now derived from `IMPAIRMENT_OFF` intersected with the
+    profile scope, so an impairment joining the scope cannot be forgotten there, and `buffer` is
+    correctly excluded (demanding `buffer == 0` of a harmless preset would demand an unbounded
+    buffer). `test_profile_scope_is_derived` updated to the 12 fields.
+  - `presets.py` gained module-level imports of `fields` and `settings`. No cycle: nothing in
+    `settings`'s dependency chain imports `presets` (checked), and `test_layering.py` is green.
+
 - **BREAKING:** the effective-loss figure is redefined at both ends (audit F4). `gui/pages/stats.py`
   and `repro.py` computed `100 * drop_loss / seen`. The numerator was the configured Loss alone,
   ignoring `drop_rate`, `drop_flap`, `drop_block`, `drop_syn`, `drop_mtu`, `drop_nat`, `drop_rst`

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -75,6 +75,29 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   covers the partial-preset `KeyError`. Both verified by mutation: reverting `cli.py` turns them
   red with `buffer 1000 != 1007` and `KeyError: 'corrupt'` respectively.
 
+- **`ProfileStore._clean` falls back to each field's DEFAULT, not to zero** (`gui/profiles.py`).
+  `float(values.get(key, 0) or 0)` was correct only while every profile field defaulted to zero.
+  It does not any more: a `profiles.json` written before the scope widened has no `buffer` key, and
+  `buffer = 0` means an UNBOUNDED link buffer, so the old fill would have loaded every profile
+  saved by an earlier version as the runaway token bucket the bounded buffer exists to prevent -
+  silently, on settings the user had already saved. Absence (`null` and `""` included) now takes
+  `presets.PRESET_DEFAULTS[key]`; an explicit `0` in the file stays 0, because that is what "no cap
+  on the queue" looks like when it is meant. The on-disk format therefore needs NO migration and no
+  version field: it stays backward compatible (fewer keys read fine) and forward compatible (an
+  older build ignores keys it does not know, losing only the new fields).
+  Side effect of dropping `or 0`: a falsy non-numeric value (`[]`, `{}`) now drops the profile and
+  reports it via `store.problem`, where it used to load silently as 0. That matches what the module
+  promises - validate every entry, drop what it cannot use, and say so.
+  Tests (all new, `test_release_fixes.py`):
+  `::test_a_profile_from_before_the_wider_scope_loads_with_field_defaults` - a seven-key file loads
+  with its own values, `buffer` at the default and the impairments it never named off; verified by
+  mutation (restoring the blanket zero turns it red with `buffer 0.0`).
+  `::test_an_explicit_zero_buffer_is_not_the_same_as_a_missing_one` - the paired constraint that
+  makes the fallback usable; it is deliberately NOT a regression guard (it survives the mutation,
+  because both paths yield 0 there).
+  `::test_a_profile_round_trips_the_widened_scope` - save and load carry `flap_*`, `spike_*` and
+  `buffer`, through the same `settings_to_preset` call `App.save_profile` makes.
+
 - **BREAKING:** the effective-loss figure is redefined at both ends (audit F4). `gui/pages/stats.py`
   and `repro.py` computed `100 * drop_loss / seen`. The numerator was the configured Loss alone,
   ignoring `drop_rate`, `drop_flap`, `drop_block`, `drop_syn`, `drop_mtu`, `drop_nat`, `drop_rst`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### BREAKING
 
+- **BREAKING:** **Profiles now remember more of the link.** A profile used to store seven things
+  about a connection: loss, corruption, duplication, latency, jitter and the two speed limits. It
+  now also stores the latency spikes, the link outages (flapping) and the buffer. The outages are
+  the reason this was worth doing: they repeat on a fixed cadence, so a profile can finally describe
+  a link that cuts out every so often - a satellite handover, a flaky uplink - which none of the
+  other fields could say. Four things follow from it:
+  - **Profiles you saved with an earlier version load exactly as before.** The fields they never had
+    are simply off, and the buffer keeps its normal 1000 ms instead of quietly becoming unlimited.
+  - **Picking a preset or a profile now sets all of those fields at once.** None of the twelve
+    built-in presets mentions a spike, an outage or a buffer, so those go back to their defaults
+    rather than keeping whatever was left in the form: "Perfect network" now really does clear
+    everything. If you had dialled the buffer yourself, picking a preset resets it to 1000 ms.
+  - **`--preset` on the command line now does the same thing the window does.** It applied only the
+    original seven values, so the same preset name could produce different traffic depending on
+    which one you started it from.
+  - If you open a profile saved by this version in an older build, the new fields are ignored.
+
 - **BREAKING:** **The reproduction report's "connections reset" counted packets, not connections.**
   It held the number of packets a reset connection swallows while it is held down, which for a
   30 second cooldown on a busy connection is thousands against a handful of actual resets - one

--- a/README.md
+++ b/README.md
@@ -284,6 +284,14 @@ International roaming, Satellite link, 56k modem, Terrible network - plus your o
 name). The program **always starts on "Perfect network"** (nothing is impaired until you set
 something). Built-in presets cannot be deleted - the "Delete" button is disabled for them.
 
+A profile stores **what the link is like**: loss, corruption, duplication, latency, jitter, latency
+spikes, link outages (flapping), the speed limits and the buffer. Everything else - the target, the
+destination, blocking, RST, MTU, NAT expiry, the schedule, the seed - stays out of it; saving a
+profile warns you about the ones you currently have switched on. Use **"Save file..."** for the
+complete configuration. Picking a profile or a preset sets **all** of those fields at once,
+including the ones a given preset does not mention - those go back to their default, so "Perfect
+network" really means perfect. Profiles saved by an earlier version load unchanged.
+
 In the CLI (`--preset`) a preset can be given by its **canonical id** or a **name in any UI
 language** (case- and Polish-diacritic-insensitive - `"Perfect network"` works too). Ids:
 `presets.perfect`, `presets.good_wifi`, `presets.5g`, `presets.lte`, `presets.dsl`,

--- a/README.pl.md
+++ b/README.pl.md
@@ -209,6 +209,8 @@ jest martwe przez podany procent czasu. Symuluje migające połączenie.
 
 **Profile** - gotowe presety **posortowane od najlepszego (góra) do najgorszego (dół)**: Idealna sieć, Dobre WiFi, Sieć 5G, Sieć LTE/4G, DSL domowy, Słabe WiFi, Kawiarnia (zatłoczone WiFi), Sieć 3G, Roaming zagraniczny, Łącze satelitarne, Modem 56k, Fatalna sieć - oraz Twoje własne (zapis pod nazwą). Program **startuje zawsze na „Idealnej sieci”** (nic nie jest psute, dopóki sam czegoś nie ustawisz). Presetów wbudowanych nie da się usunąć - przycisk „Usuń” jest wtedy nieaktywny.
 
+Profil zapisuje to, **jakie jest łącze**: stratę, uszkodzenia, duplikację, opóźnienie, jitter, skoki latencji, przerwy w łączu (flapping), limity prędkości i bufor. Reszta ustawień - cel, adres docelowy, blokada, RST, MTU, wygasanie NAT, harmonogram, seed - do profilu nie wchodzi; przy zapisie zobaczysz ostrzeżenie z listą tych, które akurat masz włączone. Pełną konfigurację zapisujesz przyciskiem **„Zapisz plik...”**. Wybranie profilu albo presetu ustawia **wszystkie** te pola naraz, także te, których dany preset nie wymienia - wracają wtedy do wartości domyślnej, żeby „Idealna sieć” naprawdę znaczyła idealną. Profile zapisane wcześniejszą wersją wczytują się bez zmian.
+
 W CLI (`--preset`) preset można podać przez **kanoniczne id** albo **nazwę w dowolnym języku UI** (bez rozróżniania wielkości liter i polskich znaków - `"Idealna siec"` też zadziała). Id: `presets.perfect`, `presets.good_wifi`, `presets.5g`, `presets.lte`, `presets.dsl`, `presets.weak_wifi`, `presets.cafe`, `presets.3g`, `presets.roaming`, `presets.satellite`, `presets.modem56k`, `presets.terrible`.
 
 ## Składnia filtrów (proces / IP / port)

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -25,7 +25,7 @@ from .engine import BeanEngine
 from .fields import BOOL, FIELD_DEFS
 from .filters import CLI_FILTERS
 from .paths import is_frozen
-from .presets import PRESETS, resolve_preset
+from .presets import PRESETS, preset_to_settings, resolve_preset
 from .repro import save_repro_report, settings_to_cli_string
 from .scenario import load_scenario_file
 from .settings import (DEFAULT_SETTINGS, apply_settings, build_matchers,
@@ -210,9 +210,14 @@ def config_from_args(args):
         if canon is None:
             _fail(exitcodes.CONFIG, f"unknown preset: {args.preset!r} "
                                     f"(canonical ids: {', '.join(PRESETS)})")
-        p = PRESETS[canon]
-        s.update(loss=p["loss"], corrupt=p["corrupt"], dup=p["dup"],
-                 latency=p["lat"], jitter=p["jit"], down=p["down"], up=p["up"])
+        # Through the SHARED mapping, not a copy of it. This used to hand-write
+        # the seven classic keys, which meant the GUI (which has always gone
+        # through preset_to_settings) and the CLI applied different subsets of
+        # the same preset: a profile field the copy did not know about reached
+        # one front end and not the other, under the same preset name. Since a
+        # preset may now name only the fields it means something by, the copy
+        # would also KeyError on the first partial preset.
+        s.update(preset_to_settings(PRESETS[canon]))
 
     # The flag -> settings-key mapping is DERIVED from the field registry, not
     # hand-written. It used to be a literal dict here, which meant a new field had

--- a/beantester/fields.py
+++ b/beantester/fields.py
@@ -49,6 +49,7 @@ class Field(NamedTuple):
     tip: str = ""                  # i18n key of the tooltip
     hint: str = ""                 # i18n key of the greyed hint next to the entry
     in_profile: bool = False       # stored by a user profile / built-in preset
+    preset_key: str = ""           # short key a preset/profile stores it under ("" = key)
     span: bool = False             # takes a whole row in the section grid
     cli: str = ""                  # argparse flag (without "--")
     overridden_by: str = ""        # key of a field that makes this one inert
@@ -82,20 +83,32 @@ FIELD_DEFS = (
           bounds=RATE, tip="tips.up_limit", in_profile=True, cli="up",
           overridden_by="rate_schedule", override_note="fields.schedule_overrides"),
     # The link buffer for the speed limit: how much queueing delay a rate-limited
-    # link may build up before it drops (bufferbloat), in ms. 0 = unbounded. NOT
-    # in_profile (like the other advanced impairments): only the seven classic
-    # preset fields are stored in a profile. It applies to the constant limits AND
-    # to a schedule, so it is NOT overridden_by the schedule.
+    # link may build up before it drops (bufferbloat), in ms. 0 = unbounded. It
+    # applies to the constant limits AND to a schedule, so it is NOT
+    # overridden_by the schedule.
+    #
+    # in_profile even though it is the one profile field that cannot impair
+    # anything on its own: both readers sit inside `if rate > 0` (core.decide
+    # steps 11 and 12), so with no speed limit it touches no packet. It belongs
+    # to a profile anyway, because `down`/`up` do: the buffer is what decides
+    # whether that same limit shows up as DELAY or as LOSS, and a profile that
+    # stored the limit without it stored half the link.
     Field("buffer", NUMBER, "fields.buffer", "speed_limit", unit="ms",
           bounds=MS, width=8, tip="tips.buffer", hint="fields.buffer_hint",
-          span=True, cli="buffer",
+          span=True, cli="buffer", in_profile=True,
           help_title="dialogs.buffer_help_title", help_body="dialogs.buffer_help"),
 
     # -- latency ----------------------------------------------------------- #
+    # preset_key: presets and profiles have stored these two under short names
+    # since the first version. The file on disk is a frozen format (a profile
+    # written by any release must still load), so the short names stay and the
+    # registry declares them instead of a second table doing the translation.
     Field("latency", NUMBER, "fields.latency", "latency", unit="ms",
-          bounds=MS, tip="tips.latency", in_profile=True, cli="latency"),
+          bounds=MS, tip="tips.latency", in_profile=True, preset_key="lat",
+          cli="latency"),
     Field("jitter", NUMBER, "fields.jitter", "latency", unit="ms",
-          bounds=MS, tip="tips.jitter", in_profile=True, cli="jitter"),
+          bounds=MS, tip="tips.jitter", in_profile=True, preset_key="jit",
+          cli="jitter"),
 
     # -- impairments ------------------------------------------------------- #
     Field("loss", NUMBER, "fields.loss", "impairments", unit="%",
@@ -106,10 +119,16 @@ FIELD_DEFS = (
           bounds=PCT, width=6, tip="tips.dup", in_profile=True, cli="dup"),
 
     # -- flapping ---------------------------------------------------------- #
+    # in_profile: the outage is PERIODIC and phase-locked to the session start
+    # (core.decide step 5), so a profile carrying these two reproduces a link
+    # that drops out on a cadence - which is what a satellite handover or a
+    # flaky uplink actually looks like, and what no other profile field can say.
     Field("flap_period", NUMBER, "fields.period", "flapping", unit="s",
-          bounds=SECONDS, width=6, tip="tips.flap", cli="flap-period"),
+          bounds=SECONDS, width=6, tip="tips.flap", in_profile=True,
+          cli="flap-period"),
     Field("flap_down", NUMBER, "fields.flap_down_pct", "flapping", unit="%",
-          bounds=PCT, width=6, tip="tips.flap", cli="flap-down"),
+          bounds=PCT, width=6, tip="tips.flap", in_profile=True,
+          cli="flap-down"),
 
     # -- destination ------------------------------------------------------- #
     Field("dst_ip", EXPR, "fields.ip", "destination", expr_kind=KIND_IP,
@@ -134,9 +153,11 @@ FIELD_DEFS = (
           unit_key="fields.unit_b_off", bounds=(0.0, 65535.0), width=8,
           tip="tips.mtu", cli="max-size"),
     Field("spike_prob", NUMBER, "fields.spike_prob", "advanced", unit="%",
-          bounds=PCT, width=6, tip="tips.spike", cli="spike-prob"),
+          bounds=PCT, width=6, tip="tips.spike", in_profile=True,
+          cli="spike-prob"),
     Field("spike_ms", NUMBER, "fields.spike_ms", "advanced", unit="ms",
-          bounds=MS, width=8, tip="tips.spike", cli="spike-ms"),
+          bounds=MS, width=8, tip="tips.spike", in_profile=True,
+          cli="spike-ms"),
     Field("nat_timeout", NUMBER, "fields.nat_timeout", "advanced",
           unit_key="fields.unit_s_off", bounds=SECONDS, width=6,
           tip="tips.nat", cli="nat-timeout"),

--- a/beantester/gui/profiles.py
+++ b/beantester/gui/profiles.py
@@ -1,15 +1,20 @@
 """Persistence of user-defined profiles (JSON file next to the app).
 
-A profile stores the 7 link-characteristic fields a preset stores (see
-``presets.settings_to_preset``). The file is the user's - it can be edited,
-deleted or corrupted between two runs, and none of that may break startup or
-destroy the rest of the profiles.
+A profile stores the link-characteristic fields a preset stores (see
+``presets.settings_to_preset``) - the field registry decides which those are.
+The file is the user's - it can be edited, deleted or corrupted between two
+runs, and none of that may break startup or destroy the rest of the profiles.
+
+The format is FORWARD and BACKWARD compatible by construction: a file written
+before the profile scope widened simply has fewer keys, and each missing one
+falls back to that field's default (see ``_clean``); a file written after it is
+read by an older build, which ignores the keys it does not know.
 """
 from ..jsonfile import read_json, write_json
 from ..paths import PROFILE_FILE
-from ..presets import PRESET_TO_SETTING
+from ..presets import PRESET_DEFAULTS, PRESET_TO_SETTING
 
-VALUE_KEYS = tuple(PRESET_TO_SETTING)          # loss, corrupt, dup, lat, jit, down, up
+VALUE_KEYS = tuple(PRESET_TO_SETTING)          # short keys, in registry order
 
 
 class ProfileStore:
@@ -41,13 +46,28 @@ class ProfileStore:
 
     @staticmethod
     def _clean(values):
-        """A profile is 7 numbers; anything else is not a profile."""
+        """One number per profile field; anything else is not a profile.
+
+        A field the file does not mention falls back to THAT FIELD'S DEFAULT,
+        not to zero. The old blanket zero was right only while every profile
+        field defaulted to zero: ``buffer`` defaults to 1000 ms and 0 means an
+        UNBOUNDED link buffer there, so a zero-fill would have turned every
+        profile written before the scope widened into the runaway token bucket
+        the bounded buffer exists to prevent (``BeanCore.decide`` step 11).
+
+        An explicit ``0`` in the file stays 0 - that is what "no cap on the
+        queue" looks like when the user means it - so absence and zero must not
+        collapse into each other. ``null`` and ``""`` count as absence.
+        """
         if not isinstance(values, dict):
             return None
         out = {}
         for key in VALUE_KEYS:
+            raw = values.get(key)
+            if raw is None or raw == "":
+                raw = PRESET_DEFAULTS[key]
             try:
-                out[key] = float(values.get(key, 0) or 0)
+                out[key] = float(raw)
             except (TypeError, ValueError):
                 return None
         return out

--- a/beantester/presets.py
+++ b/beantester/presets.py
@@ -6,7 +6,9 @@ language files, and ``resolve_preset`` accepts either form.
 """
 import unicodedata
 
+from .fields import FIELD_DEFS
 from .i18n import loaded_language_codes, translate
+from .settings import DEFAULT_SETTINGS
 
 PRESETS = {
     # ordered best -> worst (top = best network, bottom = worst)
@@ -53,27 +55,45 @@ def resolve_preset(name):
     return None
 
 
-# Presets use short keys (lat/jit/...) for historical reasons; the settings model
-# uses the long ones. The mapping lives HERE, once - the GUI and the CLI used to
-# each carry their own copy of it.
-PRESET_TO_SETTING = {"loss": "loss", "corrupt": "corrupt", "dup": "dup",
-                     "lat": "latency", "jit": "jitter", "down": "down", "up": "up"}
+# Presets store their fields under short keys ("lat", "jit") and the settings
+# model uses the long ones. Which is which is DERIVED from the field registry
+# (``Field.in_profile`` + ``Field.preset_key``), so a field joins the profile
+# scope by exactly one flag. It used to be a second hand-written table, which
+# meant ``in_profile`` could say a field was in a profile while the save path
+# quietly dropped it - the flag and the storage disagreeing with nothing to
+# notice.
+PRESET_TO_SETTING = {(f.preset_key or f.key): f.key
+                     for f in FIELD_DEFS if f.in_profile}
+SETTING_TO_PRESET = {v: k for k, v in PRESET_TO_SETTING.items()}
+
+# What a profile field holds when nobody asked for anything. NOT zero: ``buffer``
+# defaults to 1000 ms and 0 means UNBOUNDED there - the runaway token bucket the
+# bounded buffer exists to prevent (see BeanCore.decide step 11). Filling a
+# missing field with a blanket zero would have quietly reinstated it.
+PRESET_DEFAULTS = {short: DEFAULT_SETTINGS[long]
+                   for short, long in PRESET_TO_SETTING.items()}
 
 
 def preset_to_settings(preset):
-    """``PRESETS`` entry (or preset id/name) -> settings-shaped dict."""
+    """``PRESETS`` entry (or preset id/name) -> settings-shaped dict.
+
+    ALWAYS complete: a preset names only the fields it means something by, and
+    every other profile field comes back at its default. Callers fill widgets
+    from this, so a partial answer would leave the PREVIOUS profile's flapping
+    or latency spikes on screen after picking a clean link.
+    """
     if isinstance(preset, str):
         canon = resolve_preset(preset)
         if canon is None:
             return {}
         preset = PRESETS[canon]
-    return {PRESET_TO_SETTING[k]: v for k, v in preset.items()
-            if k in PRESET_TO_SETTING}
-
-
-SETTING_TO_PRESET = {v: k for k, v in PRESET_TO_SETTING.items()}
+    out = {long: DEFAULT_SETTINGS[long] for long in SETTING_TO_PRESET}
+    out.update({PRESET_TO_SETTING[k]: v for k, v in preset.items()
+                if k in PRESET_TO_SETTING})
+    return out
 
 
 def settings_to_preset(s):
-    """Settings dict -> the 7-field shape a profile/preset is stored in."""
-    return {short: s.get(long, 0) for long, short in SETTING_TO_PRESET.items()}
+    """Settings dict -> the shape a profile/preset is stored in."""
+    return {short: s.get(long, DEFAULT_SETTINGS[long])
+            for long, short in SETTING_TO_PRESET.items()}

--- a/lang/en.json
+++ b/lang/en.json
@@ -95,7 +95,7 @@
   "dialogs.profile_name": "Profile name:",
   "dialogs.profile_name_taken": "This name is already used by a built-in preset. Choose another name.",
   "dialogs.profile_scope_title": "Profile scope",
-  "dialogs.profile_scope_warning": "A profile stores only the link characteristics: loss, corruption, duplication, latency, jitter and speed limits.\n\nThese active settings will NOT be saved in the profile: {fields}.\n\nUse 'Save file...' to store the complete configuration.",
+  "dialogs.profile_scope_warning": "A profile stores what the link is like: loss, corruption, duplication, latency, jitter, latency spikes, link outages, the speed limits and the buffer.\n\nThese active settings will NOT be saved in the profile: {fields}.\n\nUse 'Save file...' to store the complete configuration.",
   "dialogs.report_not_saved": "Report not saved",
   "dialogs.reset_layout_body": "Forget the remembered window size and position, collapsed sections and table sorting? Your settings and the current session are kept.",
   "dialogs.reset_layout_title": "Reset window layout",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -95,7 +95,7 @@
   "dialogs.profile_name": "Nazwa profilu:",
   "dialogs.profile_name_taken": "Ta nazwa jest już zajęta przez wbudowany preset. Wybierz inną nazwę.",
   "dialogs.profile_scope_title": "Zakres profilu",
-  "dialogs.profile_scope_warning": "Profil zapisuje tylko charakterystykę łącza: stratę, uszkodzenia, duplikację, opóźnienie, jitter i limity prędkości.\n\nTe aktywne ustawienia NIE zostaną zapisane w profilu: {fields}.\n\nPełną konfigurację zapiszesz przyciskiem 'Zapisz plik...'.",
+  "dialogs.profile_scope_warning": "Profil zapisuje to, jakie jest łącze: stratę, uszkodzenia, duplikację, opóźnienie, jitter, skoki latencji, przerwy w łączu, limity prędkości i bufor.\n\nTe aktywne ustawienia NIE zostaną zapisane w profilu: {fields}.\n\nPełną konfigurację zapiszesz przyciskiem 'Zapisz plik...'.",
   "dialogs.report_not_saved": "Nie zapisano raportu",
   "dialogs.reset_layout_body": "Zapomnieć zapamiętany rozmiar i pozycję okna, zwinięte sekcje i sortowanie tabel? Ustawienia i bieżąca sesja zostają.",
   "dialogs.reset_layout_title": "Zresetuj układ okna",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,62 @@ def test_cli_english():
     check("CLI: Polish preset name still works", cfg2["settings"]["latency"] == ref["lat"])
 
 
+def test_a_preset_carries_every_profile_field_into_the_settings(monkeypatch):
+    """``--preset`` goes through the shared mapping, not a copy of it.
+
+    The GUI has always applied a preset through ``preset_to_settings``; the CLI
+    hand-wrote the seven classic keys, so the same preset name produced
+    different traffic depending on which front end applied it. Nothing caught
+    it: ``test_cli_english`` asserts ``latency`` and ``down`` only.
+
+    The probe preset sets every profile field to a NON-DEFAULT value on purpose.
+    Run against the twelve real presets this test would be vacuous - none of
+    them names a buffer, a spike or a flap, so the hand-written copy would leave
+    those keys at exactly the defaults the shared mapping fills them with, and
+    the check would pass against the very code it exists to reject.
+    """
+    from beantester.cli import build_arg_parser, config_from_args
+    from beantester.fields import PROFILE_FIELDS
+    from beantester.presets import PRESETS, SETTING_TO_PRESET
+    from beantester.settings import DEFAULT_SETTINGS
+
+    probe = {SETTING_TO_PRESET[long]: float(DEFAULT_SETTINGS[long]) + 7
+             for long in PROFILE_FIELDS}          # +7 stays inside every bound
+    monkeypatch.setitem(PRESETS, "presets.__probe__", probe)
+
+    cfg = config_from_args(build_arg_parser().parse_args(
+        ["--preset", "presets.__probe__", "--simulate"]))
+    for long in PROFILE_FIELDS:
+        want = probe[SETTING_TO_PRESET[long]]
+        check(f"CLI: --preset carries {long}", cfg["settings"][long] == want,
+              f"(got {cfg['settings'][long]!r}, wanted {want!r})")
+
+
+def test_a_preset_that_names_only_some_fields_does_not_break_the_cli():
+    """A preset may name only what it means; the rest come back as defaults.
+
+    The hand-written copy indexed ``p["corrupt"]`` and friends directly, so the
+    first partial preset would have taken the CLI down with a KeyError.
+    """
+    from beantester.cli import build_arg_parser, config_from_args
+    from beantester.presets import PRESETS
+    from beantester.settings import DEFAULT_SETTINGS
+
+    partial = {"loss": 1, "lat": 40, "flap_period": 15, "flap_down": 3}
+    try:
+        PRESETS["presets.__partial__"] = partial
+        cfg = config_from_args(build_arg_parser().parse_args(
+            ["--preset", "presets.__partial__", "--simulate"]))
+    finally:
+        PRESETS.pop("presets.__partial__", None)
+    s = cfg["settings"]
+    check("CLI: a partial preset applies what it names",
+          s["loss"] == 1 and s["latency"] == 40 and s["flap_period"] == 15)
+    check("CLI: a partial preset leaves the rest at their defaults",
+          s["buffer"] == DEFAULT_SETTINGS["buffer"] and s["jitter"] == 0
+          and s["spike_ms"] == 0, f"(buffer={s['buffer']!r})")
+
+
 def test_lan_mode_cli():
     from beantester import build_arg_parser, config_from_args
     cfg = config_from_args(build_arg_parser().parse_args(["--lan-mode", "--simulate"]))

--- a/tests/test_field_registry.py
+++ b/tests/test_field_registry.py
@@ -91,12 +91,35 @@ def test_numeric_fields_declare_bounds():
 
 
 def test_profile_scope_is_derived():
-    check("registry: a profile stores exactly the 7 link-characteristic fields",
+    check("registry: a profile stores the link-characteristic fields",
           set(F.PROFILE_FIELDS) == {"loss", "corrupt", "dup", "latency", "jitter",
-                                    "down", "up"}, f"({F.PROFILE_FIELDS})")
+                                    "down", "up", "buffer", "spike_prob",
+                                    "spike_ms", "flap_period", "flap_down"},
+          f"({F.PROFILE_FIELDS})")
     non_profile = {k for k, _ in F.NON_PROFILE_FIELDS}
     check("registry: profile and non-profile fields partition the model",
           non_profile | set(F.PROFILE_FIELDS) == set(DEFAULT_SETTINGS))
+
+
+def test_the_stored_profile_shape_follows_the_registry():
+    """``in_profile`` is the ONLY switch that puts a field into a profile.
+
+    The short-key map used to be a second hand-written table in ``presets.py``,
+    so ``in_profile=True`` could declare a field in scope while the save path
+    ignored it - and the failure was silent in both directions: the warning
+    dialog (built from ``NON_PROFILE_FIELDS``) would stop listing the field as
+    "not saved", and it still would not be saved.
+    """
+    from beantester.presets import PRESET_DEFAULTS, PRESET_TO_SETTING
+    stored = set(PRESET_TO_SETTING.values())
+    check("registry: the stored shape covers exactly the profile fields",
+          stored == set(F.PROFILE_FIELDS),
+          f"({sorted(stored ^ set(F.PROFILE_FIELDS))})")
+    # the on-disk format is frozen: these two have been short since v1
+    check("registry: the historical short keys are unchanged",
+          {"lat", "jit"} <= set(PRESET_TO_SETTING), f"({sorted(PRESET_TO_SETTING)})")
+    check("registry: every stored field has a default to fall back to",
+          set(PRESET_DEFAULTS) == set(PRESET_TO_SETTING))
 
 
 def test_every_registry_field_reaches_the_settings_through_its_cli_flag():

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -31,7 +31,7 @@ from hypothesis import strategies as st
 
 from beantester.core import BeanCore, Decision
 from beantester.engine import BeanEngine
-from beantester.presets import PRESETS, preset_to_settings
+from beantester.presets import PRESETS, SETTING_TO_PRESET, preset_to_settings
 from beantester.settings import DEFAULT_SETTINGS, apply_settings
 from beantester.synthetic import SyntheticDivert
 from fakes import FakeDivert, FakePacket, check
@@ -49,8 +49,18 @@ IMPAIRMENT_OFF = {
     "rate_schedule": "", "lan_mode": False,
 }
 
-# The seven fields a preset carries (short keys), and their "no impairment" value.
-PRESET_OFF = {"loss": 0, "corrupt": 0, "dup": 0, "lat": 0, "jit": 0, "down": 0, "up": 0}
+# The profile fields that can impair traffic, and their "no impairment" value.
+# Derived from IMPAIRMENT_OFF (settings keys) so an impairment joining the
+# profile scope cannot be forgotten here - the omission that would let a preset
+# ship with a live flap and still count as "harmless".
+#
+# `buffer` is a profile field and is deliberately NOT here: it is absent from
+# IMPAIRMENT_OFF because it cannot impair anything on its own - both of its
+# readers sit inside `if rate > 0` (BeanCore.decide steps 11 and 12), so with no
+# speed limit it touches no packet. Demanding `buffer == 0` of a harmless preset
+# would demand an UNBOUNDED buffer, which is the opposite of harmless.
+PRESET_OFF = {key: off for key, off in IMPAIRMENT_OFF.items()
+              if key in SETTING_TO_PRESET}
 
 
 def perfect_settings():
@@ -92,7 +102,9 @@ def test_defaults_have_every_impairment_switched_off():
 
 
 def test_the_perfect_preset_is_completely_harmless():
-    perfect = PRESETS["presets.perfect"]
+    # through the real mapping: a preset names only the fields it means, so what
+    # it DELIVERS is the completed dict, not the literal in the table
+    perfect = preset_to_settings(PRESETS["presets.perfect"])
     for key, off in PRESET_OFF.items():
         check(f"perfect preset {key} is off",
               perfect[key] == off, f"(is {perfect[key]!r})")
@@ -102,7 +114,8 @@ def test_perfect_is_the_only_harmless_preset():
     """Every OTHER preset must impair something. A 'bad network' preset that
     silently does nothing would pass every damage test while being useless."""
     harmless = [key for key, spec in PRESETS.items()
-                if all(spec[k] == off for k, off in PRESET_OFF.items())]
+                if all(preset_to_settings(spec)[k] == off
+                       for k, off in PRESET_OFF.items())]
     check("exactly one all-zero preset exists", harmless == ["presets.perfect"],
           f"(harmless presets: {harmless})")
 

--- a/tests/test_release_fixes.py
+++ b/tests/test_release_fixes.py
@@ -119,6 +119,69 @@ def test_profiles_are_written_atomically_and_validated():
     check("dropping it is reported", bool(reloaded.problem))
 
 
+def test_a_profile_from_before_the_wider_scope_loads_with_field_defaults():
+    """Old files carry seven keys and no ``buffer`` - and 0 there means UNBOUNDED.
+
+    ``_clean`` used to fill a missing key with a blanket zero, which was correct
+    only while every profile field defaulted to zero. ``buffer`` defaults to
+    1000 ms, so that fill would have turned every profile written before the
+    scope widened into a runaway token bucket (``BeanCore.decide`` step 11) the
+    moment it was loaded - silently, on somebody else's saved settings.
+    """
+    from beantester.gui.profiles import ProfileStore
+    from beantester.settings import DEFAULT_SETTINGS
+    path = os.path.join(tempfile.mkdtemp(), "profiles.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"old": {"loss": 2, "corrupt": 0, "dup": 0, "lat": 80,
+                           "jit": 40, "down": 2048, "up": 1024}}, f)
+    entry = ProfileStore(path).get("old")
+    check("a pre-widening profile still loads", entry is not None)
+    check("the fields it names survive",
+          entry["loss"] == 2 and entry["lat"] == 80 and entry["down"] == 2048)
+    check("a missing buffer falls back to its default, not to 0",
+          entry["buffer"] == DEFAULT_SETTINGS["buffer"], f"({entry['buffer']!r})")
+    check("the impairments it never named are off",
+          entry["flap_period"] == 0 and entry["flap_down"] == 0
+          and entry["spike_prob"] == 0 and entry["spike_ms"] == 0)
+
+
+def test_an_explicit_zero_buffer_is_not_the_same_as_a_missing_one():
+    """``buffer: 0`` is a real choice (no cap on the queue) and must survive.
+
+    The pair with the test above: absence falls back to the default, an explicit
+    zero does not. Collapsing the two would make the fallback unusable.
+    """
+    from beantester.gui.profiles import ProfileStore
+    path = os.path.join(tempfile.mkdtemp(), "profiles.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"unbounded": {"down": 50, "buffer": 0}}, f)
+    entry = ProfileStore(path).get("unbounded")
+    check("an explicit 0 buffer survives the load", entry["buffer"] == 0.0,
+          f"({entry['buffer']!r})")
+
+
+def test_a_profile_round_trips_the_widened_scope():
+    """Save and load must carry the spike and flap fields, not just the classic seven."""
+    from beantester.gui.profiles import ProfileStore
+    from beantester.presets import settings_to_preset
+    from beantester.settings import DEFAULT_SETTINGS
+    path = os.path.join(tempfile.mkdtemp(), "profiles.json")
+    store = ProfileStore(path)
+    # exactly what App.save_profile stores: the widget settings, mapped
+    store.set("leo-ish", settings_to_preset(dict(
+        DEFAULT_SETTINGS, latency=40, flap_period=15, flap_down=3,
+        spike_prob=2, spike_ms=150, buffer=250)))
+    check("saving works", store.persist() is None)
+
+    entry = ProfileStore(path).get("leo-ish")
+    check("the periodic outage survives a round trip",
+          entry["flap_period"] == 15 and entry["flap_down"] == 3, f"({entry})")
+    check("the latency spike survives a round trip",
+          entry["spike_prob"] == 2 and entry["spike_ms"] == 150, f"({entry})")
+    check("the link buffer survives a round trip", entry["buffer"] == 250,
+          f"({entry['buffer']!r})")
+
+
 # -- targeting: the live port set ---------------------------------------------- #
 class _FakeTable:
     """A socket table under the test's control."""

--- a/tests/test_validators_settings.py
+++ b/tests/test_validators_settings.py
@@ -12,7 +12,9 @@ import pytest
 
 from beantester.cli import build_arg_parser, config_from_args
 from beantester.gui.ui_state import UiStateStore
-from beantester.presets import PRESETS, preset_to_settings, settings_to_preset
+from beantester.fields import PROFILE_FIELDS
+from beantester.presets import (PRESET_DEFAULTS, PRESETS, SETTING_TO_PRESET,
+                                preset_to_settings, settings_to_preset)
 from beantester.settings import (DEFAULT_SETTINGS, settings_from_raw,
                                  validate_ranges)
 from beantester.validators import parse_number, parse_seed
@@ -93,9 +95,34 @@ def test_preset_mapping_is_shared_by_gui_and_cli():
         s = preset_to_settings(preset)
         check(f"preset {key}: mapped to model keys",
               s["latency"] == preset["lat"] and s["jitter"] == preset["jit"])
-        check(f"preset {key}: round-trips back", settings_to_preset(s) == dict(preset))
+        # a preset names only the fields it means something by, so the round
+        # trip lands on the COMPLETED shape: defaults overlaid with the literal
+        check(f"preset {key}: round-trips back",
+              settings_to_preset(s) == dict(PRESET_DEFAULTS, **preset))
     check("preset: resolvable by name too",
           preset_to_settings("presets.3g")["down"] == PRESETS["presets.3g"]["down"])
+
+
+def test_a_preset_always_yields_every_profile_field():
+    """Unnamed profile fields come back as DEFAULTS - not zero, not missing.
+
+    Not missing, because the GUI fills widgets from this dict: a partial answer
+    would leave the PREVIOUS profile's flapping or spikes on screen after
+    picking a clean link. Not zero, because ``buffer`` defaults to 1000 ms and
+    0 means UNBOUNDED there - a blanket zero-fill would have quietly reinstated
+    the runaway token bucket on every preset pick.
+    """
+    for key, preset in PRESETS.items():
+        s = preset_to_settings(preset)
+        check(f"preset {key}: covers every profile field",
+              set(s) == set(PROFILE_FIELDS),
+              f"({sorted(set(s) ^ set(PROFILE_FIELDS))})")
+        for long in PROFILE_FIELDS:
+            if SETTING_TO_PRESET[long] in preset:
+                continue                       # the preset says something itself
+            check(f"preset {key}: unnamed {long} falls back to its default",
+                  s[long] == DEFAULT_SETTINGS[long],
+                  f"(is {s[long]!r}, default {DEFAULT_SETTINGS[long]!r})")
 
 
 def test_every_preset_is_within_the_declared_bounds():


### PR DESCRIPTION
## What and why

**A profile stored seven fields; it now stores twelve** - the five additions are `spike_prob`,
`spike_ms`, `flap_period`, `flap_down` and `buffer`.

The reason is flapping. It is the one impairment in the tool that is **periodic and phase-locked to
the session start** (`BeanCore.decide` step 5), so a profile carrying `flap_period`/`flap_down` can
describe a link that cuts out on a cadence - a satellite handover, a flaky uplink - which no other
profile field can express. This unblocks a LEO satellite preset (a separate PR); the mechanism
lands first.

This reverses a recorded owner decision ("Variant A": a profile deliberately stores only the seven
classic preset fields). Reversed on the owner's explicit request, with the ADR replaced rather than
layered over.

### The three traps this had to avoid

1. **`PROFILE_FIELDS` had no production consumer.** What a profile actually stored came from
   `presets.PRESET_TO_SETTING`, a second hand-written table in another module, so `in_profile=True`
   could declare a field in scope while the save path ignored it - failing silently in both
   directions (the warning dialog would stop calling it "not saved", and it still would not be
   saved). The mapping is now derived from `Field.in_profile` + the new `Field.preset_key`, so one
   flag is the whole switch.

2. **The fill for unnamed fields is the field's default, not zero.** `buffer` defaults to 1000 ms
   and `0` means an *unbounded* buffer there, so a blanket zero-fill would have quietly reinstated
   the runaway token bucket the bounded buffer exists to prevent - on every preset pick, and on
   every `profiles.json` written before this change (those files have no `buffer` key at all).
   `preset_to_settings`, `settings_to_preset` and `ProfileStore._clean` all take the field default
   now; an explicit `0` in a file still means 0.

3. **`--preset` carried its own copy of the mapping.** The GUI has always applied presets through
   `preset_to_settings`; `cli.py` hand-wrote the seven classic keys, so the same preset name
   produced different traffic depending on the front end. Once partial presets became legal it
   would also have crashed: reproduced against the future `presets.leo` shape, the old code raises
   `KeyError: 'corrupt'`.

### Why `buffer` is in the profile even though it impairs nothing

Both of its readers sit inside `if rate > 0` (`decide` steps 11 and 12), so with no speed limit it
touches no packet. It belongs to a profile because `down`/`up` do: the buffer is what decides
whether that same limit shows up as **delay** or as **loss**. Consequently it is absent from
`IMPAIRMENT_OFF`, and `PRESET_OFF` now takes the intersection - demanding `buffer == 0` of a
"harmless" preset would demand an unbounded one.

## Reviewer notes

- **On-disk format: no migration, no version field.** Backward compatible (a seven-key file reads
  fine, missing fields take their defaults) and forward compatible (an older build ignores keys it
  does not know, losing only the new fields). Breaking is the *scope*, not the parser.
- **Visible behaviour change:** picking a preset now sets all twelve fields, so a customised buffer
  goes back to 1000 ms. Same rule that has always applied to `loss`/`down`, wider reach.
- **`--config f.json --preset presets.3g`** now resets `buffer`, `spike_*` and `flap_*` to defaults.
  The documented precedence (defaults < file < preset < flags) is unchanged; the preset just
  carries five more keys.
- **Every new guard was verified by mutation, not assumed.** Reverting each fix turns the matching
  test red: `buffer 1000 != 1007` and `KeyError: 'corrupt'` for the CLI, `buffer 0.0` for the
  profile store.
- **The CLI guard runs on a synthetic probe preset on purpose.** Against the twelve real presets it
  would be vacuous - none of them names a buffer, a spike or a flap, so the old hand-written copy
  left exactly the defaults the shared mapping fills in, and the test would have passed against the
  very code it exists to reject.
- **One deliberate non-guard:** `test_an_explicit_zero_buffer_is_not_the_same_as_a_missing_one`
  survives the mutation (both paths yield 0 there). It is the paired constraint that makes the
  fallback usable, not a regression guard - flagged so nobody counts it as protection it does not
  give.
- Side effect of dropping `or 0` in `_clean`: a falsy non-numeric value (`[]`, `{}`) now drops the
  profile and reports it via `store.problem` instead of loading silently as 0. That is what the
  module promises.
- `presets.py` gained module-level imports of `fields` and `settings`; no cycle (nothing in
  `settings`'s dependency chain imports `presets`), `test_layering.py` green.
- **Not covered here:** the GUI was not launched - headless GUI tests pass, but `smoke_gui.py` is
  the owner's to run. Worth clicking: pick a preset after changing the buffer by hand (should snap
  back to 1000), and save/reload a profile with a flap set.

## Checklist

- [x] `python -m pytest tests` passes locally (full suite green after each of the four commits).
- [x] New behaviour has tests (7 new, listed in `CHANGELOG-INTERNAL.md`).
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in `CHANGELOG-INTERNAL.md`, under `[Unreleased]`.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - `VERSION.txt` untouched (a bump *is* required: on-disk format + `--preset` behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
