### PR TITLE
fix(gui): scroll the Live stats tab, reserve panel footers, focus the profile name box

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,47 +17,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
-### Fixed
-
-- **The Live stats tab is a `ScrollableFrame`** (`gui/pages/stats.py`). The counter grid reflows its
-  column count with the window WIDTH, so a narrow window turns it into five tall rows; it packs at
-  its natural height and the chart, packed `expand=True`, took the leftover - about ten pixels. The
-  canvas `height=scaled(180)` is a REQUEST, and pack shrinks below a request when it has nothing to
-  hand out, so it was never a floor. This is the same squeeze the module docstring records at page
-  level ("pack simply gave the last two panels no space at all"), reappearing one level down.
-  Convention 14 is satisfied - no Treeview/Text/Listbox on the tab, the chart canvas is a drawing
-  surface with no scrolling of its own.
-  🔴 **Known trade, verified rather than assumed:** `ScrollableFrame._on_canvas_configure` only
-  stretches the inner window's WIDTH, so content is laid out at its requested height. The chart
-  therefore stops growing on a tall window and keeps its 180 px. Making the scroller stretch height
-  to the viewport when content is shorter would restore it, but that is shared with the Control page
-  and was not touched here.
-- **Panel footers are packed FIRST** (`gui/panels/settings.py`, `gui/panels/about.py`). pack hands
-  out height in call order, so a footer packed last gets what the content left - which for Settings
-  was nothing, and "Close" was clipped by the window edge. About had the identical shape and only
-  fits today because its content is shorter.
-- **`dialogs._center` takes the widget to focus** and sets it after `focus_force()`; `ask_string`
-  passes its entry. The old `entry.focus_set()` failed twice over: it ran while the dialog was still
-  `withdraw()`n (`_shell`), where focus does not stick, and `_center` then forced focus to the
-  window and discarded it. That is why "Save profile..." needed a click before typing.
-  Guards (`test_gui_layout.py`): `::test_the_live_stats_tab_is_scrolled_so_the_chart_cannot_vanish`
-  and `::test_a_panel_window_reserves_its_footer_before_its_content`, which walks
-  `body.pack_slaves()` and asserts the bottom-packed footer is at index 0. Both mutation-verified -
-  reverting them gives "the Live tab is not scrolled" and "the footer is packed at position 5 of 6".
-
-### Tests
-
-- **`test_failsafe.py::test_a_dead_capture_thread_fails_open` was racy and CI caught it** (green ~5/5
-  locally, red on the runner). `_stop_locked` clears `_running` as its SECOND statement - deliberate,
-  so a watchdog mid-maintenance sees nothing to fire - and closes the divert several statements
-  later, logging the STOP event after that. So `not is_running()` is true well before all three
-  things the test then asserted, and a loaded runner can be descheduled inside that window. **The
-  product is correct: the fail-open invariant holds**, the divert is closed inside the same critical
-  section. The test now waits for the outcome (running cleared AND divert closed AND the event
-  logged), which is exactly the fix `::test_the_engine_stops_itself_after_its_duration` already
-  carries a few lines above - complete with the comment "Wait for the promise, not for the flag".
-  That test was fixed after CI caught the same shape; this one was never given the same treatment.
-
 ### BREAKING
 
 - **BREAKING:** **`reset_now` removed from `scenario.ACTIONS`**, leaving `reset_tcp` as the only
