### PR TITLE
docs: ask for a star right after the intro, in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ traffic with the **[WinDivert](https://www.reqrypt.org/windivert.html)** driver 
 **[PyDivert](https://github.com/ffalcinelli/pydivert)**), and offers both a clear windowed
 interface with tooltips and a command-line mode for CI.
 
+⭐ **If it saved you time, leave a star.** That is how the next tester who needs it finds out it
+exists.
+
 > This is the English documentation. Polish version: [README.pl.md](README.pl.md).
 
 **What it can do**

--- a/README.pl.md
+++ b/README.pl.md
@@ -13,6 +13,9 @@ przechwytywanie ruchu sterownikiem **[WinDivert](https://www.reqrypt.org/windive
 **[PyDivert](https://github.com/ffalcinelli/pydivert)**) i daje zarówno czytelny interfejs okienkowy
 z podpowiedziami, jak i tryb wiersza poleceń do CI.
 
+⭐ **Jeśli oszczędziło Ci czasu, zostaw gwiazdkę.** Dzięki temu trafi do kolejnego testera, który
+go potrzebuje.
+
 **Co potrafi**
 
 - **Dodaje opóźnienie i jitter** - stałe lub losowe.


### PR DESCRIPTION
## What and why

One line asking for a star, at the end of the intro paragraph in **both** READMEs.

The repo already asks - the clickable `docs/star.gif` banner - but that sits below the demo gif,
which is past the point where a good share of readers stop. This catches them at the end of the
sentence that just told them what the tool does, and says what a star is *for* ("that is how the
next tester who needs it finds out it exists") rather than only asking for one.

**EN:**
> ⭐ **If it saved you time, leave a star.** That is how the next tester who needs it finds out it exists.

**PL:**
> ⭐ **Jeśli oszczędziło Ci czasu, zostaw gwiazdkę.** Dzięki temu trafi do kolejnego testera, który go potrzebuje.

## Reviewer notes

- **No link and no "on GitHub"** - deliberate. The README is read on GitHub, where the repo link
  and the meaning of "star" are both already on screen.
- **The `star.gif` banner stays.** There are now two star asks on the first screen; they are
  different formats at different reading moments (text right after the description, banner after
  watching the demo). Owner's call, flagged before the change.
- Nothing else touched: no code, no changelog (documentation only, no behaviour change), no test.
  `test_readme_guards.py` guards the layout tree, the pipeline order and the `--preset` id list -
  none of them go near the intro - and it is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
