### PR TITLE
feat(gui): collapse "Blocking (firewall)" on a fresh install

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -39,6 +39,16 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Changed
 
+- **`block` added to `FIRST_RUN_COLLAPSED`** (`gui/app.py`), and the list reordered to match form
+  order. It only applies when `ui.json` has no saved `collapsed` state, so existing users see no
+  change.
+  New guard `test_prefs.py::test_the_first_run_collapse_list_names_real_sections`: every id must be
+  a real **Control-page** section, with no duplicates, and the panels a first-time user needs
+  (`profiles`, `traffic`, `latency`, `impairments`) must not be in it. The list is consumed by
+  `form.py` as `sec.id not in app.collapsed_sections`, so **nothing ever looks an id up** - a typo
+  raises nothing, it just leaves that panel expanded, which is invisible. Verified by mutation:
+  `"blocking"` instead of `"block"` fails with `assert not ['blocking']`.
+
 - **`spike_prob` and `spike_ms` moved from the `advanced` section to `latency`** (`fields.py`): the
   two `Field` entries were relocated inside `FIELD_DEFS` so the registry reads in form order, and
   the two `Section` tuples were updated. **One entry per field really was enough** - grepped every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Changed
 
+- **"Blocking (firewall)" now starts collapsed** on a fresh install, like the other advanced
+  panels. If you have used the tool before, your own collapsed/expanded choices are remembered and
+  nothing moves.
+
 - **"Spike chance" and "Spike size" moved from "Advanced (NAT / connections)" to
   "Latency (ping)".** A spike is latency - an occasional large one - so it now sits next to the
   steady value and the jitter around it, instead of among the NAT and connection knobs. Nothing

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -76,7 +76,10 @@ SECTION_BY_ID = {s.id: s for s in SECTIONS}
 # opening the tool on a dozen expanded panels of NAT/MTU/schedule jargon is a wall
 # for a first-time user. Only the simple, common sections stay open; the choice is
 # remembered per-user afterwards, so a power user expands them once.
-FIRST_RUN_COLLAPSED = ["destination", "flapping", "advanced", "schedule",
+# Listed in form order, and every id must be a real Control-page section: a typo
+# here does NOT raise, it just leaves that panel expanded, which is invisible.
+# Guarded by tests/test_prefs.py::test_the_first_run_collapse_list_names_real_sections.
+FIRST_RUN_COLLAPSED = ["flapping", "destination", "block", "advanced", "schedule",
                        "session", "repro"]
 
 

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -249,6 +249,28 @@ def test_settings_window_number_field_says_why_it_is_red():
     """)
 
 
+def test_the_first_run_collapse_list_names_real_sections():
+    """A typo in ``FIRST_RUN_COLLAPSED`` fails SILENTLY.
+
+    Nothing looks the id up - the form asks "is my id in this list", so an entry
+    that matches no section simply never matches, and the panel it was meant to
+    fold opens on a fresh install with nobody the wiser. Same class as a preset
+    with no translation or a column missing from the docs: wrong, and invisible.
+
+    The list also has to name CONTROL-page sections. Collapsing a Settings-window
+    section from here would be a line that reads as if it did something.
+    """
+    from beantester.fields import CONTROL_SECTIONS
+    from beantester.gui.app import FIRST_RUN_COLLAPSED
+    control = {s.id for s in CONTROL_SECTIONS}
+    stray = [s for s in FIRST_RUN_COLLAPSED if s not in control]
+    assert not stray, (stray, sorted(control))
+    assert len(set(FIRST_RUN_COLLAPSED)) == len(FIRST_RUN_COLLAPSED), FIRST_RUN_COLLAPSED
+    # and the panels a first-time user needs must NOT be folded away
+    for stays_open in ("profiles", "traffic", "latency", "impairments"):
+        assert stays_open not in FIRST_RUN_COLLAPSED, stays_open
+
+
 def test_reset_ui_layout_forgets_window_state():
     run_gui("""
         from beantester.gui import dialogs


### PR DESCRIPTION
## What and why

**"Blocking (firewall)" now starts collapsed** on a fresh install, alongside the other advanced
panels. One entry in `FIRST_RUN_COLLAPSED`, plus the list reordered to match form order.

It only applies when `ui.json` has no saved `collapsed` state, so **anyone who has already used the
tool keeps their own expanded/collapsed choices** and sees nothing move.

## The guard that was missing

Not requested - offered and taken - because the list had a silent failure mode. `form.py` consumes
it as `sec.id not in app.collapsed_sections`, so **nothing ever looks an id up**. A typo raises
nothing: the entry simply matches no section, the panel opens on a fresh install, and there is no
error, no log line and no visual cue that the line did nothing. Same class as a preset with no
translation or a column missing from the docs - wrong, and invisible.

`test_prefs.py::test_the_first_run_collapse_list_names_real_sections` pins three things:

- every id is a real **Control-page** section (collapsing a Settings-window section from here would
  be a line that reads as if it did something),
- no duplicates,
- the panels a first-time user actually needs - `profiles`, `traffic`, `latency`, `impairments` -
  are *not* in the list, so nobody can fold away the on-ramp by accident.

Verified by mutation: `"blocking"` instead of `"block"` fails with `assert not ['blocking']`.

## Reviewer notes

- No documentation ripple: both READMEs say the collapse state is remembered but never enumerate
  which sections start folded, so there was nothing to keep in step.
- Green: prefs, windows, GUI layout, GUI state, field registry. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