@@ -82,8 +41,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   went red on the change, which is the removal proving itself - they now use `reset_tcp`. (My
   pre-change survey missed them: the grep output was cut by `head`, and I reported "no test uses it
   as a scenario action". The tests were right and the summary was wrong.)
-
-### BREAKING
 
 - **BREAKING:** **`scenario.py` validates the keys it always accepted silently.** New `STEP_KEYS`
   and `FILE_KEYS` registries; an unknown key in a step or at the file level raises a translated
@@ -167,6 +124,47 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   bullet moved out of "Advanced (NAT / connections)" and into the delay text. **Nothing guards
   that** - the bullet structure is prose, not a registry view - so it is the one part of this change
   a test could not have caught.
+
+### Fixed
+
+- **The Live stats tab is a `ScrollableFrame`** (`gui/pages/stats.py`). The counter grid reflows its
+  column count with the window WIDTH, so a narrow window turns it into five tall rows; it packs at
+  its natural height and the chart, packed `expand=True`, took the leftover - about ten pixels. The
+  canvas `height=scaled(180)` is a REQUEST, and pack shrinks below a request when it has nothing to
+  hand out, so it was never a floor. This is the same squeeze the module docstring records at page
+  level ("pack simply gave the last two panels no space at all"), reappearing one level down.
+  Convention 14 is satisfied - no Treeview/Text/Listbox on the tab, the chart canvas is a drawing
+  surface with no scrolling of its own.
+  🔴 **Known trade, verified rather than assumed:** `ScrollableFrame._on_canvas_configure` only
+  stretches the inner window's WIDTH, so content is laid out at its requested height. The chart
+  therefore stops growing on a tall window and keeps its 180 px. Making the scroller stretch height
+  to the viewport when content is shorter would restore it, but that is shared with the Control page
+  and was not touched here.
+- **Panel footers are packed FIRST** (`gui/panels/settings.py`, `gui/panels/about.py`). pack hands
+  out height in call order, so a footer packed last gets what the content left - which for Settings
+  was nothing, and "Close" was clipped by the window edge. About had the identical shape and only
+  fits today because its content is shorter.
+- **`dialogs._center` takes the widget to focus** and sets it after `focus_force()`; `ask_string`
+  passes its entry. The old `entry.focus_set()` failed twice over: it ran while the dialog was still
+  `withdraw()`n (`_shell`), where focus does not stick, and `_center` then forced focus to the
+  window and discarded it. That is why "Save profile..." needed a click before typing.
+  Guards (`test_gui_layout.py`): `::test_the_live_stats_tab_is_scrolled_so_the_chart_cannot_vanish`
+  and `::test_a_panel_window_reserves_its_footer_before_its_content`, which walks
+  `body.pack_slaves()` and asserts the bottom-packed footer is at index 0. Both mutation-verified -
+  reverting them gives "the Live tab is not scrolled" and "the footer is packed at position 5 of 6".
+
+### Tests
+
+- **`test_failsafe.py::test_a_dead_capture_thread_fails_open` was racy and CI caught it** (green ~5/5
+  locally, red on the runner). `_stop_locked` clears `_running` as its SECOND statement - deliberate,
+  so a watchdog mid-maintenance sees nothing to fire - and closes the divert several statements
+  later, logging the STOP event after that. So `not is_running()` is true well before all three
+  things the test then asserted, and a loaded runner can be descheduled inside that window. **The
+  product is correct: the fail-open invariant holds**, the divert is closed inside the same critical
+  section. The test now waits for the outcome (running cleared AND divert closed AND the event
+  logged), which is exactly the fix `::test_the_engine_stops_itself_after_its_duration` already
+  carries a few lines above - complete with the comment "Wait for the promise, not for the flag".
+  That test was fixed after CI caught the same shape; this one was never given the same treatment.
 
 ### Docs
 

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,47 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Live stats tab is a `ScrollableFrame`** (`gui/pages/stats.py`). The counter grid reflows its
+  column count with the window WIDTH, so a narrow window turns it into five tall rows; it packs at
+  its natural height and the chart, packed `expand=True`, took the leftover - about ten pixels. The
+  canvas `height=scaled(180)` is a REQUEST, and pack shrinks below a request when it has nothing to
+  hand out, so it was never a floor. This is the same squeeze the module docstring records at page
+  level ("pack simply gave the last two panels no space at all"), reappearing one level down.
+  Convention 14 is satisfied - no Treeview/Text/Listbox on the tab, the chart canvas is a drawing
+  surface with no scrolling of its own.
+  🔴 **Known trade, verified rather than assumed:** `ScrollableFrame._on_canvas_configure` only
+  stretches the inner window's WIDTH, so content is laid out at its requested height. The chart
+  therefore stops growing on a tall window and keeps its 180 px. Making the scroller stretch height
+  to the viewport when content is shorter would restore it, but that is shared with the Control page
+  and was not touched here.
+- **Panel footers are packed FIRST** (`gui/panels/settings.py`, `gui/panels/about.py`). pack hands
+  out height in call order, so a footer packed last gets what the content left - which for Settings
+  was nothing, and "Close" was clipped by the window edge. About had the identical shape and only
+  fits today because its content is shorter.
+- **`dialogs._center` takes the widget to focus** and sets it after `focus_force()`; `ask_string`
+  passes its entry. The old `entry.focus_set()` failed twice over: it ran while the dialog was still
+  `withdraw()`n (`_shell`), where focus does not stick, and `_center` then forced focus to the
+  window and discarded it. That is why "Save profile..." needed a click before typing.
+  Guards (`test_gui_layout.py`): `::test_the_live_stats_tab_is_scrolled_so_the_chart_cannot_vanish`
+  and `::test_a_panel_window_reserves_its_footer_before_its_content`, which walks
+  `body.pack_slaves()` and asserts the bottom-packed footer is at index 0. Both mutation-verified -
+  reverting them gives "the Live tab is not scrolled" and "the footer is packed at position 5 of 6".
+
+### Tests
+
+- **`test_failsafe.py::test_a_dead_capture_thread_fails_open` was racy and CI caught it** (green ~5/5
+  locally, red on the runner). `_stop_locked` clears `_running` as its SECOND statement - deliberate,
+  so a watchdog mid-maintenance sees nothing to fire - and closes the divert several statements
+  later, logging the STOP event after that. So `not is_running()` is true well before all three
+  things the test then asserted, and a loaded runner can be descheduled inside that window. **The
+  product is correct: the fail-open invariant holds**, the divert is closed inside the same critical
+  section. The test now waits for the outcome (running cleared AND divert closed AND the event
+  logged), which is exactly the fix `::test_the_engine_stops_itself_after_its_duration` already
+  carries a few lines above - complete with the comment "Wait for the promise, not for the flag".
+  That test was fixed after CI caught the same shape; this one was never given the same treatment.
+
 ### BREAKING
 
 - **BREAKING:** **`reset_now` removed from `scenario.ACTIONS`**, leaving `reset_tcp` as the only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
-### Fixed
-
-- **The throughput chart could be squeezed until it vanished.** On a narrow window the counter grid
-  reflows into more rows, took the height, and left the chart a black sliver under its own heading.
-  The "Live" tab now scrolls, so nothing on it can be pushed out of existence. One trade worth
-  knowing: the chart keeps a fixed height now instead of growing to fill a tall window.
-- **"Close" was cut in half at the bottom of the Settings window.** The button is now reserved
-  before the settings above it, so it is always there whatever the window is holding. The About
-  window had the same construction and was one longer translation away from the same bug.
-- **"Save profile..." opens with the cursor already in the name box.** It used to need a click
-  before you could type.
-
 ### BREAKING
 
 - **BREAKING:** **the old `reset_now` name for a scenario action is gone.** `reset_tcp` does the
   same thing and is now the only action a scenario step can carry. A scenario file still using
   `reset_now` will not load, and says which step to fix. The **"Reset TCP now" button is not
   affected** - it never had anything to do with this name.
-
-### BREAKING
 
 - **BREAKING:** **A mistake in a scenario file now says so instead of doing nothing.** A misspelled
   key used to be accepted and ignored, which is the worst possible outcome: `"duraton"` quietly left
@@ -33,6 +19,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   error naming the key, the same way an unknown *setting* name has always been. `duration` is
   validated too: it has to be a number of seconds and it only means something next to an `action`.
   A file that was correct keeps working; one that was quietly half-working will now tell you where.
+
+### Added
+
+- **The README documents three things it never did**, in both languages:
+  - **The scenario file format** - the file and step keys, what may go in `settings`, the two
+    actions there are, the 1000-step limit, how looping restarts, and the 0.1 s tick.
+  - **The seven shipped scenarios**, a line each: what each one reproduces and what it is for
+    (which one kills the network mid-request, which one only touches DNS, which one is a one-shot).
+  - **Both CSV exports and all 17 Connections columns.** The two exports behave differently on
+    purpose - the statistics one appends and ignores the "targeted traffic only" switch, the
+    connections one overwrites and follows your search, sorting and that switch - and the
+    connections CSV does not reuse the table's labels, so there is a column-by-column map between
+    them.
 
 ### Changed
 
@@ -61,18 +60,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   about how it works changed, and neither did its `--spike-prob` / `--spike-ms` flags or its place
   in a saved profile.
 
-### Added
+### Fixed
 
-- **The README documents three things it never did**, in both languages:
-  - **The scenario file format** - the file and step keys, what may go in `settings`, the two
-    actions there are, the 1000-step limit, how looping restarts, and the 0.1 s tick.
-  - **The seven shipped scenarios**, a line each: what each one reproduces and what it is for
-    (which one kills the network mid-request, which one only touches DNS, which one is a one-shot).
-  - **Both CSV exports and all 17 Connections columns.** The two exports behave differently on
-    purpose - the statistics one appends and ignores the "targeted traffic only" switch, the
-    connections one overwrites and follows your search, sorting and that switch - and the
-    connections CSV does not reuse the table's labels, so there is a column-by-column map between
-    them.
+- **The throughput chart could be squeezed until it vanished.** On a narrow window the counter grid
+  reflows into more rows, took the height, and left the chart a black sliver under its own heading.
+  The "Live" tab now scrolls, so nothing on it can be pushed out of existence. One trade worth
+  knowing: the chart keeps a fixed height now instead of growing to fill a tall window.
+- **"Close" was cut in half at the bottom of the Settings window.** The button is now reserved
+  before the settings above it, so it is always there whatever the window is holding. The About
+  window had the same construction and was one longer translation away from the same bug.
+- **"Save profile..." opens with the cursor already in the name box.** It used to need a click
+  before you could type.
 
 ## [0.4.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [Unreleased]
 
+### Fixed
+
+- **The throughput chart could be squeezed until it vanished.** On a narrow window the counter grid
+  reflows into more rows, took the height, and left the chart a black sliver under its own heading.
+  The "Live" tab now scrolls, so nothing on it can be pushed out of existence. One trade worth
+  knowing: the chart keeps a fixed height now instead of growing to fill a tall window.
+- **"Close" was cut in half at the bottom of the Settings window.** The button is now reserved
+  before the settings above it, so it is always there whatever the window is holding. The About
+  window had the same construction and was one longer translation away from the same bug.
+- **"Save profile..." opens with the cursor already in the name box.** It used to need a click
+  before you could type.
+
 ### BREAKING
 
 - **BREAKING:** **the old `reset_now` name for a scenario action is gone.** `reset_tcp` does the

--- a/beantester/gui/dialogs.py
+++ b/beantester/gui/dialogs.py
@@ -21,8 +21,16 @@ WRAP = 380
 _result = {}          # per-dialog result, keyed by the toplevel
 
 
-def _center(win, parent):
-    """Place the dialog over its parent and only THEN show it."""
+def _center(win, parent, focus=None):
+    """Place the dialog over its parent and only THEN show it.
+
+    ``focus`` is the widget the keyboard should land on. It has to be given HERE
+    rather than set by the caller beforehand, for two reasons that stack: the
+    dialog is built withdrawn (see ``_shell``), where focus does not stick, and
+    ``focus_force`` below moves it to the window and would discard it anyway.
+    That is why "Save profile..." opened with the cursor nowhere and the name
+    field had to be clicked.
+    """
     try:
         win.update_idletasks()
         w, h = win.winfo_reqwidth(), win.winfo_reqheight()
@@ -37,6 +45,8 @@ def _center(win, parent):
         win.deiconify()
         win.lift()
         win.focus_force()
+        if focus is not None:
+            focus.focus_set()
     except Exception as _exc:
         crashlog.note(_exc, "gui.dialogs")
 
@@ -156,10 +166,6 @@ def ask_string(parent, title, prompt):
     var = tk.StringVar(value="")
     entry = ttk.Entry(body, textvariable=var, width=32)
     entry.pack(fill="x", pady=(scaled(10), 0))
-    try:
-        entry.focus_set()
-    except Exception as _exc:
-        crashlog.note(_exc, "gui.dialogs")
 
     def accept():
         _close(win, var.get())
@@ -173,5 +179,5 @@ def ask_string(parent, title, prompt):
     win.protocol("WM_DELETE_WINDOW", lambda: _close(win, None))
     win.bind("<Escape>", lambda e: _close(win, None))
     win.bind("<Return>", lambda e: accept())
-    _center(win, parent)
+    _center(win, parent, focus=entry)      # type straight away, no click needed
     return _run(win, None)

--- a/beantester/gui/pages/stats.py
+++ b/beantester/gui/pages/stats.py
@@ -20,6 +20,7 @@ from ..chart import draw_throughput_chart
 from ..labels import wrapping_label
 from ..rates import average_kbps
 from ..scaling import scaled
+from ..scrollable import ScrollableFrame
 from ..theme import BG2, DOWN_C, EVENT_COLORS, UP_C
 from ..tooltip import add_tooltip
 from ..widgets import SortableTree
@@ -106,6 +107,22 @@ class StatsPage:
 
     # -- sub-pages ----------------------------------------------------------- #
     def _build_live(self, parent):
+        # Scrolled, because this tab hit the SAME squeeze the page-level split
+        # above was meant to end. The counter grid reflows its columns with the
+        # window WIDTH, so a narrow window turns it into five tall rows; the grid
+        # packs at its natural height and the chart, packed expand=True, gets the
+        # leftover - which was about ten pixels, a black sliver under its own
+        # heading. A canvas asking for 180 px is still shrunk below it when pack
+        # has nothing left to give, so the request was never a floor.
+        # No Treeview/Text/Listbox lives in here (convention 14) - the chart
+        # canvas is a drawing surface with no scrolling of its own - so a
+        # scroller is safe, and nothing on this tab can be squeezed out of
+        # existence again. The trade: the scroller sizes its content to the
+        # REQUESTED height (gui/scrollable.py only stretches the width), so the
+        # chart no longer grows to fill a tall window - it keeps its 180 px.
+        self.scroll = ScrollableFrame(parent, top_margin=scaled(4))
+        parent = self.scroll.body
+
         self.grid = ttk.Frame(parent)
         self.grid.pack(fill="x", padx=scaled(8), pady=scaled(6))
         for key, cap, unit, tip in CELLS:

--- a/beantester/gui/panels/about.py
+++ b/beantester/gui/panels/about.py
@@ -43,6 +43,19 @@ class AboutWindow(PanelWindow):
     def build(self, body):
         pad = scaled(12)
 
+        # Packed FIRST so it reserves its height, for the reason spelled out in
+        # panels/settings.py: pack gives out space in call order, so a footer
+        # packed last is the one that gets clipped when the content grows. This
+        # window still fits today - it is the same code, one translation away
+        # from the same bug.
+        foot = ttk.Frame(body)
+        foot.pack(side="bottom", fill="x", padx=pad, pady=pad)
+        donate = ttk.Button(foot, text=T("buttons.donate"), style="Donate.TButton",
+                            command=self._donate)
+        donate.pack(side="left")
+        add_tooltip(donate, "tips.donate")
+        ttk.Button(foot, text=T("buttons.close"), command=self.close).pack(side="right")
+
         head = ttk.Frame(body)
         head.pack(side="top", fill="x", padx=pad, pady=(pad, scaled(4)))
         ttk.Label(head, text=APP_NAME, style="Title.TLabel").pack(side="left")
@@ -91,14 +104,6 @@ class AboutWindow(PanelWindow):
                         % (name, version, licence, "", "", url))
         text.insert("end", "\n" + T("about.licenses_dir", path=legal.licenses_dir()) + "\n")
         text.config(state="disabled")
