### PR TITLE
docs(readme): explain that a process target resolves to LOCAL ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,20 @@ ports. The port set is kept current during the session from the system's socket 
 opened connections of the process are caught as they open (without real WinDivert it falls back to
 re-scanning the socket table a few times a second).
 
+**What "its local ports" means in practice.** A packet carries addresses and ports, never a program
+name, so the tool cannot match on "Chrome" directly. It looks up which **local** ports the process
+owns and matches every packet on its local port.
+
+This is why `443` never shows up here. When Chrome loads a page, `443` is the **server's** port -
+Chrome's own end of that connection is a temporary port like `15597`, and that number belongs to
+one process at a time, so its traffic is caught exactly.
+
+A few ports work differently. mDNS (5353), SSDP (1900) and DHCP (67/68) are held by several
+programs at once, because that is how programs find devices on your network. There the port number
+no longer says whose traffic it is, so it is all or nothing: either everything on that port is
+impaired or nothing on it is. The log says so when it happens and names which of the two applies.
+Ordinary traffic is not affected.
+
 ### The "IP" field
 
 **IPv4 and IPv6** are supported. A rule never matches an address from the other family - an IPv4

--- a/README.pl.md
+++ b/README.pl.md
@@ -312,6 +312,20 @@ Zbiór portów jest utrzymywany na bieżąco w trakcie sesji ze zdarzeń gniazd 
 otwarte połączenia procesu są łapane od razu (bez realnego WinDivert narzędzie wraca do skanowania
 tabeli gniazd kilka razy na sekundę).
 
+**Co znaczy „jego porty lokalne” w praktyce.** Pakiet niesie adresy i porty, nigdy nazwy programu,
+więc narzędzie nie umie dopasować po „Chrome”. Sprawdza, jakie **porty lokalne** ma ten proces,
+i każdy pakiet dopasowuje po jego porcie lokalnym.
+
+Dlatego nie zobaczysz tu `443`. Gdy Chrome otwiera stronę, `443` należy do **serwera** - własny
+koniec tego połączenia po stronie Chrome'a to port tymczasowy, na przykład `15597`, a taki numer ma
+w danej chwili jeden proces, więc jego ruch jest łapany dokładnie.
+
+Kilka portów działa inaczej. mDNS (5353), SSDP (1900) i DHCP (67/68) trzyma naraz kilka programów,
+bo tak właśnie programy znajdują urządzenia w Twojej sieci. Tam numer portu przestaje mówić, czyj
+to ruch, więc jest wszystko albo nic: albo psuje się wszystko na tym porcie, albo nic na nim. Log
+mówi o tym, gdy to zajdzie, i nazywa, który z dwóch przypadków zachodzi. Zwykłego ruchu to nie
+dotyczy.
+
 ### Pole „IP”
 
 Obsługiwane jest **IPv4 i IPv6**. Reguła nigdy nie dopasowuje adresu z innej rodziny -


### PR DESCRIPTION
## Why

The same gap got hit twice in one session, from opposite directions:

- *"targetowałem tylko proces chrome.exe, nigdzie nie podawałem portu"* - so why a warning about port 5353?
- *"czyli mogę wpisać chrome.exe i na porcie 443 mi będzie go łapać, ale na 5353 może chwycić inny proces?"*

Both come from one missing sentence. The READMEs said only that matching processes *"contribute their local ports"* - true, and it explains nothing.

## What it adds

A packet carries addresses and ports and **never a program name**, so a process target has to be turned into a list of local port numbers before it can be matched at all ([core.py:523](beantester/core.py:523) is literally `local_port not in self.target_ports`). Two consequences follow, and the text spells out both:

**`443` never appears here.** It is the *server's* port. The browser's own end is a temporary port - the example, `15597`, is a real one measured on this machine - and that number belongs to one process at a time, so ordinary traffic is caught exactly.

**A few ports work differently.** mDNS (5353), SSDP (1900) and DHCP (67/68) are held by several programs at once, so the number stops identifying an owner and it is all or nothing for the whole port. The log already says which of the two applies, from #94.

## Scope

Documentation only, both languages, no behaviour change. No changelog entry: the behaviour it describes shipped in #94 and is logged there.

Editorial calls, flagged in case they should be reversed: port `49664` (contested between `svchost` and `lsass`, measured) is left out as a fourth example that adds noise rather than understanding, and the DHCP foot-gun (targeting `svchost` could put port 68 in scope) is left out because it reads as a scare-story next to a scenario nobody runs.

README guards, repo conventions and code hygiene run green locally. Full suite left to CI at the owner's call - this touches no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
