### PR TITLE
feat(scenario): drop the legacy reset_now action and stop duplicating the action list

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -19,6 +19,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### BREAKING
 
+- **BREAKING:** **`reset_now` removed from `scenario.ACTIONS`**, leaving `reset_tcp` as the only
+  action. Touches the frozen scenario-file format ("Kontrakty publiczne"), so it needs the owner's
+  version bump. Thanks to the step validation added earlier in this release, a file still using the
+  old name fails with a message naming the step rather than being silently ignored.
+- **`scenario_runner` now reads `ACTIONS` instead of carrying its own copy of the names.** It
+  matched against a hand-written `("reset_tcp", "reset_now")` one module away from the tuple that
+  decides which names are legal. The two agreeing was a coincidence maintained by hand, and the
+  drift is silent BOTH ways: an action dropped from `ACTIONS` keeps firing here, and one added
+  there validates and then does nothing. Same class as the preset mapping the CLI used to duplicate.
+  Guard: `test_scenario_runner.py::test_the_runner_fires_exactly_the_actions_the_validator_accepts`
+  drives every name in `ACTIONS` through the real runner loop and asserts a rejected name fires
+  nothing. Verified by mutation - restoring the hardcoded tuple fails with
+  `the runner ignores a name the validator would reject`.
+  🔴 **`reset_now` still exists as a METHOD name** (`core.reset_now`, `engine.reset_now`,
+  `App.reset_now_click`, the `buttons.reset_now` / `tips.reset_now` keys) - that is the GUI's
+  "Reset TCP now" button and the engine's public API, unrelated to the scenario action. A
+  grep-and-delete would have removed a working feature. Noted in `PROJECT_NOTES` beside the action
+  list.
+  Three fixtures in `test_settings_config_scenario.py` used `reset_now` as a scenario action and
+  went red on the change, which is the removal proving itself - they now use `reset_tcp`. (My
+  pre-change survey missed them: the grep output was cut by `head`, and I reported "no test uses it
+  as a scenario action". The tests were right and the summary was wrong.)
+
+### BREAKING
+
 - **BREAKING:** **`scenario.py` validates the keys it always accepted silently.** New `STEP_KEYS`
   and `FILE_KEYS` registries; an unknown key in a step or at the file level raises a translated
   error naming it, exactly as an unknown `settings` name already did. `duration` is validated as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### BREAKING
 
+- **BREAKING:** **the old `reset_now` name for a scenario action is gone.** `reset_tcp` does the
+  same thing and is now the only action a scenario step can carry. A scenario file still using
+  `reset_now` will not load, and says which step to fix. The **"Reset TCP now" button is not
+  affected** - it never had anything to do with this name.
+
+### BREAKING
+
 - **BREAKING:** **A mistake in a scenario file now says so instead of doing nothing.** A misspelled
   key used to be accepted and ignored, which is the worst possible outcome: `"duraton"` quietly left
   a reset at its 3-second default, `"lop"` quietly turned looping off, and in both cases the tool

--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ BeanNetworkTester.exe --simulate --scenario scenarios/cafe-wifi.json
 
 The seed guarantees identical **per-packet decisions** for the same packet sequence. Scenario steps
 are cumulative (each patches the state), and `action: reset_tcp` tears down TCP connections at that
-moment (the old name `reset_now` still works). The scenario file is **validated** - random JSON ends
+moment. The scenario file is **validated** - random JSON ends
 with a readable error, not a "scenario with 0 steps".
 
 Every CLI run ends by printing the **effective seed** and a ready command to reproduce it, and
@@ -898,7 +898,7 @@ pause.
 |---|---|
 | `at` | required - seconds from the start of the session (`>= 0`). Steps are sorted by it, so their order in the file does not matter. |
 | `settings` | a **partial** settings object. **Cumulative**: each step patches the state the previous ones left, so a value stays until some later step changes it back. |
-| `action` | `reset_tcp` - tear down the TCP connections in scope at that moment. `reset_now` is the pre-1.3 spelling and still works. **These two are the only actions.** |
+| `action` | `reset_tcp` - tear down the TCP connections in scope at that moment. **It is the only action.** The pre-1.3 spelling `reset_now` has been removed, so a file still using it fails to load with a message naming the step. |
 | `duration` | seconds the reset holds connections down (default `3`). Only valid together with an `action`. |
 
 **Which names go in `settings`** - any setting the tool has, under the **same name as the config

--- a/README.pl.md
+++ b/README.pl.md
@@ -623,7 +623,7 @@ BeanNetworkTester.exe --simulate --scenario scenarios/cafe-wifi.json
 
 Seed gwarantuje identyczne **decyzje na pakiet** dla tej samej sekwencji pakietów.
 Kroki scenariusza są kumulatywne (każdy nakłada łatkę na stan), a `action: reset_tcp`
-zrywa w danym momencie połączenia TCP (stara nazwa `reset_now` nadal działa). Plik scenariusza
+zrywa w danym momencie połączenia TCP. Plik scenariusza
 jest **walidowany** - losowy JSON kończy się czytelnym błędem, a nie „scenariuszem z 0 kroków”.
 
 Każdy przebieg CLI kończy się wypisaniem **efektywnego seeda** i gotowej komendy do odtworzenia,
@@ -759,7 +759,7 @@ błąd, a nie pauza.
 |---|---|
 | `at` | wymagany - sekundy od startu sesji (`>= 0`). Kroki są po nim sortowane, więc ich kolejność w pliku nie ma znaczenia. |
 | `settings` | **częściowy** obiekt ustawień. **Kumulatywny**: każdy krok nakłada łatkę na stan zostawiony przez poprzednie, więc wartość trwa, dopóki któryś późniejszy krok jej nie zmieni. |
-| `action` | `reset_tcp` - zrywa w tym momencie połączenia TCP będące w zasięgu. `reset_now` to pisownia sprzed 1.3 i nadal działa. **To jedyne dwie akcje.** |
+| `action` | `reset_tcp` - zrywa w tym momencie połączenia TCP będące w zasięgu. **To jedyna akcja.** Pisownia sprzed 1.3, `reset_now`, została usunięta, więc plik, który jej używa, nie wczyta się i wskaże numer kroku. |
 | `duration` | ile sekund reset trzyma połączenia zerwane (domyślnie `3`). Ma sens wyłącznie razem z `action`. |
 
 **Jakie nazwy wchodzą do `settings`** - dowolne ustawienie, jakie ma narzędzie, pod **tą samą nazwą

--- a/beantester/scenario.py
+++ b/beantester/scenario.py
@@ -11,7 +11,10 @@ import json
 from .i18n import translate
 from .settings import DEFAULT_SETTINGS
 
-ACTIONS = ("reset_tcp", "reset_now")      # "reset_now" = the pre-1.3 spelling
+# The actions a step may carry. ``scenario_runner`` reads THIS tuple rather than
+# listing them again - it used to carry its own copy, which would have accepted a
+# name the validator here rejects.
+ACTIONS = ("reset_tcp",)
 MAX_STEPS = 1000
 
 # Everything a step and a file may contain. Anything else is a typo, and a typo

--- a/beantester/scenario_runner.py
+++ b/beantester/scenario_runner.py
@@ -9,6 +9,7 @@ import threading
 import time
 
 from .i18n import T
+from .scenario import ACTIONS
 from .settings import apply_settings
 from .summary import settings_summary
 
@@ -49,9 +50,11 @@ class ScenarioRunner:
                 last = s
                 eng.log_event("SCENARIO", settings_summary(s, "en"))
             for at, ev in scenario.events_between(prev_t, t):
-                # "reset_now" is the pre-1.3 spelling of "reset_tcp" (the action
-                # only ever reset TCP connections - see BeanCore.decide step 4)
-                if str(ev.get("action")) in ("reset_tcp", "reset_now"):
+                # From scenario.ACTIONS, not a second list of the same names: a
+                # copy here would keep honouring an action the validator has
+                # stopped accepting, which is how "reset_now" outlived its own
+                # removal for exactly as long as nobody looked.
+                if str(ev.get("action")) in ACTIONS:
                     eng.reset_now(float(ev.get("duration", 3.0)))
                     log(f"{T('log.scenario')} [{at:.0f}s]: {T('log.scenario_reset')}.")
             prev_t = t

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -81,6 +81,36 @@ def test_runner_applies_each_step_and_fires_reset_events(spy_apply):
           any(kind == "SCENARIO" for kind, _ in engine.events), f"({engine.events})")
 
 