-
-        foot = ttk.Frame(body)
-        foot.pack(side="bottom", fill="x", padx=pad, pady=pad)
-        donate = ttk.Button(foot, text=T("buttons.donate"), style="Donate.TButton",
-                            command=self._donate)
-        donate.pack(side="left")
-        add_tooltip(donate, "tips.donate")
-        ttk.Button(foot, text=T("buttons.close"), command=self.close).pack(side="right")
 
     def _donate(self):
         """Open the support page in the user's browser - the app opens no sockets."""

--- a/beantester/gui/panels/settings.py
+++ b/beantester/gui/panels/settings.py
@@ -42,6 +42,16 @@ class SettingsWindow(PanelWindow):
     def build(self, body):
         pad = scaled(12)
         app = self.app
+
+        # Packed FIRST, though it sits at the bottom. pack hands out height in
+        # call order, so a footer packed last gets whatever the content left -
+        # which was nothing, and "Close" was sliced in half by the window edge.
+        # Reserving it here means the content above is what runs out of room,
+        # and the button a user needs to shut the window always exists.
+        foot = ttk.Frame(body)
+        foot.pack(side="bottom", fill="x", padx=pad, pady=pad)
+        ttk.Button(foot, text=T("buttons.close"), command=self.close).pack(side="right")
+
         self._pref_vars = {}
         self._pref_entries = {}
         self._pref_errors = {}      # group label -> (error label, its number keys)
