### PR TITLE
fix(portmap): stop the tool stalling its own capture thread and blaming WinDivert

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -299,6 +299,47 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Fixed
 
+- **The tool was stalling its own capture thread and then blaming WinDivert for it.** Reported as a
+  spurious warning on the first START ("WinDivert held a packet for 105 ms ... the driver's queue is
+  backing up ... narrow the traffic filter"), which was true about the wait and wrong about the
+  cause: nothing outside the tool was congested, and narrowing the filter could not have helped.
+  - **Cause.** `PortTable.warm_names()` runs on the WATCHDOG thread and resolves every socket-owning
+    PID. The resolve went through `psutil.Process(pid)`, whose `ppid()` on Windows is `ppid_map()` -
+    a snapshot of EVERY process, taken afresh per call, because the C extension exports only
+    `ppid_map` and no `proc_ppid` (checked, psutil 7.2.2). So a pass took **one full system scan per
+    PID**: measured 9.36 ms/PID, **308.9 ms for 33 PIDs**, against 9.6 ms for a single snapshot
+    covering all 453 processes. The name was never the expensive part - `name()` measured
+    0.02-0.06 ms, and the docstring blaming NAME resolution for the cold resolve was wrong.
+  - **Not a startup wart.** `_expire_info` drops an entry `INFO_TTL_S` after it was WRITTEN and a
+    cache hit deliberately does not renew that stamp, so cold passes RECUR. Measured over 95 s:
+    spikes at t=0.3, 30.5, 60.9, 91.1 s, peaks 457/317/206/202 ms. With process churn (new PIDs
+    arriving continuously) it is worse still - 13 of 19 windows over the warn line, **peak 508 ms,
+    7 warnings in 95 s**.
+  - **Fix: `portmap._process_info` - one handle instead of one snapshot per PID.** New
+    `_native_process_info` reads name, parent and creation stamp through a single
+    `OpenProcess` + `NtQueryInformationProcess` + `GetProcessTimes` + `QueryFullProcessImageNameW`,
+    with `_psutil_process_info` kept behind it as the fallback. **0.03 ms/PID, 1.0 ms for the set.**
+    Measured end to end on the shipped code, churn on, 95 s: **peak 508 -> 16.6 ms, 0 of 20 windows
+    over the warn line, 7 warnings -> 0**, process names still 36/36. `warm_names()` cold:
+    344-458 -> 24 ms; warm 0.22 ms.
+  - **Why the handle and not a cached `{pid: ppid}` table**, which measured 0.31 ms/PID and would
+    also have fixed the symptom: the handle PINS the identity, so name, parent and creation stamp
+    describe the one process the kernel gave us. A cached table has a staleness window in which a
+    recycled PID lets one process's name meet another's parent - the mixture `_looks_recycled`
+    exists to prevent. Speed was not the deciding argument.
+  - **Verified against churn** (2149 lookups, 489 PIDs, continuous spawn/exit): 0 ppid
+    disagreements with psutil, 0 with the toolhelp snapshot (461/461 identical). **NOT verified:**
+    PID recycling could not be forced (0 observed), so that property rests on the mechanism, not a
+    measurement; 32-bit/WOW64 and ARM64 are untested. Every failure path returns `None` and falls
+    back, so if a future Windows withdraws `NtQueryInformationProcess` this degrades to today's
+    behaviour and today's cost, not to a broken tool.
+  - **One bug found by the suite, worth recording.** The first version gated
+    `_ALLOW_NATIVE_PROCESSES` while BINDING the ctypes entry points and cached the result, so the
+    flag was read once per process: `test_a_target_restarting_onto_a_recycled_pid_is_still_impaired`
+    asked its fake world for pid 5000 and got `wslhost.exe` off the real machine. The gate is now
+    read per call, like `_toolhelp_process_table` does it. Caching ABILITY is fine; caching POLICY
+    is not, and it fails in both directions.
+
 - **The Live stats tab is a `ScrollableFrame`** (`gui/pages/stats.py`). The counter grid reflows its
   column count with the window WIDTH, so a narrow window turns it into five tall rows; it packs at
   its natural height and the chart, packed `expand=True`, took the leftover - about ten pixels. The
@@ -326,6 +367,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   reverting them gives "the Live tab is not scrolled" and "the footer is packed at position 5 of 6".
 
 ### Tests
+
+- **Four new guards in `test_processes.py` for the per-PID handle read**, filling a gap that had
+  been open for as long as `ppid` has mattered: it feeds `PortTable.ancestors`, which is how
+  `targeting.py` matches a process TREE, and every existing targeting test drives a FAKE table with
+  its own `ancestors` - so all of them stay green no matter what the real resolver returns.
+  - `::test_the_handle_read_agrees_with_an_independent_oracle_on_the_parent` - checks the parent
+    against `os.getppid()`, which shares no code with psutil or toolhelp, and cross-checks name and
+    parent against the psutil path it replaced.
+  - `::test_a_process_that_will_not_name_itself_is_declined` - PID 4 (`System`) never yields an
+    image name and must resolve to `None`, not to a nameless cache entry.
+  - `::test_a_name_that_comes_back_empty_is_declined_not_cached` - the succeeded-but-EMPTY name, the
+    state a just-exited process is in (measured under churn: pid 45336, identical parent and start
+    time across two reads, name `'cmd.exe'` then `''`). Drives the five ctypes entry points through
+    an injected fake, which also pins the FILETIME epoch conversion and runs the parsing on
+    **every platform**, not only where the API exists.
+  - `::test_the_native_policy_gate_is_read_per_call_not_cached` - regression test for the bind-time
+    gate described above.
+  - **Verified by mutation, and one had to be rewritten to earn it.** Four mutants: policy gate
+    removed, parent replaced by the process's own pid, creation stamp dropped, empty name cached.
+    The first version of the empty-name guard **SURVIVED** its mutant - PID 4 leaves by the
+    failed-call branch, so deleting the empty-string check changed nothing it could see. Splitting
+    it into the two tests above catches all four.
+- `test_hot_path.py::OS_FUNCTIONS` gained `_native_process_info`. Without it the guard would have
+  gone on passing while no longer watching the main resolve route - the failure mode where a test
+  stays green because it stopped looking. Its docstring's call tally is re-measured.
 
 - **`test_failsafe.py::test_a_dead_capture_thread_fails_open` was racy and CI caught it** (green ~5/5
   locally, red on the runner). `_stop_locked` clears `_running` as its SECOND statement - deliberate,

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -333,6 +333,23 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
     measurement; 32-bit/WOW64 and ARM64 are untested. Every failure path returns `None` and falls
     back, so if a future Windows withdraws `NtQueryInformationProcess` this degrades to today's
     behaviour and today's cost, not to a broken tool.
+  - **Stability, since this opens a kernel handle per PID and runs forever.** 20 000 calls over a
+    mix of live, dead and nonsense PIDs: **handles 185 -> 185, RSS flat**, 35.6 us each. The two
+    failure routes leak nothing either (5 000 calls each with the binding dead, and with the query
+    failing *after* `OpenProcess` succeeded: handle count unchanged) - the `finally` gives the
+    handle back on every path. A 5-minute session with traffic and continuous process churn:
+    **handles 231 -> 232** (range 225-234), RSS +1.4 MB, worst wait in any 20 s window **19.8 ms,
+    0 of 15 windows over the warn line, 0 warnings**, names resolved 100% throughout.
+    Degenerate input returns `None` rather than raising: `None`, 0, negative, non-numeric text,
+    values past a DWORD, and dead PIDs.
+  - **A concurrency fault that a lock did NOT fix, found by measuring twice.** The lazy bind
+    published an "in progress" marker in the shared slot before loading the DLLs. The fast path
+    reads that slot unlocked and `False is not None`, so every other thread read it as "unavailable"
+    and returned without ever queueing - **adding a lock changed nothing, 200 of 1600 calls, 5
+    trials of 5**, and only a state trace showed why. Nothing is published now until the binding has
+    an answer: **1600 of 1600**. It matters because the two threads that hit this from cold are the
+    watchdog warming names and the resolver matching a target, i.e. session start - the exact moment
+    this change exists to make cheap.
   - **One bug found by the suite, worth recording.** The first version gated
     `_ALLOW_NATIVE_PROCESSES` while BINDING the ctypes entry points and cached the result, so the
     flag was read once per process: `test_a_target_restarting_onto_a_recycled_pid_is_still_impaired`
@@ -384,6 +401,10 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
     **every platform**, not only where the API exists.
   - `::test_the_native_policy_gate_is_read_per_call_not_cached` - regression test for the bind-time
     gate described above.
+  - `::test_a_cold_binding_does_not_push_other_threads_onto_the_slow_path` - 8 threads released
+    together onto a never-bound surface; every one of the 400 calls must take the handle route.
+    Regression test for the marker-in-the-shared-slot fault, and it catches its mutant (putting the
+    marker back) while the lock alone does not.
   - **Verified by mutation, and one had to be rewritten to earn it.** Four mutants: policy gate
     removed, parent replaced by the process's own pid, creation stamp dropped, empty name cached.
     The first version of the empty-name guard **SURVIVED** its mutant - PID 4 leaves by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The tool kept pausing itself and then warning you about WinDivert.** Every so often - on the
+  first Start, then roughly every 30 seconds, and far more often on a busy machine - it spent up to
+  half a second working out which program owns which connection. While that was going on it stopped
+  picking up packets, so they piled up inside the driver, and then it told you: *"WinDivert held a
+  packet for 105 ms ... the driver's queue is backing up ... narrow the traffic filter."*
+  Nothing was wrong with your filter and nothing was wrong with the driver. The delay was the tool's
+  own, so narrowing the filter could not have helped - and that half second landed on your traffic
+  without showing up in any counter, in a tool whose whole job is to control delay precisely.
+  Looking up those program names now takes about a millisecond instead of several hundred. Measured
+  over a 95-second session with programs constantly starting and stopping: the worst pile-up dropped
+  from 508 ms to 17 ms, and the warning stopped appearing. The process names in the Connections tab
+  are exactly as before. If you do see that warning now, it means what it says.
+
 - **With "Capture only the targeted traffic" on, the Statistics and Connections tabs said the exact
   opposite of the truth.** Both kept their usual line - "Counters cover ALL captured traffic" and
   "All captured connections ... targeting decides what gets impaired, not what gets listed" - even

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -353,6 +353,152 @@ def _looks_recycled(current, cached):
     return abs(current - cached) >= 0.001
 
 
+# -- one process, read through ONE handle --------------------------------------- #
+# psutil has no cheap per-process parent lookup on Windows. ``Process.ppid()`` is
+# ``ppid_map()`` - a snapshot of EVERY process, taken afresh on every call, because
+# the C extension exports only ``ppid_map`` and no ``proc_ppid`` (checked, psutil
+# 7.2.2). MEASURED 2026-08-01, elevated, 33 socket-owning PIDs: **9.36 ms per PID,
+# 308.9 ms for the set** - which ``warm_names()`` paid on the WATCHDOG thread, so
+# the capture thread was starved and the driver's queue backed up to 508 ms.
+#
+# OpenProcess answers the same three questions for **0.03 ms per PID** (1.0 ms for
+# the set), and answers them BETTER: the handle pins the identity, so the name, the
+# parent and the creation stamp all describe the one process the kernel handed us.
+#
+# A cached ``{pid: ppid}`` table was measured (0.31 ms per PID) and REJECTED: its
+# staleness window lets one process's name meet another process's parent once a PID
+# is recycled, which is the very mixture ``_looks_recycled`` exists to prevent.
+# Speed was not the reason to prefer the handle; that was.
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_STATUS_SUCCESS = 0
+_FILETIME_EPOCH_DELTA = 11644473600.0     # 1601-01-01 -> unix epoch, in seconds
+
+# ``(ctypes, wintypes, kernel32, ntdll, PROCESS_BASIC_INFORMATION)``, bound once;
+# ``False`` once it is known to be unavailable. Deliberately NOT rebuilt per call,
+# unlike the structure ``_toolhelp_process_table`` declares inline: that one is
+# throttled to a snapshot a second and can afford it, this one runs once per PID.
+#
+# This caches ABILITY, never POLICY. ``_ALLOW_NATIVE_PROCESSES`` is checked per call
+# in ``_native_process_info`` instead, and the first version of this got that wrong:
+# gating the BINDING meant the flag was read once, so a test flipping it afterwards
+# was silently ignored - ``test_a_target_restarting_onto_a_recycled_pid_is_still_
+# impaired`` asked its fake world for pid 5000 and got ``wslhost.exe`` off the real
+# machine. Caching a policy decision breaks in both directions, too: bound while a
+# test had it off, the native route would then stay off for the whole process.
+_NATIVE_INFO_API = [None]
+
+
+def _native_info_api():
+    """Bind the entry points and the result structure once. ``None`` if unavailable."""
+    if _NATIVE_INFO_API[0] is None:
+        _NATIVE_INFO_API[0] = False
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            class PROCESS_BASIC_INFORMATION(ctypes.Structure):
+                _fields_ = [("ExitStatus", ctypes.c_long),
+                            ("PebBaseAddress", ctypes.c_void_p),
+                            ("AffinityMask", ctypes.c_size_t),
+                            ("BasePriority", ctypes.c_long),
+                            ("UniqueProcessId", ctypes.c_size_t),
+                            ("InheritedFromUniqueProcessId", ctypes.c_size_t)]
+
+            k32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+            # restype/argtypes MATTER here for the same reason they do in
+            # _toolhelp_process_table: the handle is pointer-sized and the default
+            # c_int return truncates it on 64-bit.
+            k32.OpenProcess.restype = wintypes.HANDLE
+            k32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+            k32.CloseHandle.argtypes = [wintypes.HANDLE]
+            k32.GetProcessTimes.argtypes = (
+                [wintypes.HANDLE] + [ctypes.POINTER(wintypes.FILETIME)] * 4)
+            k32.QueryFullProcessImageNameW.restype = wintypes.BOOL
+            k32.QueryFullProcessImageNameW.argtypes = [
+                wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+                ctypes.POINTER(wintypes.DWORD)]
+            ntdll.NtQueryInformationProcess.argtypes = [
+                wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p,
+                wintypes.ULONG, ctypes.POINTER(wintypes.ULONG)]
+            _NATIVE_INFO_API[0] = (ctypes, wintypes, k32, ntdll,
+                                   PROCESS_BASIC_INFORMATION)
+        except Exception:
+            _NATIVE_INFO_API[0] = False
+    return _NATIVE_INFO_API[0] or None
+
+
+def _native_process_info(pid):
+    """``(name, ppid, created)`` for one pid through a single handle, or ``None``.
+
+    ``None`` means "not resolved" and hands the question to the caller's existing
+    fallbacks; it is never an error worth reporting. Three ways to get there, and
+    the third was found by measurement rather than reasoning:
+
+    * ``OpenProcess`` refuses - not elevated, or the process is protected. The
+      snapshot path names those without opening them, which is what it is for.
+    * the process is gone between the socket table naming it and this call. Normal
+      under churn: 11-18 of ~2100 lookups in a 25 s churn test.
+    * **the process has just exited and answers only PARTLY.**
+      ``NtQueryInformationProcess`` and ``GetProcessTimes`` still succeed on it
+      while ``QueryFullProcessImageNameW`` returns an EMPTY name (caught in that
+      same test: pid 45336, identical ppid and creation stamp across two reads,
+      name ``'cmd.exe'`` then ``''``). Caching that empty string would blank the
+      connection log's process column, so it counts as unresolved. PID 4
+      (``System``) answers the same way, permanently.
+
+    ``NtQueryInformationProcess`` is documented as subject to change, so every
+    failure mode above lands on the same ``None``: if a future Windows withdraws it,
+    this degrades to the psutil path that used to run - to today's behaviour and
+    today's cost, not to a broken tool.
+    """
+    if not _ALLOW_NATIVE_PROCESSES:
+        return None
+    api = _native_info_api()
+    if api is None:
+        return None
+    ctypes, wintypes, k32, ntdll, PROCESS_BASIC_INFORMATION = api
+    try:
+        handle = k32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid))
+    except Exception:
+        return None
+    if not handle:
+        return None
+    try:
+        basic = PROCESS_BASIC_INFORMATION()
+        written = wintypes.ULONG()
+        status = ntdll.NtQueryInformationProcess(      # 0 = ProcessBasicInformation
+            handle, 0, ctypes.byref(basic), ctypes.sizeof(basic), ctypes.byref(written))
+        if status != _STATUS_SUCCESS:
+            # Also the guard for a structure that does not match this architecture
+            # (WOW64): the query fails rather than returning nonsense.
+            return None
+        ppid = int(basic.InheritedFromUniqueProcessId)
+
+        created_ft, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+        if not k32.GetProcessTimes(handle, ctypes.byref(created_ft), ctypes.byref(exited),
+                                   ctypes.byref(kernel), ctypes.byref(user)):
+            return None
+        ticks = (created_ft.dwHighDateTime << 32) | created_ft.dwLowDateTime
+        created = ticks / 10_000_000.0 - _FILETIME_EPOCH_DELTA
+
+        size = wintypes.DWORD(512)
+        buffer = ctypes.create_unicode_buffer(512)
+        if not k32.QueryFullProcessImageNameW(handle, 0, buffer, ctypes.byref(size)):
+            return None
+        name = (buffer.value or "").rsplit("\\", 1)[-1]
+        if not name:
+            return None
+        return (name, ppid, created)
+    except Exception:
+        return None
+    finally:
+        # The handle must go back whatever happened above - this runs once per PID,
+        # so leaking here would leak steadily for the life of the session.
+        with crashlog.quiet("portmap.close_handle"):
+            k32.CloseHandle(handle)
+
+
 def _psutil_created(pid):
     """Start time of ``pid`` right now - the identity stamp. ``None`` if unknown.
 
@@ -374,13 +520,30 @@ def _psutil_created(pid):
 
 
 def _psutil_process_info(pid):
-    """``(name, ppid, created)`` for one pid, or ``None`` when it cannot be resolved."""
+    """``(name, ppid, created)`` for one pid, or ``None`` when it cannot be resolved.
+
+    The portable path, and the fallback whenever ``_native_process_info`` cannot
+    answer - see ``_process_info``. Kept as the fallback rather than replaced: it
+    resolves whatever the handle route cannot, at the cost the tool used to pay
+    anyway, so no environment loses an answer it has today.
+    """
     try:
         import psutil
         process = psutil.Process(int(pid))
         return str(process.name() or ""), process.ppid(), process.create_time()
     except Exception:
         return None
+
+
+def _process_info(pid):
+    """``(name, ppid, created)`` for one pid: the handle first, psutil behind it.
+
+    The one route ``PortTable.info`` takes to resolve a PID it has not cached.
+    Both halves are module-level functions so the hot-path guard can count trips to
+    the OS by replacing them (``tests/test_hot_path.py``).
+    """
+    resolved = _native_process_info(pid)
+    return resolved if resolved is not None else _psutil_process_info(pid)
 
 
 # -- the table ----------------------------------------------------------------- #
@@ -619,15 +782,20 @@ class PortTable:
         scans the whole system for that one PID). An ADMIN opens every socket-owning
         PID - 0 of 27 denied here - so a warm refresh's recycle check is ~0.16 ms; a
         NON-admin is denied on system / other-user PIDs (16 of 27) and it climbs to
-        ~90-180 ms, with the cold resolve at ~380 ms against ~36 ms elevated. Real
-        impairment ALWAYS runs elevated (WinDivert will not open without admin), so
-        this is cheap in every real session; the slow figure appears only on the one
-        non-elevated path that runs the resolver at all, ``--simulate`` (synthetic
-        packets, and the cost sits on the RESOLVER thread, never the capture one).
-        Batching the denied PIDs in one ``NtQuerySystemInformation`` was measured and
-        REJECTED (2026-07-24): it speeds only the non-elevated warm check - a demo
-        mode - and does nothing for the elevated hot path or for the cold resolve,
-        which NAME resolution dominates.
+        ~90-180 ms. Real impairment ALWAYS runs elevated (WinDivert will not open
+        without admin), so this is cheap in every real session; the slow figure
+        appears only on the one non-elevated path that runs the resolver at all,
+        ``--simulate`` (synthetic packets, and the cost sits on the RESOLVER thread,
+        never the capture one). Batching the denied PIDs in one
+        ``NtQuerySystemInformation`` was measured and REJECTED (2026-07-24): it
+        speeds only the non-elevated warm check - a demo mode - and does nothing for
+        the elevated hot path.
+
+        The cold RESOLVE behind a cache miss is no longer psutil's - see
+        ``_process_info``. This note used to put it at ~36 ms elevated and blame NAME
+        resolution; both halves were wrong. MEASURED 2026-08-01: the PARENT lookup
+        was 9.36 ms of a 9.4 ms per-PID resolve while the name cost 0.02-0.06 ms, so
+        33 PIDs came to 308.9 ms. Read through one handle, the same set costs 1.0 ms.
         """
         if pid is None:
             return ("", None)