+def test_the_runner_fires_exactly_the_actions_the_validator_accepts(spy_apply):
+    """The runner reads ``scenario.ACTIONS`` instead of listing the names again.
+
+    It used to carry its own copy of the tuple, one module away from the
+    validator that decides which names are legal. The two agreeing was a
+    coincidence maintained by hand, and the failure mode is silent in both
+    directions: an action dropped from ``ACTIONS`` would keep working here long
+    after the file that declares it stopped accepting it, and one added there
+    would validate fine and then do nothing.
+    """
+    from beantester.scenario import ACTIONS
+
+    def run(action):
+        class OneAction(FakeScenario):
+            def events_between(self, prev_t, t):
+                if prev_t < 0.1 <= t:
+                    yield (0.1, {"action": action, "duration": 1.5})
+        engine = FakeEngine()
+        runner = ScenarioRunner(engine)
+        runner.start(OneAction(loop=False, duration=0.3), base_settings={})
+        _join(runner)
+        return engine.resets
+
+    for action in ACTIONS:
+        check(f"the runner honours {action!r}", run(action) == [1.5],
+              f"({run(action)})")
+    check("the runner ignores a name the validator would reject",
+          run("reset_now") == [], "(reset_now is no longer an action)")
+
+
 def test_a_change_is_applied_only_when_the_settings_actually_change(spy_apply):
     class Constant(FakeScenario):
         def settings_at(self, t, base):