@@ -83,10 +93,6 @@ class SettingsWindow(PanelWindow):
         # -- GUI preferences (ui.json-backed, see gui/prefs.py) --------------- #
         for group_label, keys in PREF_GROUPS:
             self._build_pref_group(body, group_label, keys)
-
-        foot = ttk.Frame(body)
-        foot.pack(side="bottom", fill="x", padx=pad, pady=pad)
-        ttk.Button(foot, text=T("buttons.close"), command=self.close).pack(side="right")
 
     # -- preference rows ------------------------------------------------------- #
     def _build_pref_group(self, body, group_label, keys):

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -186,8 +186,23 @@ def test_a_dead_capture_thread_fails_open():
     divert = ExplodingDivert(packets=3)
     eng.start("test", divert=divert)
 
-    check("fail-open: the engine stops on a capture failure",
-          _wait_until(lambda: not eng.is_running()))
+    # Wait for the promise, not for the flag - the same fix
+    # test_the_engine_stops_itself_after_its_duration already carries. ``_running``
+    # is cleared as the SECOND statement of ``_stop_locked`` (deliberately: an
+    # early clear stops the watchdog firing a second, racing stop), and the divert
+    # is closed several statements later, with the event logged after that. So
+    # "not is_running()" is true well before any of the three things asserted
+    # below, and a loaded runner can be scheduled away inside that window. It was
+    # green ~5/5 locally and red on CI, which is exactly the shape of that gap.
+    def stopped_completely():
+        kinds = [(e[2], e[3]) for e in eng.events_snapshot()]
+        return (not eng.is_running() and divert.closed
+                and ("STOP", "events.fault") in kinds)
+
+    check("fail-open: the engine stops on a capture failure and finishes teardown",
+          _wait_until(stopped_completely),
+          f"(running={eng.is_running()}, closed={divert.closed}, "
+          f"events={[(e[2], e[3]) for e in eng.events_snapshot()]})")
     check("fail-open: the divert is closed (network restored)", divert.closed is True)
     check("fail-open: the reason is recorded", eng.stop_reason == "fault",
           f"({eng.stop_reason})")

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -114,6 +114,46 @@ def test_the_profile_picker_regrows_when_a_long_profile_is_saved():
     """)
 
 
+def test_the_live_stats_tab_is_scrolled_so_the_chart_cannot_vanish():
+    """BUG: the throughput chart was squeezed to a ten-pixel sliver.
+
+    The counter grid reflows its columns with the window WIDTH, so a narrow
+    window turns it into five tall rows. It packs at its natural height, and the
+    chart - packed ``expand=True`` - got the leftover, which was almost nothing.
+    A canvas asking for 180 px is still shrunk below it when pack has nothing
+    left to hand out, so the request alone was never a floor.
+    """
+    run_gui("""
+        stats = app.pages["statistics"]
+        assert getattr(stats, "scroll", None) is not None, "the Live tab is not scrolled"
+        assert stats.canvas.kw.get("height", 0) > 0, stats.canvas.kw
+    """)
+
+
+def test_a_panel_window_reserves_its_footer_before_its_content():
+    """BUG: "Close" was sliced in half by the bottom edge of the Settings window.
+
+    pack hands out height in call order, so a footer packed LAST gets whatever
+    the content above left over - and the Settings content grew past its 520 px
+    until that was nothing. Packing the footer first reserves it, and the
+    content is what runs out of room instead. About had the same shape and was
+    one longer translation away from the same bug.
+    """
+    run_gui("""
+        for window_id in ("settings", "about"):
+            app.windows.open(window_id)
+            panel = app.windows._open[window_id]
+            packed = panel.body.pack_slaves()
+            bottom = [i for i, w in enumerate(packed)
+                      if (w.pack_info or {}).get("side") == "bottom"]
+            assert bottom, f"{window_id}: no bottom-packed footer"
+            assert bottom[0] == 0, (
+                f"{window_id}: the footer is packed at position {bottom[0]} of "
+                f"{len(packed)}, so the content above it claims the height first")
+            app.windows.close(window_id)
+    """)
+
+
 def test_start_bar_and_log_can_never_be_squeezed_away():
     """A ttk.PanedWindow pushed its sash down whenever a page grew, and the whole
     bottom strip (START / Apply / log) disappeared. It is packed to the bottom now."""


### PR DESCRIPTION
## What and why

Three reported GUI problems and the CI failure. Two of the three turned out to be the same bug in
different windows.

### 1. The throughput chart could be squeezed until it vanished

The counter grid reflows its column count with the window **width**, so a narrow window turns it
into five tall rows. It packs at its natural height, and the chart - packed `expand=True` - takes
the leftover, which in the screenshot was about ten pixels: a black sliver under its own heading.
`height=scaled(180)` on the canvas is a **request**, and pack shrinks below a request when it has
nothing left to hand out, so it was never a floor.

This is the same squeeze the module docstring records at page level (*"pack simply gave the last two
panels no space at all"*), reappearing one level down. The Live tab now scrolls.

🔴 **Known trade, checked rather than assumed:** `ScrollableFrame._on_canvas_configure` only
stretches the inner window's **width**, so content is laid out at its requested height. The chart
therefore keeps its 180 px instead of growing to fill a tall window. Making the scroller stretch
height when the content is shorter than the viewport would restore that, but it is shared with the
Control page and I did not touch it here. Say the word if you want it.

### 2. "Close" cut in half in Settings - and About was next

Same root cause one level up: pack hands out height in call order, so a footer packed **last** gets
whatever the content left. Settings' content had grown past its 520 px, so that was nothing. Both
footers are packed first now. **About had the identical construction** and only fits today because
its content is shorter - it was one longer translation from the same bug.

### 3. "Save profile..." needed a click before typing

`ask_string` already called `entry.focus_set()`. It failed twice over: it ran while the dialog was
still `withdraw()`n, where focus does not stick, and `_center` then called `focus_force()` on the
window, discarding it. `_center` now takes the widget to focus.

### 4. The CI failure was a race in the test, not a regression

`test_a_dead_capture_thread_fails_open` was green ~5/5 locally and red on the runner.

`_stop_locked` clears `_running` as its **second statement** - deliberately, so a watchdog finishing
a slow op sees nothing to fire - and closes the divert several statements later, logging the STOP
event after that. So `not is_running()` is true well before all three things the test then asserted,
and a loaded runner can be descheduled inside that window.

**The product is correct - the fail-open invariant holds.** The divert is closed inside the same
critical section. The test now waits for the outcome, which is exactly the fix
`::test_the_engine_stops_itself_after_its_duration` already carries a few lines above, comment
included: *"Wait for the promise, not for the flag."* That one was fixed after CI caught the same
shape; this one was never given the same treatment.

## Reviewer notes

- **Two new guards, both mutation-verified:**
  `::test_the_live_stats_tab_is_scrolled_so_the_chart_cannot_vanish` and
  `::test_a_panel_window_reserves_its_footer_before_its_content`, which walks `body.pack_slaves()`
  and asserts the bottom-packed footer sits at index 0. Reverting each gives *"the Live tab is not
  scrolled"* and *"the footer is packed at position 5 of 6"*.
- **What a test cannot catch here:** the fake Tk does not compute geometry, so none of this proves
  anything about real pixels. The guards pin the *structure* that caused the clipping; the rendered
  result needs your eyes. Worth checking: the Live tab at a narrow window, Settings and About at
  their default size, and the Save-profile dialog.
- I briefly reverted two of my own files with `git checkout --` while undoing a mutation, which
  discarded the uncommitted fixes in them. Caught it by re-reading `git status` before committing;
  both are back and re-tested. Noting it because the commit would otherwise have quietly shipped two
  of the four fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