@@ -653,7 +821,7 @@ class PortTable:
             # ask the OS. "" is the honest answer; the resolver will have filled the
             # cache by the time this row is looked at again.
             return ("", None)
-        resolved = _psutil_process_info(pid)
+        resolved = _process_info(pid)
         if resolved is None:
             # psutil.Process could not open the process (it is HARDENED - Chrome's
             # network service, some services - or denied, or already gone). Fall back
@@ -694,8 +862,19 @@ class PortTable:
         belongs to before deciding what to target.
 
         Cheap in the steady state: the names are already cached, so this is one
-        identity check per PID (~0.13 ms for the 25-odd PIDs a desktop has). The
-        first pass pays the real resolve (~124 ms) once.
+        identity check per PID (measured 0.2-0.4 ms for the 33 this desktop has).
+
+        A COLD pass is NOT a one-off, and the sentence that used to say it was hid a
+        real fault for as long as it stood. Entries expire ``INFO_TTL_S`` after they
+        were WRITTEN and a cache hit deliberately does not renew that stamp (see
+        ``_expire_info``), while every newly started process arrives uncached - so
+        cold passes recur for the whole life of a session: every 30 s on an idle
+        machine, and on nearly every watchdog tick while processes churn. When the
+        resolve behind them cost 9.4 ms per PID this starved the CAPTURE thread,
+        backing the driver's queue up to 508 ms and printing 7 spurious "the driver
+        is dropping packets" warnings in 95 s (measured 2026-08-01 - the whole reason
+        ``_process_info`` exists). At ~1 ms the recurrence is harmless, but it is
+        still a recurrence, not a first pass.
         """
         for pid in set(self.snapshot().values()):
             self.info(pid)

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -387,11 +387,33 @@ _FILETIME_EPOCH_DELTA = 11644473600.0     # 1601-01-01 -> unix epoch, in seconds
 # test had it off, the native route would then stay off for the whole process.
 _NATIVE_INFO_API = [None]
 
+# Taken only while BINDING, never per lookup. Without it the bind is not just racy in
+# theory: the first arrival used to publish its "in progress" marker before loading
+# the DLLs, so every other thread read it as "unavailable" and silently took the
+# psutil path for the whole window. MEASURED with 8 threads from cold, 3 trials of 3:
+# exactly 200 of 1600 calls got the native route and 1400 fell back - the seven
+# threads that lost the race ran their entire loop inside one DLL load. Harmless for
+# correctness, but it lands at SESSION START, which is the moment this whole change
+# exists to make cheap. A leaf lock: nothing else is held while it is taken (``info``
+# calls ``_process_info`` outside ``self._lock``), and it is uncontended after the
+# first bind because the fast path never reaches it.
+_NATIVE_INFO_LOCK = threading.Lock()
+
 
 def _native_info_api():
     """Bind the entry points and the result structure once. ``None`` if unavailable."""
-    if _NATIVE_INFO_API[0] is None:
-        _NATIVE_INFO_API[0] = False
+    api = _NATIVE_INFO_API[0]
+    if api is not None:
+        return api or None
+    with _NATIVE_INFO_LOCK:
+        if _NATIVE_INFO_API[0] is not None:      # somebody bound it while we waited
+            return _NATIVE_INFO_API[0] or None
+        # Nothing is published until the binding has an ANSWER. An "in progress"
+        # marker here defeats the lock without appearing to: the fast path reads
+        # this slot unlocked, and ``False is not None``, so every other thread took
+        # it as "known unavailable" and returned without ever queueing. That is the
+        # bug the lock was supposed to fix, surviving the lock - measured unchanged
+        # at 200 of 1600 calls, and only the state trace showed why.
         try:
             import ctypes
             from ctypes import wintypes

--- a/tests/test_hot_path.py
+++ b/tests/test_hot_path.py
@@ -29,15 +29,26 @@ nobody has written yet. Threads are compared by IDENTITY against the engine's ow
 handles rather than by name substring, so it does not depend on how CPython
 happens to name a thread.
 
-Measured while writing this, on a real session with traffic and targeting active
-(the numbers are the point of the test, not decoration):
+Measured on a real session with traffic and targeting active (the numbers are the
+point of the test, not decoration). Re-measured 2026-08-01, when the per-PID resolve
+moved from psutil to a handle read (``portmap._process_info``):
 
-    5232x  _psutil_created         from bean-target-resolver
-    1431x  _psutil_process_info    from bean-target-resolver
-     448x  _psutil_created         from the watchdog
-     212x  _Native._table          from bean-target-resolver
-       3x  _psutil_process_table   from bean-target-resolver
+    1210x  _psutil_created         from bean-target-resolver
+     330x  _native_process_info    from bean-target-resolver
+     330x  _psutil_process_info    from bean-target-resolver
+     238x  _psutil_created         from MainThread
+      70x  _native_process_info    from MainThread
+      68x  _psutil_created         from the watchdog
+      67x  _psutil_process_info    from MainThread
+      40x  _Native._table          from bean-target-resolver
        0x  anything                from the capture or inject thread
+
+The two resolve counts matching is not double work: this test points targeting at a
+name nothing has, so the socket table keeps naming PIDs that have already EXITED
+(checked: ``psutil.pid_exists`` is False for the frequent ones). Both routes decline
+them, one after the other. Traced separately over 390 resolves, the handle answered
+4, declined 386, and psutil then resolved 1 of those - which is the fallback earning
+its place rather than shadowing the primary.
 
 The work is real and it is heavy - and all of it happens somewhere the user's
 packets do not wait for it. That is the whole design, asserted.
@@ -87,7 +98,7 @@ from fakes import check
 # level functions called through module globals, so replacing the attribute is
 # enough - production picks up the replacement at call time.
 OS_FUNCTIONS = ("_psutil_port_pid_map", "_psutil_process_table",
-                "_psutil_created", "_psutil_process_info")
+                "_psutil_created", "_psutil_process_info", "_native_process_info")
 
 
 @contextlib.contextmanager

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -406,6 +406,54 @@ def test_the_native_policy_gate_is_read_per_call_not_cached(monkeypatch):
               portmap._native_process_info(os.getpid()) is not None)
 
 
+@pytest.mark.skipif(not sys.platform.startswith("win"),
+                    reason="the handle read is Windows-only")
+def test_a_cold_binding_does_not_push_other_threads_onto_the_slow_path(monkeypatch):
+    """Threads arriving while the ctypes surface is being bound must WAIT, not degrade.
+
+    Two threads reach this from the first moments of a session - the watchdog warming
+    names and the resolver matching a target - so the bind window lands exactly where
+    the whole change exists to save time. Silently taking the psutil route there costs
+    9 ms a lookup instead of 0.03 ms, which is what was being fixed.
+
+    A regression test for a fault a LOCK DID NOT FIX. Publishing an "in progress"
+    marker in the shared slot defeated it invisibly: the fast path reads that slot
+    unlocked and ``False is not None``, so every other thread read it as "unavailable"
+    and returned without ever queueing on the lock. Measured before: exactly 200 of
+    1600 calls took the native route, 3 trials of 3 and then 5 of 5 - one thread's
+    worth, every time. After: 1600 of 1600, 5 trials of 5.
+    """
+    import os
+    import threading
+    from beantester import portmap
+
+    monkeypatch.setattr(portmap, "_NATIVE_INFO_API", [None])      # never bound yet
+    threads_n, per_thread = 8, 50
+    resolved, failures = [], []
+    barrier = threading.Barrier(threads_n)
+
+    def hammer():
+        barrier.wait()                    # everybody hits the cold slot together
+        try:
+            for _ in range(per_thread):
+                resolved.append(portmap._native_process_info(os.getpid()) is not None)
+        except Exception as exc:          # noqa: BLE001 - the point is to report it
+            failures.append(repr(exc))
+
+    workers = [threading.Thread(target=hammer) for _ in range(threads_n)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=30)
+
+    check("no thread raised while the surface was being bound", not failures,
+          f"({failures[:2]})")
+    check("every thread got an answer", len(resolved) == threads_n * per_thread,
+          f"({len(resolved)} of {threads_n * per_thread})")
+    check("and none of them was pushed onto the psutil path by the bind",
+          all(resolved), f"({sum(resolved)} of {len(resolved)} took the handle route)")
+
+
 # -- port resolution fails LOUDLY (for us), quietly (for the user) ---------- #
 #
 # All three of these used to swallow. An empty map, a blank process name and a

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -254,6 +254,158 @@ def test_toolhelp_snapshot_names_this_process_without_opening_it():
     check("the snapshot carries no start time (TTL takes over)", created is None)
 
 
+# -- the per-PID handle read (Windows only) --------------------------------- #
+@pytest.mark.skipif(not sys.platform.startswith("win"),
+                    reason="the handle read is Windows-only")
+def test_the_handle_read_agrees_with_an_independent_oracle_on_the_parent():
+    """The PARENT pid, checked against something that is neither psutil nor toolhelp.
+
+    ``ppid`` is load-bearing and had no guardian: it feeds ``PortTable.ancestors``,
+    which is how ``targeting.py`` matches a process TREE, so a wrong parent silently
+    stops a target from catching its children. Every existing targeting test drives a
+    FAKE table with its own ``ancestors``, so all of them stay green no matter what
+    this returns - the trap PROJECT_NOTES calls out about fixtures that cannot tell
+    the variants apart.
+
+    ``os.getppid()`` is the independent oracle: CPython asks the OS directly, so it
+    shares no code with either resolver.
+    """
+    import os
+    from beantester.portmap import _native_process_info, _psutil_process_info
+    resolved = _native_process_info(os.getpid())
+    check("the handle read answered for this process", resolved is not None)
+    name, ppid, created = resolved
+    check("it names this process", name.lower().endswith(".exe"), f"({name!r})")
+    check("the parent matches the OS", ppid == os.getppid(),
+          f"(handle said {ppid}, os.getppid() said {os.getppid()})")
+    check("it carries a start time, so the recycle check stays verifiable",
+          isinstance(created, float) and created > 0, f"({created!r})")
+    # and it must agree with the path it replaced, or the connection log changes
+    # meaning without anybody deciding that it should
+    fallback = _psutil_process_info(os.getpid())
+    check("name and parent match the psutil path it replaced",
+          fallback is not None and fallback[0].lower() == name.lower()
+          and fallback[1] == ppid, f"({fallback!r} vs {resolved!r})")
+
+
+@pytest.mark.skipif(not sys.platform.startswith("win"),
+                    reason="the handle read is Windows-only")
+def test_a_process_that_will_not_name_itself_is_declined():
+    """PID 4 (``System``) never yields an image name, so it must resolve to ``None``.
+
+    A real standing example of the partial read rather than a race to reproduce. It
+    exercises the FAILED-call route out; the succeeded-but-empty route has its own
+    test below, because a mutant showed these are two different branches and this
+    one alone does not cover both.
+    """
+    from beantester.portmap import _native_process_info
+    check("the System process is declined, not cached nameless",
+          _native_process_info(4) is None)
+
+
+def _fake_native_api(name_value, ppid=4321, ticks=133_000_000_000_000_000, ok=True):
+    """A stand-in for the bound ctypes surface, so the parsing can be driven directly.
+
+    The five entry points live in one injectable tuple precisely so this is possible:
+    it makes the branches reachable without a process in the right state, and it runs
+    the parsing on EVERY platform rather than only where the API exists.
+    """
+    class _Field:
+        def __init__(self, v=0):
+            self.value = v
+
+    class _Basic:
+        def __init__(self):
+            self.InheritedFromUniqueProcessId = ppid
+            self.UniqueProcessId = 999
+
+    class _Filetime:
+        def __init__(self):
+            self.dwHighDateTime = ticks >> 32
+            self.dwLowDateTime = ticks & 0xFFFFFFFF
+
+    class _Ctypes:
+        byref = staticmethod(lambda x: x)
+        sizeof = staticmethod(lambda x: 48)
+        create_unicode_buffer = staticmethod(lambda n: _Field(name_value))
+
+    class _Wintypes:
+        ULONG = _Field
+        DWORD = _Field
+        FILETIME = _Filetime
+
+    class _K32:
+        OpenProcess = staticmethod(lambda *a: 1234)
+        CloseHandle = staticmethod(lambda *a: 1)
+        GetProcessTimes = staticmethod(lambda *a: 1)
+        QueryFullProcessImageNameW = staticmethod(lambda *a: 1 if ok else 0)
+
+    class _Ntdll:
+        NtQueryInformationProcess = staticmethod(lambda *a: 0)
+
+    return (_Ctypes, _Wintypes, _K32, _Ntdll, _Basic)
+
+
+def test_a_name_that_comes_back_empty_is_declined_not_cached(monkeypatch):
+    """The succeeded-but-EMPTY name must fall through, never reach the cache.
+
+    A process that has just exited still answers NtQueryInformationProcess and
+    GetProcessTimes while its image name comes back blank (measured under churn: pid
+    45336, identical parent and start time across two reads, name 'cmd.exe' then '').
+    Caching that would blank the connection log's process column - the exact bug the
+    column was added to fix.
+
+    Written after a mutant SURVIVED: deleting the empty-name guard changed nothing
+    the PID 4 test could see, because PID 4 leaves by the failed-call branch instead.
+    """
+    from beantester import portmap
+    monkeypatch.setattr(portmap, "_ALLOW_NATIVE_PROCESSES", True)
+
+    monkeypatch.setattr(portmap, "_NATIVE_INFO_API", [_fake_native_api("")])
+    check("an empty name resolves to nothing at all",
+          portmap._native_process_info(45336) is None)
+
+    monkeypatch.setattr(portmap, "_NATIVE_INFO_API",
+                        [_fake_native_api(r"C:\Windows\System32\cmd.exe")])
+    resolved = portmap._native_process_info(45336)
+    check("a real name resolves", resolved is not None, f"({resolved!r})")
+    check("...to its basename, not the full path", resolved[0] == "cmd.exe",
+          f"({resolved[0]!r})")
+    check("...with the parent the API reported", resolved[1] == 4321,
+          f"({resolved[1]})")
+    # 133e15 FILETIME ticks = 2022-06-18T04:26:40Z, checked two ways (the epoch shift
+    # by hand, and datetime from the 1601 base). Pinned because that shift is the one
+    # piece of arithmetic here and off-by-a-constant would look perfectly plausible.
+    check("...and a start time converted off the FILETIME epoch",
+          abs(resolved[2] - 1655526400.0) < 1.0, f"({resolved[2]!r})")
+
+    monkeypatch.setattr(portmap, "_NATIVE_INFO_API",
+                        [_fake_native_api("cmd.exe", ok=False)])
+    check("a failed name call is declined too",
+          portmap._native_process_info(45336) is None)
+
+
+def test_the_native_policy_gate_is_read_per_call_not_cached(monkeypatch):
+    """``_ALLOW_NATIVE_PROCESSES`` must gate every call, not just the first one.
+
+    This is a REGRESSION TEST, not a hypothetical: the first version of the handle
+    read checked the flag while BINDING the ctypes entry points and cached the
+    result, so a test switching the flag off afterwards was ignored and got real
+    machine processes back inside its fake world. Caching a policy decision fails in
+    both directions - bound while the flag was off, the native route would then stay
+    off for the rest of the process.
+    """
+    import os
+    from beantester import portmap
+    monkeypatch.setattr(portmap, "_ALLOW_NATIVE_PROCESSES", False)
+    check("the native read declines while the flag is off",
+          portmap._native_process_info(os.getpid()) is None)
+    monkeypatch.undo()
+    if sys.platform.startswith("win"):
+        check("...and answers again once it is back on",
+              portmap._native_process_info(os.getpid()) is not None)
+
+
 # -- port resolution fails LOUDLY (for us), quietly (for the user) ---------- #
 #
 # All three of these used to swallow. An empty map, a blank process name and a


### PR DESCRIPTION
## What was reported

After a fresh build, the first **Start** logged:

> UWAGA: WinDivert przetrzymał pakiet 105 ms, zanim to narzędzie w ogóle go zobaczyło. Kolejka sterownika się zapycha... Zawęź filtr ruchu, żeby przez narzędzie szło mniej.

True about the wait, wrong about the cause. Nothing outside the tool was congested, and narrowing the filter could not have helped.

## Cause

`PortTable.warm_names()` runs on the **watchdog** thread and resolves every socket-owning PID. That resolve went through `psutil.Process(pid)`, whose `ppid()` on Windows is `ppid_map()` — a snapshot of **every** process, taken afresh on **every call** (psutil 7.2.2 exports only `ppid_map`; there is no `proc_ppid`).

| | measured |
|---|---|
| `psutil` resolve, per PID | **9.36 ms** |
| ...for the 33 socket-owning PIDs | **308.9 ms** |
| one whole-system snapshot (453 processes) | 9.6 ms |
| `name()` — never the expensive part | 0.02–0.06 ms |

That starved the **capture** thread, so packets piled up in the driver's queue.

**It was not a startup wart.** `_expire_info` drops an entry 30 s after it was *written*, and a cache hit deliberately does not renew that stamp, so cold passes recur — spikes at t=0.3 / 30.5 / 60.9 / 91.1 s on an idle machine. With process churn it is near-continuous: **13 of 19 windows over the warn line, peak 508 ms, 7 warnings in 95 s.**

## Fix

`portmap._process_info` — one **handle** instead of one system scan per PID. `_native_process_info` reads name, parent and creation stamp through a single `OpenProcess` + `NtQueryInformationProcess` + `GetProcessTimes` + `QueryFullProcessImageNameW`, with `_psutil_process_info` kept behind it as the fallback.

Measured end to end on the shipped code, churn on, 95 s:

| | before | after |
|---|---|---|
| peak `driver_wait` | 508 ms | **16.6 ms** |
| windows over the warn line | 13 of 19 | **0 of 20** |
| driver-queue warnings | 7 | **0** |
| `warm_names()` cold | 344–458 ms | **24 ms** |
| process names resolved | 37/37 | 36/36 |

**Why the handle and not a cached `{pid: ppid}` table**, which measured 0.31 ms/PID and would also have fixed the symptom: the handle **pins the identity**, so all three fields describe the one process the kernel gave us. A cached table has a staleness window in which a recycled PID lets one process's name meet another's parent — the mixture `_looks_recycled` exists to prevent. Speed was not the deciding argument.

It is also *stronger* than what it replaces: `psutil.Process(pid)` binds identity at construction, but `ppid()` → `_raise_if_pid_reused()` never raises for a freshly built object, so there was an unvalidated ~11.5 ms window.

## Stability

- 20 000 calls over live, dead and nonsense PIDs: handles **185 → 185**, RSS flat, 35.6 µs each
- both failure routes leak nothing (5 000 calls with the binding dead, and with the query failing *after* `OpenProcess` succeeded)
- 5 minutes with traffic and continuous churn: handles **231 → 232** (range 225–234), RSS +1.4 MB, worst 20 s window 19.8 ms, **0 warnings**, names resolved 100 % throughout
- degenerate input returns `None` rather than raising: `None`, 0, negative, non-numeric text, past a DWORD, dead PIDs

## Two implementation traps, both caught before merge

1. **`_ALLOW_NATIVE_PROCESSES` was checked while *binding* and cached** — so the flag was read once per process and a test flipping it afterwards got real machine processes inside its fake world. Cache **ability**, never **policy**.
2. **A lock that did not fix the race it was added for.** The lazy bind published an "in progress" marker into a slot the fast path reads *unlocked*, and `False is not None` — so other threads read "unavailable" and returned instead of queueing. Adding the lock left the measurement **identical at 200 of 1600 calls** (5 trials of 5); only a state trace showed why. Nothing is published now until the binding has an answer: **1600 of 1600**.

## Tests

Five new guards in `test_processes.py` (parent vs `os.getppid()` as an independent oracle, both partial-read branches, the per-call policy gate, the cold-bind race), **all verified by mutation** — one had to be rewritten after its first version let a mutant survive, and the cold-bind guard catches a mutant the lock alone does not.

`test_hot_path.py::OS_FUNCTIONS` gained the new route; without it that guard would have kept passing while no longer watching the main resolve path. Its call tally is re-measured.

Full suite green.

## Not verified

- **PID recycling could not be forced** (0 observed in 2149 lookups across 489 PIDs), so that property rests on the mechanism, not a measurement
- 32-bit / WOW64 / ARM64 untested — a mismatched structure fails the query rather than returning nonsense
- `NtQueryInformationProcess` is documented as subject to change; every failure path returns `None` and falls back to psutil, so its withdrawal degrades to today's behaviour and today's cost, not to a broken tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)