--- a/tests/test_settings_config_scenario.py
+++ b/tests/test_settings_config_scenario.py
@@ -189,7 +189,7 @@ def test_scenario_block_step_applies_and_clears():
 
 def test_scenario_events():
     from beantester import Scenario
-    sc = Scenario([{"at": 10, "action": "reset_now", "duration": 3}])
+    sc = Scenario([{"at": 10, "action": "reset_tcp", "duration": 3}])
     check("scenario: action within (9,11]", len(sc.events_between(9, 11)) == 1)
     check("scenario: no action before", len(sc.events_between(0, 9)) == 0)
     check("scenario: no action after", len(sc.events_between(11, 20)) == 0)
@@ -200,7 +200,7 @@ def test_scenario_file_roundtrip():
     import tempfile, os as _os, json as _json
     data = {"loop": True, "steps": [{"at": 0, "settings": {"latency": 0}},
                                     {"at": 5, "settings": {"latency": 300}},
-                                    {"at": 10, "action": "reset_now", "duration": 2}]}
+                                    {"at": 10, "action": "reset_tcp", "duration": 2}]}
     path = _os.path.join(tempfile.gettempdir(), "ns_scen.json")
     with open(path, "w") as f:
         _json.dump(data, f)
@@ -225,7 +225,7 @@ def test_scenario_unsorted_and_empty():
 
 def test_scenario_events_boundaries():
     from beantester import Scenario
-    sc = Scenario([{"at": 10, "action": "reset_now"}])
+    sc = Scenario([{"at": 10, "action": "reset_tcp"}])
     check("scenario: t0 exclusive - (10,11] misses at=10, (9,10] catches it",
           len(sc.events_between(10, 11)) == 0 and len(sc.events_between(9, 10)) == 1)
 


### PR DESCRIPTION
## What and why

**`reset_now` is gone from scenario files.** `reset_tcp` does the same thing and is now the only
action a step can carry.

A file still using the old name **fails to load with the step number**, which is only true because
of the step validation added earlier in this release - before that it would have been accepted and
quietly ignored. That is the right failure for a removed name.

## The second half: the runner had its own copy of the list

`scenario_runner` matched against a hand-written `("reset_tcp", "reset_now")`, one module away from
the `ACTIONS` tuple that decides which names are legal. Removing the alias from `ACTIONS` alone
would have left the runner **still honouring it**.

The drift is silent in both directions: an action dropped from `ACTIONS` keeps firing in the runner,
and one added there validates fine and then does nothing. Same class as the preset mapping the CLI
used to duplicate. It now reads `ACTIONS`, and
`test_scenario_runner.py::test_the_runner_fires_exactly_the_actions_the_validator_accepts` drives
every name in it through the real loop and asserts a rejected name fires nothing. Mutation-verified:
restoring the hardcoded tuple fails with *"the runner ignores a name the validator would reject"*.

## Reviewer notes

- 🔴 **`reset_now` still exists as a method name, deliberately.** `core.reset_now`,
  `engine.reset_now`, `App.reset_now_click`, `buttons.reset_now`, `tips.reset_now` - that is the
  GUI's **"Reset TCP now" button** and the engine's public API, with no relation to the scenario
  action. Of the 12 grep hits for the name, only 2 were the thing being removed. A
  grep-and-delete would have ripped out a working feature; this is now written beside the action
  list in `PROJECT_NOTES` so the next reader does not repeat it.
- **My pre-change survey was wrong about one thing and the tests caught it.** I reported that no
  test used `reset_now` as a scenario action - the grep output had been cut by `head`. Three
  fixtures in `test_settings_config_scenario.py` used it and went red on the change. They now use
  `reset_tcp`. The failure was the removal proving itself, but the summary I gave beforehand was
  inaccurate and is corrected in `CHANGELOG-INTERNAL`.
- **No shipped scenario used it** - `mobile-lte-to-3g.json` and `upload-drop-midway.json` were
  already on `reset_tcp`. Nothing in `scenarios/` changes.
- **Docs:** four places across both READMEs, including a sentence that claimed *"these two are the
  only actions"*. The replacement deliberately does **not** name a version number for the removal -
  I do not set `VERSION.txt`, and prose that guesses it is prose with an expiry date.
- **BREAKING** - it touches the frozen scenario-file format, so it needs your version bump.
- `test_layering.py` green with the new `scenario_runner -> scenario` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
