### PR TITLE
feat(gui): move the latency spike fields into the Latency section

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -37,6 +37,24 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   offending key is NAMED in the message, since "invalid scenario" without a name would leave the
   user hunting. Verified by mutation: disabling the two checks turns all three red.
 
+### Changed
+
+- **`spike_prob` and `spike_ms` moved from the `advanced` section to `latency`** (`fields.py`): the
+  two `Field` entries were relocated inside `FIELD_DEFS` so the registry reads in form order, and
+  the two `Section` tuples were updated. **One entry per field really was enough** - grepped every
+  reader first, and `core.py`, `settings.py`, `summary.py`, `repro.py`, `presets.py` and the GUI's
+  variable wiring all go by the field KEY, so none of them knew which section the fields lived in.
+  `test_prefs.py` and `test_windows.py` use `"advanced"` as a collapsed-section id; the section
+  still exists with its remaining five fields, so they are unaffected.
+  Moving the entries changes the KEY ORDER of `PRESET_TO_SETTING` and `PRESET_DEFAULTS` (both are
+  derived from `FIELD_DEFS` order) and therefore the key order written into `profiles.json`. Checked
+  rather than assumed: every test over those compares sets or whole dicts, never order, and JSON
+  object order carries no meaning here.
+  Docs: the option walkthrough in both READMEs is organised by GUI section, so the *Latency spike*
+  bullet moved out of "Advanced (NAT / connections)" and into the delay text. **Nothing guards
+  that** - the bullet structure is prose, not a registry view - so it is the one part of this change
+  a test could not have caught.
+
 ### Docs
 
 - **Three registries gained a documented mirror, and a guard to keep it honest.** The scenario

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   validated too: it has to be a number of seconds and it only means something next to an `action`.
   A file that was correct keeps working; one that was quietly half-working will now tell you where.
 
+### Changed
+
+- **"Spike chance" and "Spike size" moved from "Advanced (NAT / connections)" to
+  "Latency (ping)".** A spike is latency - an occasional large one - so it now sits next to the
+  steady value and the jitter around it, instead of among the NAT and connection knobs. Nothing
+  about how it works changed, and neither did its `--spike-prob` / `--spike-ms` flags or its place
+  in a saved profile.
+
 ### Added
 
 - **The README documents three things it never did**, in both languages:

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ another in the queue - jitter inherently **reorders packets** (a real network do
 added delay rises above latency itself (e.g. latency 0, jitter 50 ms gives ~half the packets with
 no delay and a mean of ~12 ms, not 0). When latency is larger than jitter the effect is negligible.
 
+*Latency spike* lives in the same section, because a spike is latency too - an occasional large
+one. With the given probability it appends extra delay (ms) to a **single packet**, which is how
+momentary "lag" actually arrives. The chance is per packet and applies **in each direction**, so a
+round trip hits it about twice as often as the number suggests.
+
 **Impairment (%)** - *Loss*: percentage of packets vanishing without a trace (5% is already a
 clearly failing network). *Corruption*: percentage of packets with a flipped data bit - it affects
 **only payload-bearing packets**; packets with no data (e.g. pure ACK, SYN) have nothing to flip,
@@ -268,8 +273,6 @@ given percentage of the time. Simulates a flickering connection.
   that will not establish (retry testing) - useful for tests from behind NAT.
 - *Max size (MTU)* - drop packets larger than N bytes; reproduces an "MTU black hole" from
   tunnels/VPN/behind NAT (small ones pass, large ones vanish). 0 = disabled.
-- *Latency spike* - with the given probability append extra delay (ms) to a single packet;
-  reproduces momentary "lag".
 - *NAT timeout* - if a connection is silent for more than N seconds, the next inbound packet is
   dropped (the mapping "disappears"); a keep-alive test. 0 = disabled.
 - *TCP tear-down (RST)* - percentage of connections abruptly torn with an RST packet; forces

--- a/README.pl.md
+++ b/README.pl.md
@@ -195,6 +195,11 @@ jest **większy od latencji**, średnie doliczone opóźnienie rośnie powyżej 
 (np. latencja 0, jitter 50 ms daje ~połowę pakietów bez opóźnienia i średnią ~12 ms, nie 0).
 Przy latencji większej niż jitter efekt jest pomijalny.
 
+*Skok latencji* jest w tej samej sekcji, bo skok to też opóźnienie - tyle że sporadyczne i duże.
+Z podanym prawdopodobieństwem dokleja dodatkowe opóźnienie (ms) do **pojedynczego pakietu**, czyli
+tak, jak chwilowy „lag” naprawdę wygląda. Szansa liczona jest na pakiet i działa **w każdą stronę**,
+więc pojedyncze odpytanie trafia na nią mniej więcej dwa razy częściej, niż sugeruje ta liczba.
+
 **Zakłócenia (%)** - *Utrata*: procent pakietów znikających bez śladu (5% to już wyraźnie
 zrywająca się sieć). *Uszkodzenie*: procent pakietów z przekłamanym bitem danych - dotyczy
 tylko pakietów z ładunkiem (payloadem); pakiety bez danych (np. czyste ACK, SYN) nie mają czego
@@ -208,7 +213,6 @@ jest martwe przez podany procent czasu. Symuluje migające połączenie.
 - *Celuj w cel (IP/port)* - psuj tylko ruch do/od wybranych serwerów. Oba pola przyjmują listy, zakresy, CIDR, wildcardy, porównania, wykluczenia i wyrażenia regularne - patrz [Składnia filtrów](#składnia-filtrów-proces--ip--port). Np. IP `10.0.0.1-10.0.0.50,!10.0.0.7`, port `80,443,8000-8100`. Puste = dowolne.
 - *Gubione TCP SYN (%)* - procent gubionych pakietów rozpoczynających połączenie; symuluje sytuację, gdy połączenie nie chce się nawiązać (test ponawiania prób) - przydatne przy testach zza NAT.
 - *Maks. rozmiar (MTU)* - gub pakiety większe niż N bajtów; odwzorowuje „czarną dziurę MTU” z tuneli/VPN/za NAT (małe przechodzą, duże znikają). 0 = wyłączone.
-- *Skok latencji* - z podanym prawdopodobieństwem doklej dodatkowe opóźnienie (ms) do pojedynczego pakietu; odwzorowuje chwilowe „lagi”.
 - *NAT timeout* - jeśli połączenie milczy dłużej niż N sekund, kolejny pakiet przychodzący jest odrzucany (mapowanie „znika”); test keep-alive. 0 = wyłączone.
 - *Zrywanie TCP (RST)* - procent połączeń nagle zrywanych pakietem RST; wymusza reconnect. **Dotyczy wyłącznie TCP** (RST to pojęcie TCP-owe; UDP nie da się „zerwać” - użyj strat albo przerwy w łączu). Przycisk **Zerwij TCP teraz** zrywa wszystkie aktywne połączenia TCP na ~3 s.
 - *Harmonogram* - zmienna przepustowość w czasie: `czas:pobieranie:wysyłanie` w KB/s, po przecinku. Np. `2:100:0, 2:500:0` = 2 s po 100 KB/s, potem 2 s po 500, w pętli. Gdy harmonogram jest niepusty, **zastępuje** stałe pola „Pobieranie/Wysyłanie” - GUI wyszarza je i mówi o tym wprost.

--- a/beantester/fields.py
+++ b/beantester/fields.py
@@ -109,6 +109,17 @@ FIELD_DEFS = (
     Field("jitter", NUMBER, "fields.jitter", "latency", unit="ms",
           bounds=MS, tip="tips.jitter", in_profile=True, preset_key="jit",
           cli="jitter"),
+    # A spike IS latency - an occasional large one - so it belongs next to the
+    # steady value and the jitter around it, not among the NAT/connection knobs
+    # it used to sit with. Nothing outside this registry knew where they lived:
+    # every other reader (core, settings, summary, repro, presets, the GUI's
+    # variable wiring) goes by the field KEY.
+    Field("spike_prob", NUMBER, "fields.spike_prob", "latency", unit="%",
+          bounds=PCT, width=6, tip="tips.spike", in_profile=True,
+          cli="spike-prob"),
+    Field("spike_ms", NUMBER, "fields.spike_ms", "latency", unit="ms",
+          bounds=MS, width=8, tip="tips.spike", in_profile=True,
+          cli="spike-ms"),
 
     # -- impairments ------------------------------------------------------- #
     Field("loss", NUMBER, "fields.loss", "impairments", unit="%",
@@ -152,12 +163,6 @@ FIELD_DEFS = (
     Field("max_size", NUMBER, "fields.max_size", "advanced",
           unit_key="fields.unit_b_off", bounds=(0.0, 65535.0), width=8,
           tip="tips.mtu", cli="max-size"),
-    Field("spike_prob", NUMBER, "fields.spike_prob", "advanced", unit="%",
-          bounds=PCT, width=6, tip="tips.spike", in_profile=True,
-          cli="spike-prob"),
-    Field("spike_ms", NUMBER, "fields.spike_ms", "advanced", unit="ms",
-          bounds=MS, width=8, tip="tips.spike", in_profile=True,
-          cli="spike-ms"),
     Field("nat_timeout", NUMBER, "fields.nat_timeout", "advanced",
           unit_key="fields.unit_s_off", bounds=SECONDS, width=6,
           tip="tips.nat", cli="nat-timeout"),
@@ -245,14 +250,14 @@ SECTIONS = (
     Section("target_process", "frames.target_process", ("target",),
             columns=1, extra="target"),
     Section("speed_limit", "frames.speed_limit", ("down", "up", "buffer"), columns=2),
-    Section("latency", "frames.latency", ("latency", "jitter"), columns=2),
+    Section("latency", "frames.latency",
+            ("latency", "jitter", "spike_prob", "spike_ms"), columns=2),
     Section("impairments", "frames.impairments", ("loss", "corrupt", "dup"), columns=3),
     Section("flapping", "frames.flapping", ("flap_period", "flap_down"), columns=2),
     Section("destination", "frames.destination", ("dst_ip", "dst_port"), columns=1),
     Section("block", "frames.block", ("block_ip", "block_port"), columns=1),
     Section("advanced", "frames.advanced",
-            ("syn_drop", "max_size", "spike_prob", "spike_ms",
-             "nat_timeout", "rst_prob", "rst_cooldown"),
+            ("syn_drop", "max_size", "nat_timeout", "rst_prob", "rst_cooldown"),
             columns=2, extra="advanced"),
     Section("schedule", "frames.schedule", ("rate_schedule",), columns=1),
     Section("session", "frames.session", ("duration",), columns=1),


### PR DESCRIPTION
## What and why

"Spike chance" and "Spike size" move from **Advanced (NAT / connections)** to **Latency (ping)**.

A spike is latency - an occasional large one - so it belongs next to the steady value and the
jitter around it, not among the NAT timeout, MTU and RST knobs it happened to share a panel with.

```
Latency (ping)                     Advanced (NAT / connections)
  Latency        Jitter              SYN drop       Max size (MTU)
  Spike chance   Spike size          NAT timeout    TCP tear-down (RST)
                                     RST cooldown
```

## Reviewer notes

- **One entry per field really was enough.** Grepped every reader before touching anything:
  `core.py`, `settings.py`, `summary.py`, `repro.py`, `presets.py` and the GUI's variable wiring
  all go by the field KEY - none of them knew which section these lived in. The change is two
  `Field` entries relocated inside `FIELD_DEFS` (so the registry reads in form order) plus the two
  `Section` tuples.
- **Behaviour, flags and profiles are untouched.** `--spike-prob` / `--spike-ms` work exactly as
  before, and the fields keep their place in a saved profile.
- **One non-obvious consequence, checked rather than assumed:** moving the entries changes the KEY
  ORDER of `PRESET_TO_SETTING` and `PRESET_DEFAULTS`, since both derive from `FIELD_DEFS` order -
  and therefore the key order written into `profiles.json`. Every test over those compares sets or
  whole dicts, never order, and JSON object order carries no meaning here.
- `test_prefs.py` and `test_windows.py` use `"advanced"` as a collapsed-section id. The section
  still exists with its remaining five fields, so they are unaffected.
- **The one part no test could catch:** the option walkthrough in both READMEs is organised by GUI
  section, so the *Latency spike* bullet had to move with the fields or the docs would describe a
  layout that no longer exists. That structure is prose, not a registry view, so there is nothing
  to guard it with - flagged here instead. While moving it I also wrote down something the bullet
  never said: the chance is **per packet and per direction**, so a round trip meets it about twice
  as often as the number suggests.
- Green: field registry, GUI layout, prefs, windows, README guards, CLI docs, i18n, release
  hygiene. Full suite is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
