### PR TITLE
test: close the gaps an engineering review of the suite found

### DIFF
--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -431,6 +431,35 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Tests
 
+- **New `tests/test_gui_file_actions.py` - Save file / Load file / Save repro were the three
+  largest uncovered blocks in `gui/app.py`.** The modules behind them are well covered and both
+  write formats frozen by "Kontrakty publiczne"; what had no test is the App side - which values
+  the form hands over, what comes back into the widgets, and what happens when the write fails.
+  Eight tests: the config round-trips through the real on-disk format, a cancelled dialog (an empty
+  path, which is how the user backs out of every one of these) writes nothing and clears nothing,
+  an unwritable path and a broken or wrong-shaped JSON are reported through `dialogs.show_error`
+  with the form left intact, a repro without a session refuses before it even opens the dialog, and
+  a saved report carries the seed plus the CLI line to replay it - into the log, or the report is
+  half useless.
+- **`fakes.wait_until` replaces the fixed waits that raced an assertion.** Ten sites in
+  `test_engine.py`, `test_release_fixes.py` and `test_scenario_runner.py` now poll to a deadline
+  instead of sleeping a guessed interval. The worst was `test_scenario_integration`: it read
+  `core.loss` 0.15 s into a 0.3 s window, so a stall longer than the gap made the "before" read
+  land after the scenario step and the test failed for a reason it was not about. It now reads the
+  first value immediately and polls for the second. The remaining fixed waits are the ones that
+  assert something does NOT happen (the session clock does not move after STOP; a looping scenario
+  is still alive past its duration) - absence cannot be polled for, so they stay, each with a
+  comment saying why. This buys reliability, not speed: the waits removed total ~1.3 s of a ~368 s
+  run.
+- **The flow-table guards live in one place again.** Four tests moved from `test_audit_fixes.py`
+  into `test_core.py`. The table had guards in three files because two of them are named after the
+  EPISODE that produced them rather than the subject they cover, so finding "what protects the flow
+  table" needed knowledge of the project's history. Nothing referenced the four by name, so the
+  move was free. The wider scatter was MEASURED before touching anything and mostly is not scatter:
+  targeting appears in eight files because there are eight distinct mechanisms, and
+  `test_release_fixes.py` / `test_gui_release_fixes.py` are cited by name from six places in the
+  handover note plus the regression-surface table, so renaming them would cost more than the
+  discoverability it buys.
 - **`crashlog.install()` claims every failure path; only one of the three was guarded.**
   Mutation-checked 2026-08-01: gutting the main-thread hook and the Tk-callback hook left 106
   tests green, while the same treatment of the worker hook reddens

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -89,6 +89,17 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Changed
 
+- **Coverage gate raised 80 -> 83** (convention 32). Measured with `COVERAGE_PROCESS_START` on
+  2026-08-01: **87.43%**, up from 83.03% on 2026-07-21. The comment above `fail_under` now also
+  records what the number is NOT: it reports lines as missing that mutation proves are guarded
+  (coverage cannot see inside `threading.excepthook`) and as covered where nothing checks them (a
+  short-circuited `and`, a line executed only while the object is built). It gauges the trend for
+  the package; a behaviour is proved guarded by mutation.
+- **`tooltip._grab_active` docstring corrected.** It said `grab_current` was the fallback "for
+  environments without `.tk` (the test double)". The double answers `call` like the real
+  interpreter now, so tests take the branch production takes; the fallback is for a widget with no
+  `tk` handle at all.
+
 - **What the on-screen numbers COVER is now derived in one place: `gui/scope.py`.** The notes on
   Statistics and Connections answer "what do these figures cover?", but both read a single input -
   the `scope_view_to_target` preference (`stats.py` line 149, `conns.py` line 122). With
@@ -419,6 +430,56 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   reverting them gives "the Live tab is not scrolled" and "the footer is packed at position 5 of 6".
 
 ### Tests
+
+- **`crashlog.install()` claims every failure path; only one of the three was guarded.**
+  Mutation-checked 2026-08-01: gutting the main-thread hook and the Tk-callback hook left 106
+  tests green, while the same treatment of the worker hook reddens
+  `test_crashlog.py::test_a_worker_thread_exception_is_recorded` at once. New:
+  `::test_an_unhandled_main_thread_exception_is_recorded` (also checks the previous
+  `sys.excepthook` still runs - we record, we do not swallow),
+  `::test_a_tk_callback_crash_is_recorded` and
+  `::test_attaching_the_tk_hook_to_a_hostile_root_is_not_a_crash`. Both new guards were confirmed
+  red against their mutants.
+- **New `tests/test_license_surface.py` - `--license` had zero test coverage**, the one finding of
+  the 2026-08-01 review with legal rather than functional weight (convention 35). What was tested
+  is that `LICENSE` and `THIRD-PARTY-NOTICES.md` EXIST in the tree; the code reads them through
+  `resource_path()`, a different resolution, and `legal._read` answers an `OSError` with an empty
+  string. So a frozen build that stopped resolving them would print an empty licence and keep the
+  suite green. Six tests: the texts resolve and are non-empty, every component carries a version
+  and a source URL, the report names all of them plus the no-telemetry line, the flag writes to
+  stdout and exits OK without touching the driver, and `--format json` is one parsable record whose
+  `components[]` matches `legal.COMPONENTS` exactly (the NDJSON schema is a frozen contract).
+- **New `tests/test_wheel_and_scroll.py` - the three user-visible fixes in `gui/scrollable.py`
+  had no guard at all** (44.5% line coverage). The one existing test replaced `_resolve` with a
+  lambda and the one touching `ensure_visible` replaced it with a spy: both good wiring tests, but
+  between them the behaviour never ran. Nine tests covering the master-chain walk (a nested control
+  scrolls the page it sits on), a self-scrolling Treeview keeping its own wheel only while it has
+  something to scroll, a bounded walk, the end-to-end `_on_wheel`, the disarmed combobox class
+  binding, and `ensure_visible` as maths in four cases including "taller than the viewport shows
+  its START". Three mutants planted in `scrollable.py` (broken walk, broken tall-widget branch,
+  removed combobox disarm) were each caught by the matching test.
+- **New `tests/test_tooltip_bubble.py` - the module's whole reason for existing was unguarded**
+  (39.9% coverage; the entire show/hide lifecycle untouched). One reused bubble per toplevel is
+  what stops Windows flashing the taskbar button on every hover, and a rewrite to one `Toplevel`
+  per hover would have passed the suite. Seven tests: the bubble is reused across widgets, a
+  destroyed one is rebuilt, a Tk grab suppresses it (it would cover the dropdown it describes),
+  empty text builds nothing, the Enter/Leave state machine, `retip` re-wording, and the shortcut
+  line.
+- **`SortableTree._clicked` - sorting by clicking a column header - was called by nothing.** Three
+  tests in `test_virtual_tables.py` go through the heading command the way a click does: the same
+  column flips direction, a different column starts from its own `default_reverse` instead of
+  inheriting the previous one, every click reaches `on_sort`, sorting returns the viewport to the
+  top, and `copy_text(header=True)` adds exactly one line while leaving the rows unchanged.
+- **Pure `winenv` helpers in `test_failsafe.py`.** `_quote` builds the parameter string for the
+  elevated re-launch (a mis-quote means the elevated copy starts with the wrong settings, or with
+  extra ones) and `elevation_disabled` reads `BEAN_NO_ELEVATE`, which the whole automated
+  GUI/screenshot workflow depends on. Both pure, both previously at zero coverage. The quoting
+  assertions build their paths with `chr(92)` so the test's own escaping cannot be what they
+  measure.
+- **Both branches of `gui/icon.py::_running_variant`.** The primary branch (copy the idle artwork,
+  stamp the dot) only became reachable once the tkinter double grew a working `tk.call`; before
+  that every GUI test silently exercised the fallback instead. Neither had a guard, so the swap
+  went unnoticed - two tests now pin both.
 
 - **A green GUI test can no longer hide a swallowed fault.** `gui_harness.run_gui` now ends every
   subprocess by reading `crashlog.recent()` back and failing the test on anything not declared via

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -420,6 +420,40 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Tests
 
+- **A green GUI test can no longer hide a swallowed fault.** `gui_harness.run_gui` now ends every
+  subprocess by reading `crashlog.recent()` back and failing the test on anything not declared via
+  the new `run_gui(allow_faults=(...))`. `crashlog.quiet`/`note` exist so a failure stops being
+  invisible to US while staying invisible to the user (convention 30) - but nothing ever read them
+  back, so the swallowing was invisible to us too. The check lives in the subprocess rather than in
+  a test that scans `crashes/`, so the failure carries the name of the test that caused it and it
+  keeps working now that the crash log is redirected per subprocess. Verified in both directions:
+  a planted `crashlog.quiet` fault fails the test, and the same fault named in `allow_faults`
+  passes.
+- **The suite no longer writes the developer's own files into the working tree.** New
+  `tests/user_files.py::redirect_to_temp` sends UI state, profiles and the crash log to a temp
+  directory; `gui_harness` and `smoke_gui.py` both call it, and a session-scoped fixture in
+  `conftest.py` does the same for the in-process tests. The redirect existed only inside the
+  harness, so `smoke_gui.py` - run by `test_gui_smoke.py` and by CI - overwrote the real
+  `bean_network_tester_ui.json` (window geometry, language, sort order, preferences) and left a
+  `crashes/` folder next to the sources on every `pytest tests`. Both are git-ignored, so nothing
+  ever showed it. A full run now leaves the tree untouched.
+- **Three more fidelity gaps in `fake_tk`, all the same class as `winfo_exists`** (production
+  reaching THROUGH an attribute of the double), all found by writing the tests that needed them:
+  - `W.__getattr__` now refuses `_bnt_*` names instead of fabricating a function for them. Those
+    are the app's own marker attributes, and `getattr(w, "_bnt_scroll_owner", None)` asks whether
+    a widget was STAMPED - a no-op function is not `None`, so `WheelDispatcher._resolve` treated
+    every widget as an owning scroll container and resolved the wheel to a function.
+  - `W.yview`/`yview_scroll`/`yview_moveto` are explicit and read a settable `_yview`;
+    `Treeview.yview` no longer hard-codes `(0.0, 1.0)`. A double that always answers "nothing to
+    scroll" cannot express the other variant, so the dispatcher's "does this widget keep its own
+    wheel" branch was unreachable and `_can_scroll` was constant.
+  - `W.bind_class` records into `CLASS_BINDINGS` instead of vanishing, which is the only way to
+    check that `_disarm_combobox_wheel` is still in place.
+- **`fakes.check` sets `__tracebackhide__`**, so a failure points at the calling test instead of at
+  the `assert` inside the helper - the one frame that is never interesting. Its docstring now also
+  says when the third argument matters: 750 of 1564 call sites omit it, and pytest can only rewrite
+  an `assert` it can see, so `check("ports match", a == b)` reports the label and nothing else.
+
 - **Three test doubles had drifted from the interfaces they stand in for, and the suite was
   recording it 809 times per run without anyone reading it.** `crashlog` writes every swallowed
   exception to `crashes/crashes.ndjson` (convention 30), so the drift was fully visible - just

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -420,6 +420,31 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Tests
 
+- **Three test doubles had drifted from the interfaces they stand in for, and the suite was
+  recording it 809 times per run without anyone reading it.** `crashlog` writes every swallowed
+  exception to `crashes/crashes.ndjson` (convention 30), so the drift was fully visible - just
+  never looked at. Measured 2026-08-01 on a full green run; after this change the same run leaves
+  **6** entries, all of them faults the tests inject on purpose.
+  - `fake_tk.W.tk` is now an explicit shared `Interp` with a recording `call()`. It was reaching
+    `W.__getattr__`, which answers any unknown attribute with a function, and a function has no
+    `.call` - so `gui/scaling.py`'s `root.tk.call("tk", "scaling", dpi/72.0)` raised into
+    `crashlog` on every App build (x526) and **Tk font scaling never ran in a single GUI test**.
+    `Interp.call` answers `grab current` from the existing `GRAB` slot, which also puts
+    `tooltip._grab_active` back on its PRIMARY path instead of the `grab_current()` fallback.
+  - `fake_tk.Text` is a real class instead of an alias for bare `W`, modelling the line
+    accounting behind `insert`/`delete`/`index`/`get`. `App._append_log_line` reads
+    `index("end-1c").split(".")` to bound the WIDGET as well as the in-memory list; against the
+    old double `index()` returned `None` and the `.split` raised (x264), so the widget-side trim
+    never executed. Verified after the fix: 900 appends with `log_lines=500` leave 502 lines in
+    the widget.
+  - `warm_names()` added to the three port-table doubles (`test_target_resolver._CountingTable`
+    and both `FakeTable`s in `test_gui_state`), plus the `cheap=` keyword `PortTable.name_of`
+    actually takes. The watchdog calls `warm_names()` every tick; without it those tests ran
+    against a silently degraded engine - the exact mechanism the `warm_names` ADR is about.
+  This is the same class of bug the note already records for `winfo_exists`: production reaching
+  THROUGH an attribute of the double. The generalised rule (any attribute whose RESULT is called
+  must be explicit in the fake) is now in the note beside it.
+
 - **Four new guards in `test_processes.py` for the per-PID handle read**, filling a gap that had
   been open for as long as `ppid` has mattered: it feeds `PortTable.ancestors`, which is how
   `targeting.py` matches a process TREE, and every existing targeting test drives a FAKE table with

--- a/beantester/gui/tooltip.py
+++ b/beantester/gui/tooltip.py
@@ -56,9 +56,12 @@ def _grab_active(widget):
     created by Tcl and is NOT a tkinter-registered widget, so ``grab_current``
     routes it through ``_nametowidget`` and raises on it; the raw ``grab
     current`` call returns the window path as a plain string instead.
-    ``grab_current`` stays as a fallback for environments without ``.tk`` (the
-    test double). A modal dialog also grabs, but those carry no tooltips and the
-    background can't emit hover events under a modal grab, so nothing is lost.
+    ``grab_current`` stays as a fallback for a widget with no ``tk`` handle at
+    all. It is NOT "the path the test double takes" - the double answers ``call``
+    like the real interpreter, so tests exercise the branch above, which is the
+    one production uses. A modal dialog also grabs, but those carry no tooltips
+    and the background can't emit hover events under a modal grab, so nothing is
+    lost.
     """
     tk_obj = getattr(widget, "tk", None)
     if tk_obj is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,20 @@ omit = ["*/__main__.py"]
 # without failing on the small run-to-run variance of the subprocess GUI coverage.
 # Raise it as coverage climbs - never lower it to make a red build go green.
 #
-# Measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, full `pytest tests`):
-#   COVERAGE_PROCESS_START set  -> 83.03%   <- the real number
+# Measured 2026-08-01 (Win11 AMD64, CPython 3.14.6, full `pytest tests`):
+#   COVERAGE_PROCESS_START set  -> 85.86%   <- the real number (was 83.03% on 2026-07-21)
 #   COVERAGE_PROCESS_START unset -> 45%     <- meaningless, see below
 #
 # NOTE: it only means anything with COVERAGE_PROCESS_START set, because the GUI tests
 # run in subprocesses whose coverage is otherwise never collected. Unset, the same
 # suite reports 45%, so ANY sane gate would fail on a codebase that is actually fine.
-fail_under = 80
+#
+# The number is a TREND gauge for the whole package, not a verdict on a module: it
+# reports lines as missing that mutation proves are guarded (coverage cannot see
+# inside threading.excepthook) and as covered where nothing checks them (a short
+# -circuited `and`, a line executed only while building the object). Guarding a
+# behaviour is proved by mutation, never by this percentage.
+fail_under = 83
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/smoke_gui.py
+++ b/smoke_gui.py
@@ -22,6 +22,13 @@ import fake_tk                                    # noqa: E402
 
 tk = fake_tk.install()
 
+# The user's own files (UI state, profiles, crash log) must not be written into
+# the repository by a smoke run. Same helper the pytest GUI harness uses; without
+# it this script overwrote the developer's real bean_network_tester_ui.json and
+# left a crashes/ folder behind on every `pytest tests`.
+import user_files                                 # noqa: E402
+user_files.redirect_to_temp()
+
 import bean_network_tester as n                   # noqa: E402  (after the fakes)
 
 fails = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,24 @@ if ROOT not in sys.path:
 
 import pytest  # noqa: E402
 
-from beantester import i18n  # noqa: E402
+from beantester import crashlog, i18n  # noqa: E402
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _crash_log_outside_the_repo(tmp_path_factory):
+    """No test run may leave a ``crashes/`` folder in the working tree.
+
+    Tests that inject faults on purpose still record them - they just record them
+    somewhere disposable. Without this the suite dropped a real crash log next to
+    the sources on every run: git-ignored, so nothing ever showed it, and
+    indistinguishable at a glance from a crash the developer actually hit.
+
+    ``tests/test_crashlog.py`` points ``app_dir`` at its own per-test directory on
+    top of this; a function-scoped monkeypatch wins over a session fixture, so the
+    two do not fight.
+    """
+    crashlog.app_dir = lambda: str(tmp_path_factory.mktemp("crashlog"))
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -17,6 +17,7 @@ SCREEN = [1920, 1080]     # mutable: tests can pretend to be on a 1366x768 lapto
 DPI = [96.0]
 CLIPBOARD = []            # what the app copied (Ctrl+C, "copy row", repro CLI)
 GRAB = [None]             # what currently holds the Tk grab (an open popdown)
+CLASS_BINDINGS = {}       # (widget class, sequence) -> handler, set by bind_class
 FOCUS = [None]            # the widget holding keyboard focus (ttk paints it)
 
 
@@ -47,6 +48,8 @@ class W:
         self.bindings = {}
         self.states = set()         # ttk widget state flags (active, focus, ...)
         self.alive = True
+        self._yview = (0.0, 1.0)    # everything fits until a test says otherwise
+        self.scrolled = []          # every scroll the widget was asked to do
         master = args[0] if args else kw.get("master")
         self.master = master if isinstance(master, W) else None
         if isinstance(master, W):
@@ -262,6 +265,39 @@ class W:
     def after_cancel(self, _job):
         return None
 
+    def bind_class(self, widget_class, sequence, func=None, add=None):
+        """Class-level binding, RECORDED - it is a behaviour, not a no-op.
+
+        ``gui/scrollable.py`` replaces ttk's own combobox wheel binding with a
+        no-op, because scrolling the page while the pointer crossed a combobox
+        silently changed the selected traffic filter. Against ``__getattr__``
+        that call vanished, so nothing could check the fix was still in place.
+        """
+        CLASS_BINDINGS[(widget_class, sequence)] = func
+        return ""
+
+    @property
+    def class_bindings(self):
+        return CLASS_BINDINGS
+
+    # -- scrolling ---------------------------------------------------------- #
+    # A widget that cannot say how much of it is visible cannot be asked whether
+    # it has anything to scroll: `_can_scroll` unpacks `yview()` into two floats,
+    # and against `__getattr__`'s no-op that raised and was swallowed, so the
+    # wheel dispatcher's "is there a scrollable under the pointer" answer was
+    # always False. Default (0.0, 1.0) = everything fits, like a fresh widget.
+    def yview(self, *args):
+        if args:
+            self.scrolled.append(("yview",) + args)
+            return None
+        return self._yview
+
+    def yview_scroll(self, amount, what="units"):
+        self.scrolled.append(("scroll", amount, what))
+
+    def yview_moveto(self, fraction):
+        self.scrolled.append(("moveto", fraction))
+
     @property
     def _w(self):
         """Tk widget path. Real code passes it straight back into ``tk.call``."""
@@ -281,6 +317,15 @@ class W:
         return INTERP
 
     def __getattr__(self, name):
+        # A MARKER the app stamps on a widget must read as absent when it was
+        # never stamped. `getattr(w, "_bnt_scroll_owner", None)` asks exactly that
+        # question, and a no-op function is not None - so the wheel dispatcher
+        # treated EVERY widget as an owning scroll container and resolved the
+        # wheel to a function. Same trap as `winfo_exists`, one layer over: there
+        # the fabricated value read as "destroyed", here as "present".
+        if name.startswith("_bnt_"):
+            raise AttributeError(name)
+
         def _f(*a, **k):
             return None
         return _f
@@ -528,8 +573,12 @@ class Treeview(W):
     def selection(self):
         return self._sel
 
-    def yview(self):
-        return (0.0, 1.0)
+    # `yview` deliberately NOT overridden: it used to return a hard-coded
+    # (0.0, 1.0), i.e. "there is never anything to scroll". A double that cannot
+    # express the other variant silently voids the test that depends on it - the
+    # wheel dispatcher asks exactly this question to decide whether a table keeps
+    # its own wheel, and with a constant answer that branch was unreachable.
+    # W.yview reads `_yview`, so a test can say how much of the table is visible.
 
 
 class Font:

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -262,10 +262,92 @@ class W:
     def after_cancel(self, _job):
         return None
 
+    @property
+    def _w(self):
+        """Tk widget path. Real code passes it straight back into ``tk.call``."""
+        return self._path()
+
+    @property
+    def tk(self):
+        """The shared interpreter handle - every real widget points at the same one.
+
+        Explicit, and it MUST be, for the reason spelled out above ``winfo_exists``:
+        ``__getattr__`` answers an unknown attribute with a function, and a function
+        has no ``.call``. Production code that reaches THROUGH this attribute
+        (``root.tk.call("tk", "scaling", ...)`` in ``gui/scaling.py``) therefore blew
+        up and had the failure swallowed by ``crashlog`` - so Tk font scaling never
+        ran in a single GUI test, silently, for as long as the fake existed.
+        """
+        return INTERP
+
     def __getattr__(self, name):
         def _f(*a, **k):
             return None
         return _f
+
+
+class Interp:
+    """The Tcl interpreter behind ``widget.tk``: records calls, answers the few
+    that production actually reads back.
+
+    Anything not modelled returns ``""`` - Tcl's empty result - rather than
+    ``None``, because callers treat the result as a string.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def call(self, *args):
+        self.calls.append(tuple(args))
+        if args[:2] == ("grab", "current"):
+            holder = GRAB[0]
+            return holder._path() if isinstance(holder, W) else ("" if holder is None
+                                                                 else str(holder))
+        return ""
+
+    def reset(self):
+        self.calls.clear()
+
+
+INTERP = Interp()
+
+
+class Text(W):
+    """A text widget that keeps line accounting, so trimming can be tested.
+
+    Only what the app asks of it: ``insert``/``delete``/``index``/``get``. It models
+    the LINE COUNT (which is all ``index("end-1c")`` is read for - see
+    ``App._append_log_line``), not full Tk index arithmetic. Before this class the
+    log box was a bare ``W``, ``index()`` came back as ``None`` from ``__getattr__``,
+    and the ``.split(".")`` behind it raised into ``crashlog`` on every logged line:
+    the widget-side trim never ran in any test.
+    """
+
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.lines = [""]           # a fresh Tk Text already holds its final newline
+
+    def insert(self, _where, text):
+        parts = str(text).split("\n")
+        self.lines[-1] += parts[0]
+        self.lines.extend(parts[1:])
+
+    def index(self, _spec="end-1c"):
+        return f"{len(self.lines)}.0"
+
+    def delete(self, start="1.0", end=None):
+        if end in (None, "end"):
+            self.lines = [""]
+            return
+        try:
+            upto = int(str(end).split(".")[0]) - int(str(start).split(".")[0])
+        except (TypeError, ValueError):
+            return
+        if upto > 0:
+            self.lines = self.lines[upto:] or [""]
+
+    def get(self, _start="1.0", _end="end"):
+        return "\n".join(self.lines)
 
 
 class Root(W):
@@ -463,7 +545,7 @@ def install():
     widgets = dict(Tk=Root, Toplevel=Root, Frame=W, Label=W, Canvas=W, PhotoImage=W,
                    StringVar=Var, BooleanVar=Var, IntVar=Var, DoubleVar=Var,
                    Button=W, Entry=W, Checkbutton=W, LabelFrame=W, Scrollbar=W,
-                   Text=W, Listbox=W, Menu=Menu, PanedWindow=Paned,
+                   Text=Text, Listbox=W, Menu=Menu, PanedWindow=Paned,
                    TclError=TclError)
     tk = types.ModuleType("tkinter")
     for name, value in widgets.items():
@@ -480,7 +562,7 @@ def install():
     tk.ttk = ttk
 
     st = types.ModuleType("tkinter.scrolledtext")
-    st.ScrolledText = W
+    st.ScrolledText = Text
     sys.modules["tkinter.scrolledtext"] = st
 
     font = types.ModuleType("tkinter.font")

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,7 +7,18 @@ LANG_DIR = os.path.join(ROOT, "lang")
 
 
 def check(name, cond, detail=""):
-    """Assertion helper keeping the original suite's readable messages."""
+    """Assertion helper keeping the original suite's readable messages.
+
+    ``__tracebackhide__`` keeps the failure pointing at the CALLING test rather
+    than at the ``assert`` inside this helper. Without it pytest's last frame is
+    always this file, which is the one place the failure is never interesting.
+
+    Pass ``detail`` whenever the values are not obvious from the name: pytest can
+    only rewrite an ``assert`` it can see, so ``check("ports match", a == b)``
+    reports the label and nothing else, while a plain ``assert a == b`` would show
+    both sides.
+    """
+    __tracebackhide__ = True
     assert cond, f"{name} {detail}".strip()
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -22,6 +22,26 @@ def check(name, cond, detail=""):
     assert cond, f"{name} {detail}".strip()
 
 
+def wait_until(predicate, timeout=5.0, interval=0.005):
+    """Block until ``predicate()`` is true; returns whether it became true.
+
+    Use this instead of ``time.sleep(0.05)`` before an assertion about worker
+    state. A fixed wait is wrong in both directions: it is a race on a loaded CI
+    box, and on a fast one it is dead time paid by every run. Polling to a
+    deadline returns as soon as the thread has done its work and only spends the
+    full timeout when the test is genuinely about to fail.
+
+    It cannot express "this never happens" - for that, a fixed wait is still the
+    honest tool, so those stay, with a comment saying so.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())
+
+
 class FakeTCP:
     def __init__(self, syn=False, ack=False):
         self.syn = syn

--- a/tests/gui_harness.py
+++ b/tests/gui_harness.py
@@ -13,7 +13,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTS = os.path.join(ROOT, "tests")
 
 PRELUDE = """
-import os, sys, tempfile
+import os, sys
 sys.path.insert(0, {root!r})
 sys.path.insert(0, {tests!r})
 import fake_tk
@@ -21,12 +21,10 @@ fake_tk.SCREEN[:] = [{screen_w}, {screen_h}]
 fake_tk.DPI[0] = {dpi}
 tk = fake_tk.install()
 
-# user files (profiles / ui state) must never be written into the repo by a test
-_tmp = tempfile.mkdtemp()
-import beantester.gui.ui_state as _ui
-import beantester.gui.profiles as _pf
-_ui.UiStateStore.__init__.__defaults__ = (os.path.join(_tmp, "ui.json"),)
-_pf.ProfileStore.__init__.__defaults__ = (os.path.join(_tmp, "profiles.json"),)
+# user files (profiles / ui state / crash log) must never be written into the
+# repo by a test - shared with smoke_gui.py so both stay isolated the same way
+import user_files
+user_files.redirect_to_temp()
 
 import bean_network_tester as bnt
 bnt.set_language({lang!r})
@@ -51,12 +49,44 @@ if os.environ.get("COVERAGE_PROCESS_START"):
 """
 
 
-def run_gui(body, lang="pl", screen=(1920, 1080), dpi=96.0):
-    """Build the App on the fake tkinter and execute ``body``; assert it passes."""
+# Nothing may be swallowed behind a green GUI test.
+#
+# `crashlog.quiet`/`note` exist so a failure stops being invisible to US while
+# staying invisible to the user (convention 30) - but no test ever read them
+# back, so the swallowing was invisible to us too. A full run was recording 809
+# faults: 526 of them one missing attribute on the tkinter double, which meant Tk
+# font scaling never ran in a single GUI test while every one of them passed.
+#
+# The check lives HERE rather than in a test that scans crashes/ because the
+# subprocess is where the fault happens: this way the failure carries the name of
+# the test that caused it, and it keeps working now that the crash log is
+# redirected to a temp dir per subprocess.
+EPILOGUE = """
+_allowed = {allowed!r}
+_faults = [e for e in __import__("beantester.crashlog", fromlist=["x"]).recent(50)
+           if not any(_frag in (e.get("message") or "") or _frag in (e.get("subsystem") or "")
+                      for _frag in _allowed)]
+assert not _faults, (
+    "the GUI swallowed %d unexpected fault(s) - a green test that quietly lost a "
+    "code path is the exact failure crashlog exists to prevent. Either fix the "
+    "cause or, if the test injects it on purpose, name it in run_gui(allow_faults=...):"
+    "\\n" + "\\n".join("  %s: %s (%s) x%s" % (e.get("subsystem"), e.get("type"),
+                                              e.get("message"), e.get("count"))
+                       for e in _faults))
+"""
+
+
+def run_gui(body, lang="pl", screen=(1920, 1080), dpi=96.0, allow_faults=()):
+    """Build the App on the fake tkinter and execute ``body``; assert it passes.
+
+    ``allow_faults`` lists message/subsystem fragments this test injects on
+    purpose; anything else swallowed by ``crashlog`` fails the test (see EPILOGUE).
+    """
     code = COVERAGE_PRELUDE
     code += PRELUDE.format(root=ROOT, tests=TESTS, lang=lang,
                            screen_w=screen[0], screen_h=screen[1], dpi=dpi)
     code += textwrap.dedent(body)
+    code += EPILOGUE.format(allowed=tuple(allow_faults))
     env = dict(os.environ, PYTHONIOENCODING="utf-8", PYTHONUTF8="1")
     proc = subprocess.run([sys.executable, "-c", code], capture_output=True,
                           text=True, encoding="utf-8", errors="replace",

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -1,7 +1,10 @@
 """Regression tests for the stability / validation fixes from the audit.
 
+The flow-table guards this file used to hold now live beside the rest of the
+flow-table tests in ``test_core.py`` - the subject owns them, not the audit that
+happened to find them.
+
 Covered:
-* flow bookkeeping tables stay bounded without RST/NAT (memory-leak fix),
 * destination IP matching is format-insensitive (IPv6 shorthand),
 * ``parse_schedule`` reports every malformed step consistently,
 * ``settings_summary`` never claims an unparsable schedule is active,
@@ -17,111 +20,6 @@ from beantester import (BeanCore, canonical_ip, config_from_args,
                         build_arg_parser, load_config_file, parse_schedule,
                         settings_summary)
 from beantester import i18n
-
-
-def test_flow_tables_bounded_without_rst():
-    """With RST and NAT disabled the flow tables must not grow without bound."""
-    core = BeanCore()                       # rst_prob = 0, nat_timeout = 0
-    rng = random.Random(1)
-    for i in range(12000):                  # 12000 distinct flows
-        core.decide(100, True, 1000 + i, float(i), rng,
-                    remote_ip="8.8.8.8", remote_port=80, is_tcp=True)
-    # the prune is throttled (runs at most every few seconds), so the table
-    # may briefly exceed the threshold by one throttle window of new flows
-    check("flow_last stays bounded", len(core._flow_last) <= 4100,
-          f"(size={len(core._flow_last)})")
-
-
-def test_flow_table_stays_bounded_under_heavy_churn():
-    """Regression, twice over.
-
-    First: the O(n) table rebuild used to run for EVERY packet, then (after the
-    first fix) once every 5 s - but it was still a REBUILD, and at 3.2 million
-    entries that is a 1001 ms freeze of the capture thread. It is now a generation
-    swap: O(1).
-
-    Second: the table was bounded by AGE only, so under churn it had no ceiling at
-    all. It now has one, and a session that opens flows as fast as it can must not
-    push past it.
-    """
-    from beantester.core import MAX_FLOWS
-
-    core = BeanCore()
-    core.reset_buckets(0.0)
-    core.nat_timeout_s = 30.0               # the only thing that makes it track
-    rng = random.Random(1)
-
-    # 500 000 brand-new flows inside ONE simulated second. This is the case that
-    # matters: the size check used to live in _prune(), which is throttled to once
-    # a second, so a whole second of churn could land between two checks. Measured
-    # at 150 000 flows/s the table peaked at 299 999 against a 200 000 ceiling -
-    # and the old version of this test never noticed, because it only ever pushed
-    # 60 000 flows through, which cannot reach the ceiling however it is enforced.
-    now = 1000.0
-    peak = 0
-    for i in range(500_000):
-        now += 0.000002                     # ~2 us apart: 500k flows in ~1 second
-        core.decide(100, True, 1024 + (i % 60000), now, rng,
-                    remote_ip=f"10.{i // 65536 % 256}.{i // 256 % 256}.{i % 256}",
-                    remote_port=443)
-        if i % 5000 == 0:
-            peak = max(peak, len(core._flow_last))
-    peak = max(peak, len(core._flow_last))
-
-    check("the flow table has a ceiling and respects it EVEN inside one second",
-          peak <= MAX_FLOWS, f"(peak={peak:,} vs ceiling {MAX_FLOWS:,})")
-    check("and it is a _FlowTable, not a bare dict that rebuilds itself",
-          not isinstance(core._flow_last, dict))
-
-
-def test_rotation_is_o1_not_a_rebuild():
-    """The whole point: no O(n) work may happen inside decide()'s lock.
-
-    "Swap the dict instead of rebuilding it" was only *most* of the answer. Moving
-    the reference is O(1), but DROPPING the last reference to a 200 000-entry dict
-    is O(n) in CPython's teardown: ~7 ms here, up to 22 ms measured in the engine.
-    That is still a stall in the packet path, in a tool whose entire job is to
-    inject a precise amount of latency. So a retired generation is handed to the
-    watchdog (``drain_retired``) and freed there.
-    """
-    import time
-
-    from beantester.core import _FlowTable
-
-    table = _FlowTable(limit=400_000, rotate_s=1.0)
-    for i in range(200_000):
-        table.set((i, "1.1.1.1", 80), 1.0)
-
-    # the ceiling rotated it on the way in, so a full generation is already retired
-    t0 = time.perf_counter()
-    table.maybe_rotate(10.0)
-    elapsed_ms = (time.perf_counter() - t0) * 1000
-
-    check("retiring a generation is O(1) - nothing is freed on this thread",
-          elapsed_ms < 1.0,
-          f"({elapsed_ms:.2f} ms - a rebuild of this table used to cost ~30 ms, "
-          f"and freeing it inline cost ~7 ms)")
-    check("the new generation starts empty", len(table._new) == 0)
-
-    # and the retired dicts are waiting for whoever is not the capture thread
-    retired = table.drain_retired()
-    check("the retired generations are handed over, not dropped", retired,
-          f"({len(retired)} generation(s))")
-    check("draining twice gives nothing the second time", table.drain_retired() == [])
-
-
-def test_the_size_ceiling_holds_inside_a_single_second():
-    """The ceiling used to be checked only from the throttled prune (once a second),
-    so a whole second of churn could land between two checks."""
-    from beantester.core import _FlowTable
-
-    table = _FlowTable(limit=1000, rotate_s=30.0)
-    peak = 0
-    for i in range(50_000):                 # 50x the ceiling, no time passing at all
-        table.set((i, "1.1.1.1", 80), 1.0)
-        peak = max(peak, len(table))
-    check("the table never passes its ceiling, whatever the clock does",
-          peak <= 1000, f"(peak={peak})")
 
 
 def test_dest_ip_matches_regardless_of_formatting():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1013,3 +1013,116 @@ def test_block_bad_expression_raises():
         core.set_block(True, ip="999.1.1.1")
     with pytest.raises(ValueError):
         core.set_block(True, port="2000-1000")
+
+
+# -- the flow table: one ceiling, guarded in ONE place ----------------------- #
+# Moved here from test_audit_fixes.py (2026-08-01). The flow table had guards in
+# three files because two of them are named after the EPISODE that produced them
+# rather than the subject they cover, so a reader looking for "what protects the
+# flow table" had to know the project's history to find them. Nothing referenced
+# these four by name, so the move costs nothing.
+
+
+def test_flow_tables_bounded_without_rst():
+    """With RST and NAT disabled the flow tables must not grow without bound."""
+    core = BeanCore()                       # rst_prob = 0, nat_timeout = 0
+    rng = random.Random(1)
+    for i in range(12000):                  # 12000 distinct flows
+        core.decide(100, True, 1000 + i, float(i), rng,
+                    remote_ip="8.8.8.8", remote_port=80, is_tcp=True)
+    # the prune is throttled (runs at most every few seconds), so the table
+    # may briefly exceed the threshold by one throttle window of new flows
+    check("flow_last stays bounded", len(core._flow_last) <= 4100,
+          f"(size={len(core._flow_last)})")
+
+
+def test_flow_table_stays_bounded_under_heavy_churn():
+    """Regression, twice over.
+
+    First: the O(n) table rebuild used to run for EVERY packet, then (after the
+    first fix) once every 5 s - but it was still a REBUILD, and at 3.2 million
+    entries that is a 1001 ms freeze of the capture thread. It is now a generation
+    swap: O(1).
+
+    Second: the table was bounded by AGE only, so under churn it had no ceiling at
+    all. It now has one, and a session that opens flows as fast as it can must not
+    push past it.
+    """
+    from beantester.core import MAX_FLOWS
+
+    core = BeanCore()
+    core.reset_buckets(0.0)
+    core.nat_timeout_s = 30.0               # the only thing that makes it track
+    rng = random.Random(1)
+
+    # 500 000 brand-new flows inside ONE simulated second. This is the case that
+    # matters: the size check used to live in _prune(), which is throttled to once
+    # a second, so a whole second of churn could land between two checks. Measured
+    # at 150 000 flows/s the table peaked at 299 999 against a 200 000 ceiling -
+    # and the old version of this test never noticed, because it only ever pushed
+    # 60 000 flows through, which cannot reach the ceiling however it is enforced.
+    now = 1000.0
+    peak = 0
+    for i in range(500_000):
+        now += 0.000002                     # ~2 us apart: 500k flows in ~1 second
+        core.decide(100, True, 1024 + (i % 60000), now, rng,
+                    remote_ip=f"10.{i // 65536 % 256}.{i // 256 % 256}.{i % 256}",
+                    remote_port=443)
+        if i % 5000 == 0:
+            peak = max(peak, len(core._flow_last))
+    peak = max(peak, len(core._flow_last))
+
+    check("the flow table has a ceiling and respects it EVEN inside one second",
+          peak <= MAX_FLOWS, f"(peak={peak:,} vs ceiling {MAX_FLOWS:,})")
+    check("and it is a _FlowTable, not a bare dict that rebuilds itself",
+          not isinstance(core._flow_last, dict))
+
+
+def test_rotation_is_o1_not_a_rebuild():
+    """The whole point: no O(n) work may happen inside decide()'s lock.
+
+    "Swap the dict instead of rebuilding it" was only *most* of the answer. Moving
+    the reference is O(1), but DROPPING the last reference to a 200 000-entry dict
+    is O(n) in CPython's teardown: ~7 ms here, up to 22 ms measured in the engine.
+    That is still a stall in the packet path, in a tool whose entire job is to
+    inject a precise amount of latency. So a retired generation is handed to the
+    watchdog (``drain_retired``) and freed there.
+    """
+    import time
+
+    from beantester.core import _FlowTable
+
+    table = _FlowTable(limit=400_000, rotate_s=1.0)
+    for i in range(200_000):
+        table.set((i, "1.1.1.1", 80), 1.0)
+
+    # the ceiling rotated it on the way in, so a full generation is already retired
+    t0 = time.perf_counter()
+    table.maybe_rotate(10.0)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+
+    check("retiring a generation is O(1) - nothing is freed on this thread",
+          elapsed_ms < 1.0,
+          f"({elapsed_ms:.2f} ms - a rebuild of this table used to cost ~30 ms, "
+          f"and freeing it inline cost ~7 ms)")
+    check("the new generation starts empty", len(table._new) == 0)
+
+    # and the retired dicts are waiting for whoever is not the capture thread
+    retired = table.drain_retired()
+    check("the retired generations are handed over, not dropped", retired,
+          f"({len(retired)} generation(s))")
+    check("draining twice gives nothing the second time", table.drain_retired() == [])
+
+
+def test_the_size_ceiling_holds_inside_a_single_second():
+    """The ceiling used to be checked only from the throttled prune (once a second),
+    so a whole second of churn could land between two checks."""
+    from beantester.core import _FlowTable
+
+    table = _FlowTable(limit=1000, rotate_s=30.0)
+    peak = 0
+    for i in range(50_000):                 # 50x the ceiling, no time passing at all
+        table.set((i, "1.1.1.1", 80), 1.0)
+        peak = max(peak, len(table))
+    check("the table never passes its ceiling, whatever the clock does",
+          peak <= 1000, f"(peak={peak})")

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -18,6 +18,7 @@ This tests all four.
 """
 import json
 import os
+import sys
 import threading
 
 import pytest
@@ -137,6 +138,68 @@ def test_a_worker_thread_exception_is_recorded(isolated):
                    for e in written), written
     finally:
         crashlog.reset()
+
+
+def test_an_unhandled_main_thread_exception_is_recorded(isolated):
+    """``install()`` claims to take over EVERY failure path; only the worker one
+    was guarded. Mutation-checked 2026-08-01: gutting this hook left 106 tests
+    green, so the main thread - where a CLI run and the Tk mainloop both live -
+    could die without leaving a single line behind.
+
+    The previous ``sys.excepthook`` must still run: we record, we do not swallow.
+    """
+    crashlog.install(native=False)
+    chained = []
+    try:
+        previous = sys.excepthook
+        exc = _boom("main thread died")
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+
+        written = _entries(isolated)
+        assert any(e["type"] == "ValueError" and "main thread died" in e["message"]
+                   and e.get("source") == "main-thread" for e in written), written
+
+        # the hook is a wrapper, not a replacement
+        crashlog.reset()
+        sys.excepthook = lambda *a: chained.append(a)
+        crashlog.install(native=False)
+        exc2 = _boom("still chained")
+        sys.excepthook(type(exc2), exc2, exc2.__traceback__)
+        assert chained, "install() must call the excepthook it replaced"
+    finally:
+        sys.excepthook = sys.__excepthook__
+        crashlog.reset()
+
+
+def test_a_tk_callback_crash_is_recorded(isolated):
+    """Widget callbacks are the third failure path, and the one a user actually
+    triggers by clicking. Tk swallows them into its own reporter, so without this
+    hook a crash inside a button handler reached nobody. Mutation-checked with
+    the main-thread hook above: gutting it changed nothing in the suite."""
+    class _Root:
+        report_callback_exception = None
+
+    root = _Root()
+    handler = crashlog.install_tk(root)
+    assert root.report_callback_exception is handler, "the hook must be attached"
+
+    exc = _boom("clicked something fatal")
+    handler(type(exc), exc, exc.__traceback__)
+
+    written = _entries(isolated)
+    assert any(e["type"] == "ValueError" and "clicked something fatal" in e["message"]
+               and e.get("source") == "tk-callback" for e in written), written
+
+
+def test_attaching_the_tk_hook_to_a_hostile_root_is_not_a_crash(isolated):
+    """``install_tk`` runs during startup; a root that refuses the attribute must
+    not take the app down with it."""
+    class _Hostile:
+        def __setattr__(self, name, value):
+            raise RuntimeError("no attributes here")
+
+    handler = crashlog.install_tk(_Hostile())
+    assert callable(handler), "it still hands back a usable handler"
 
 
 def test_install_is_idempotent(isolated):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -16,7 +16,7 @@ from beantester.engine import (DROP_BY_REASON, IMPAIRMENT_DROP_KEYS, TOOL_DROP_K
                                impairment_loss_pct)
 from beantester.settings import DEFAULT_SETTINGS, apply_settings
 from beantester.synthetic import SyntheticDivert
-from fakes import FakeDivert, FakePacket, FakeTCP, check
+from fakes import FakeDivert, FakePacket, FakeTCP, check, wait_until
 
 
 
@@ -126,10 +126,7 @@ def test_connection_log():
     fake = FakeDivert(pkts)
     sh = BeanEngine()
     sh.start("test", divert=fake)
-    deadline = time.time() + 5
-    while time.time() < deadline and sh.stats_snapshot()["seen"] < 3:
-        time.sleep(0.02)
-    time.sleep(0.05)
+    wait_until(lambda: len(sh.connections_snapshot()) == 2)
     conns = sh.connections_snapshot()
     sh.stop()
     check("connection log: 2 flows recorded", len(conns) == 2, f"(={len(conns)})")
@@ -142,10 +139,8 @@ def test_connection_fields():
             FakePacket(size=250, is_outbound=False, port=7100, src_addr="1.1.1.1", syn=True)]
     sh = BeanEngine()
     sh.start("test", divert=FakeDivert(pkts))
-    deadline = time.time() + 5
-    while time.time() < deadline and sh.stats_snapshot()["seen"] < 3:
-        time.sleep(0.02)
-    time.sleep(0.05)
+    wait_until(lambda: len(sh.connections_snapshot()) == 1
+               and sh.stats_snapshot()["seen"] >= 3)
     conns = sh.connections_snapshot()
     sh.stop()
     check("connections: single flow", len(conns) == 1, f"(={len(conns)})")
@@ -194,13 +189,14 @@ def test_effective_seed_always_set():
     sh = BeanEngine()
     sh.set_seed(None)                       # no seed -> the program should pick one itself
     sh.start("test", divert=SyntheticDivert(gen_kbps=3000, seed=1))
-    time.sleep(0.2)
+    wait_until(lambda: sh.effective_seed() is not None)
     eff = sh.effective_seed()
     sh.stop()
     check("effective seed: set even when not provided", isinstance(eff, int) and eff > 0, f"(={eff})")
     sh2 = BeanEngine(); sh2.set_seed(12345)
     sh2.start("test", divert=SyntheticDivert(gen_kbps=3000, seed=1))
-    time.sleep(0.1); e2 = sh2.effective_seed(); sh2.stop()
+    wait_until(lambda: sh2.effective_seed() is not None)
+    e2 = sh2.effective_seed(); sh2.stop()
     check("effective seed: when provided, the same number", e2 == 12345, f"(={e2})")
 
 
@@ -209,7 +205,7 @@ def test_event_log():
     sh.start("test", divert=SyntheticDivert(gen_kbps=3000, seed=1))
     sh.reset_now(2.0)
     sh.log_event("BUG", "test")
-    time.sleep(0.1)
+    wait_until(lambda: any(e[2] == "BUG" for e in sh.events_snapshot()))
     evs = sh.events_snapshot()
     sh.stop()
     kinds = [e[2] for e in evs]
@@ -251,10 +247,7 @@ def test_block_integration():
     sh = BeanEngine()
     sh.set_block(True, "203.0.113.0/24", "443")
     sh.start("test", divert=FakeDivert(pkts))
-    deadline = time.time() + 5
-    while time.time() < deadline and sh.stats_snapshot()["seen"] < 3:
-        time.sleep(0.02)
-    time.sleep(0.05)
+    wait_until(lambda: sh.stats_snapshot()["drop_block"] == 2)
     s = sh.stats_snapshot()
     sh.stop()
     check("block integ.: matching IP and port dropped (2), other passes",
@@ -1400,9 +1393,12 @@ def test_scenario_integration():
     sh = BeanEngine()
     sh.start("test", divert=SyntheticDivert(gen_kbps=2000))
     sh.start_scenario(sc, DEFAULT_SETTINGS, log=lambda *_: None)
-    time.sleep(0.15)
+    # Read the FIRST step's value straight away rather than sleeping 0.15 s into
+    # a 0.3 s window: a stall longer than the gap made the "before" read land
+    # after the step and the test failed for a reason it was not about. The late
+    # value is polled for, so a slow box makes this test slower, never red.
     loss_early = sh.core.loss
-    time.sleep(0.35)
+    wait_until(lambda: sh.core.loss >= 1.0, timeout=5.0)
     loss_late = sh.core.loss
     sh.stop()
     check("scenario: loss=0 at start", loss_early == 0.0, f"(={loss_early})")

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -915,3 +915,74 @@ def test_closing_the_window_always_releases_the_engine():
         assert stopped, "the engine was not stopped when the window closed"
         assert app.running is False
     """)
+
+
+# -- pure winenv helpers: no UAC, no ctypes, no excuse for being untested ----- #
+
+
+def test_the_relaunch_quoting_survives_a_path_with_spaces_and_quotes():
+    """``_quote`` builds the parameter string handed to ``ShellExecuteW`` when the
+    app re-launches itself elevated. It is a pure function and it was untested,
+    while a mis-quoted argument means the elevated copy starts with the WRONG
+    settings - or, with a crafted path, with extra ones.
+    """
+    from beantester import winenv
+
+    check("a plain argument is wrapped", winenv._quote("--simulate") == '"--simulate"')
+
+    # Built from parts so the test's own escaping cannot be what it measures.
+    sep = chr(92)
+    spaced = "C:" + sep + "Program Files" + sep + "bean.py"
+    check("a path with spaces stays ONE argument",
+          winenv._quote(spaced) == '"' + spaced + '"', f"({winenv._quote(spaced)})")
+    check("...and its backslashes are passed through untouched",
+          winenv._quote(spaced).count(sep) == 2, f"({winenv._quote(spaced)})")
+
+    quoted = winenv._quote('a"b')
+    check("an embedded quote is escaped, not left to close the string early",
+          quoted == '"a\\"b"', f"({quoted})")
+    check("the result always opens and closes with a quote",
+          quoted.startswith('"') and quoted.endswith('"'), f"({quoted})")
+    check("a non-string argument does not explode", winenv._quote(7) == '"7"')
+
+
+def test_the_no_elevate_switch_is_read_the_way_the_screenshot_workflow_uses_it():
+    """``BEAN_NO_ELEVATE=1`` is what keeps an automated GUI run from spawning a
+    UAC prompt that nothing can answer. Every value that is not empty and not "0"
+    disables elevation - "0" and "" must NOT."""
+    import os
+
+    from beantester import winenv
+
+    previous = os.environ.get("BEAN_NO_ELEVATE")
+    try:
+        for value, expected in (("1", True), ("yes", True), ("true", True),
+                                (" 1 ", True), ("0", False), ("", False)):
+            os.environ["BEAN_NO_ELEVATE"] = value
+            check(f"BEAN_NO_ELEVATE={value!r} -> {expected}",
+                  winenv.elevation_disabled() is expected,
+                  f"(got {winenv.elevation_disabled()})")
+        os.environ.pop("BEAN_NO_ELEVATE", None)
+        check("unset means elevation is allowed", winenv.elevation_disabled() is False)
+    finally:
+        os.environ.pop("BEAN_NO_ELEVATE", None)
+        if previous is not None:
+            os.environ["BEAN_NO_ELEVATE"] = previous
+
+
+def test_elevation_is_refused_when_the_switch_is_set():
+    """The switch has to reach the decision, not just the reader: an automated run
+    that spawns a "runas" child hangs forever in a non-interactive shell."""
+    import os
+
+    from beantester import winenv
+
+    previous = os.environ.get("BEAN_NO_ELEVATE")
+    os.environ["BEAN_NO_ELEVATE"] = "1"
+    try:
+        check("elevate_self() refuses while BEAN_NO_ELEVATE is set",
+              winenv.elevate_self([]) is False)
+    finally:
+        os.environ.pop("BEAN_NO_ELEVATE", None)
+        if previous is not None:
+            os.environ["BEAN_NO_ELEVATE"] = previous

--- a/tests/test_gui_file_actions.py
+++ b/tests/test_gui_file_actions.py
@@ -1,0 +1,190 @@
+"""Save/Load file and Save repro - the ACTIONS, not just the modules behind them.
+
+``settings.load/save_config_file`` and ``repro.save_repro_report`` are covered as
+modules (``test_settings_config_scenario.py``, ``test_summary_repro_views.py``),
+and both write formats frozen by "Kontrakty publiczne". What had no test is the
+App side: which values the form hands over, what comes back into the widgets, and
+what happens when the write fails. Measured 2026-08-01: ``save_repro`` (12 lines),
+``load_config_file`` (10) and ``save_config_file`` (8) were the three largest
+uncovered blocks in ``gui/app.py``.
+
+The file dialogs are replaced per test, which is also the point - a cancelled
+dialog returning "" must do nothing at all, and that branch is how the user backs
+out of every one of these.
+"""
+import json
+import os
+
+from gui_harness import run_gui
+
+
+def test_saving_a_config_writes_what_the_form_currently_holds():
+    run_gui("""
+        import json, os, tempfile
+        from tkinter import filedialog
+
+        target = os.path.join(tempfile.mkdtemp(), "cfg.json")
+        filedialog.asksaveasfilename = lambda **k: target
+
+        app.vars["loss"].set("13")
+        app.vars["latency"].set("240")
+        app.save_config_file()
+
+        assert os.path.exists(target), "the config was not written"
+        saved = json.load(open(target, encoding="utf-8"))
+        assert float(saved["loss"]) == 13.0, saved
+        assert float(saved["latency"]) == 240.0, saved
+        assert any("cfg.json" in line for line in app._log_lines), app._log_lines[-3:]
+    """)
+
+
+def test_loading_a_config_puts_it_back_into_the_widgets():
+    """Round trip through the real on-disk format, not through a dict."""
+    run_gui("""
+        import json, os, tempfile
+        from tkinter import filedialog
+
+        target = os.path.join(tempfile.mkdtemp(), "cfg.json")
+        filedialog.asksaveasfilename = lambda **k: target
+        filedialog.askopenfilename = lambda **k: target
+
+        app.vars["loss"].set("21")
+        app.vars["latency"].set("310")
+        app.save_config_file()
+
+        app.vars["loss"].set("0")
+        app.vars["latency"].set("0")
+        app.load_config_file()
+
+        assert float(app.vars["loss"].get()) == 21.0, app.vars["loss"].get()
+        assert float(app.vars["latency"].get()) == 310.0, app.vars["latency"].get()
+    """)
+
+
+def test_cancelling_the_dialog_writes_nothing_and_changes_nothing():
+    """An empty path is how the user backs out; it must not reach the writer."""
+    run_gui("""
+        from tkinter import filedialog
+
+        filedialog.asksaveasfilename = lambda **k: ""
+        filedialog.askopenfilename = lambda **k: ""
+
+        app.vars["loss"].set("7")
+        before = len(app._log_lines)
+
+        app.save_config_file()
+        app.load_config_file()
+
+        assert float(app.vars["loss"].get()) == 7.0, "a cancelled load must not clear the form"
+        assert len(app._log_lines) == before, app._log_lines[before:]
+    """)
+
+
+def test_an_unwritable_path_reports_the_error_instead_of_crashing():
+    """The handler is what stands between a bad path and a traceback in the UI.
+
+    The app uses its own dark modal (``gui/dialogs.show_error``), not
+    ``tkinter.messagebox`` - the native one is un-themable and takes its button
+    labels from the OS locale - so that is what the spy replaces.
+    """
+    run_gui("""
+        from tkinter import filedialog
+        import beantester.gui.dialogs as dialogs
+
+        shown = []
+        dialogs.show_error = lambda parent, title, message: shown.append(message)
+
+        # a directory that does not exist - the write must fail, not the app
+        filedialog.asksaveasfilename = lambda **k: "Z:/nope/does/not/exist/cfg.json"
+        app.save_config_file()
+
+        assert shown, "a failed save must tell the user"
+        assert "cfg.json" not in " ".join(app._log_lines[-2:]), (
+            "and it must NOT claim the file was saved: " + str(app._log_lines[-2:]))
+    """)
+
+
+def test_loading_a_file_that_is_not_a_config_is_refused_readably():
+    """Broken JSON raises out of ``settings.load_config_file``; the form must be
+    left alone rather than half-filled from a partial read."""
+    run_gui("""
+        import os, tempfile
+        from tkinter import filedialog
+        import beantester.gui.dialogs as dialogs
+
+        shown = []
+        dialogs.show_error = lambda parent, title, message: shown.append(message)
+
+        junk = os.path.join(tempfile.mkdtemp(), "junk.json")
+        open(junk, "w", encoding="utf-8").write("this is not json at all {{{")
+        filedialog.askopenfilename = lambda **k: junk
+
+        app.vars["loss"].set("33")
+        app.load_config_file()
+
+        assert shown, "a broken file must be reported, not swallowed"
+        assert float(app.vars["loss"].get()) == 33.0, "the form must survive a bad load"
+    """)
+
+
+def test_a_config_of_the_wrong_shape_is_refused_too():
+    """Valid JSON, wrong type. A settings file that is an ARRAY is what anything
+    writing one entry per line produces, so it is not an exotic input."""
+    run_gui("""
+        import os, tempfile
+        from tkinter import filedialog
+        import beantester.gui.dialogs as dialogs
+
+        shown = []
+        dialogs.show_error = lambda parent, title, message: shown.append(message)
+
+        wrong = os.path.join(tempfile.mkdtemp(), "list.json")
+        open(wrong, "w", encoding="utf-8").write('[{"loss": 5}]')
+        filedialog.askopenfilename = lambda **k: wrong
+
+        app.load_config_file()
+        assert shown, "a JSON array is not a config and must be refused"
+    """)
+
+
+def test_a_repro_report_needs_a_session_before_it_can_be_saved():
+    """Without a seed there is nothing to reproduce, so the app says so rather
+    than writing a report that cannot be replayed."""
+    run_gui("""
+        from tkinter import filedialog
+
+        called = []
+        filedialog.asksaveasfilename = lambda **k: called.append(1) or ""
+
+        assert app.engine.effective_seed() is None, "this test needs a stopped engine"
+        app.save_repro()
+        assert not called, "it must not even open the dialog without a session"
+        assert app._log_lines, "and it must say why"
+    """)
+
+
+def test_saving_a_repro_writes_the_report_and_logs_the_command_to_replay_it():
+    """The report is a frozen on-disk format AND the CLI line the user pastes
+    back; the log has to carry that line or the report is half useless."""
+    run_gui("""
+        import json, os, tempfile
+        from tkinter import filedialog
+        from beantester.synthetic import SyntheticDivert
+
+        target = os.path.join(tempfile.mkdtemp(), "repro.json")
+        filedialog.asksaveasfilename = lambda **k: target
+
+        app.engine.set_seed(4242)
+        app.engine.start("test", divert=SyntheticDivert(gen_kbps=500, seed=3))
+        try:
+            app.save_repro()
+        finally:
+            app.engine.stop()
+
+        assert os.path.exists(target), "no report was written"
+        report = json.load(open(target, encoding="utf-8"))
+        assert report["seed"] == 4242, report
+        assert report.get("cli_command"), report
+        assert any(report["cli_command"] in line for line in app._log_lines), (
+            "the replay command must reach the log: " + str(app._log_lines[-3:]))
+    """)

--- a/tests/test_gui_helpers.py
+++ b/tests/test_gui_helpers.py
@@ -171,3 +171,45 @@ def test_average_kbps_is_total_bytes_over_elapsed():
     check("avg-rate: too little elapsed time reads 0, not a spike",
           average_kbps(500_000, 0.3) == 0.0)
     check("avg-rate: no traffic is 0", average_kbps(0, 10.0) == 0.0)
+
+
+# -- the running-state icon: BOTH branches ----------------------------------- #
+def test_the_running_icon_copies_the_idle_artwork_and_stamps_a_dot():
+    """The primary branch: keep a user-supplied ``bean.png``'s artwork and stamp
+    the running dot on a COPY of it.
+
+    This branch was unreachable in tests until the tkinter double grew a working
+    ``tk.call`` (2026-08-01) - the copy raised, the exception went to crashlog and
+    every GUI test silently exercised the fallback below instead. Neither branch
+    had a guard, so the swap went unnoticed; this pins both.
+    """
+    from gui_harness import run_gui
+    run_gui("""
+        import fake_tk
+        from beantester.gui import icon
+
+        idle = icon.make_bean_icon(64)
+        fake_tk.INTERP.calls.clear()
+        running = icon._running_variant(idle, 64)
+
+        assert running is not None and running is not idle, "it must be a COPY"
+        copies = [c for c in fake_tk.INTERP.calls if len(c) > 1 and c[1] == "copy"]
+        assert copies, "the idle artwork must be copied, not redrawn: " + str(
+            fake_tk.INTERP.calls)
+    """)
+
+
+def test_the_running_icon_falls_back_to_drawing_when_the_copy_is_impossible():
+    """A user-supplied PNG that Tk cannot copy must still produce a running icon,
+    not an exception on the way to the taskbar."""
+    from gui_harness import run_gui
+    run_gui("""
+        from beantester.gui import icon
+
+        class Hostile:
+            def width(self): raise RuntimeError("no size for you")
+            def height(self): return 64
+
+        drawn = icon._running_variant(Hostile(), 64)
+        assert drawn is not None, "the fallback must still hand back an icon"
+    """, allow_faults=("no size for you",))

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -349,8 +349,9 @@ def test_a_gui_session_keeps_the_target_banner_honest():
                 self.info = {200: ("realapp.exe", 1)}
             def refresh(self, now=None, force=False): return True
             def snapshot(self): return dict(self.ports)
-            def name_of(self, pid): return self.info.get(pid, ("", None))[0]
+            def name_of(self, pid, cheap=False): return self.info.get(pid, ("", None))[0]
             def ancestors(self, pid, depth=8): return []
+            def warm_names(self): return None
             def refresh_if_stale(self, now=None, miss=False): return True
             def process_for_port(self, port, now=None, allow_refresh=True): return ""
             def pid_for(self, port): return self.ports.get(port)
@@ -450,6 +451,7 @@ def test_a_target_that_dies_mid_session_raises_the_banner_without_being_retyped(
             def snapshot(self): return dict(self.ports)
             def name_of(self, pid, cheap=False): return self.info.get(pid, ("", None))[0]
             def ancestors(self, pid, depth=8): return []
+            def warm_names(self): return None
             def refresh_if_stale(self, now=None, miss=False): return True
             def process_for_port(self, port, now=None, allow_refresh=True): return ""
             def pid_for(self, port): return self.ports.get(port)

--- a/tests/test_license_surface.py
+++ b/tests/test_license_surface.py
@@ -1,0 +1,108 @@
+"""The licensing surface: ``--license``, and the texts it must actually find.
+
+Why this file exists (measured 2026-08-01): ``legal.cli_report``, ``license_text``
+and ``notices_text`` were called by NO test. What was tested is that ``LICENSE``
+and ``THIRD-PARTY-NOTICES.md`` EXIST in the tree (``os.path.exists`` from the repo
+root) - but the code reads them through ``resource_path()``, which is a different
+resolution, and ``legal._read`` answers an ``OSError`` with an empty string.
+
+So the failure mode was: the files ship, the paths stop resolving (a frozen build,
+a renamed constant), ``--license`` prints an empty licence, and the whole suite
+stays green. That is an LGPL obligation towards the holder of the BINARY failing
+silently - convention 35 calls that a blocker, not a formality.
+
+``--doctor`` had a runtime test; ``--license``, the flag with legal weight, did not.
+"""
+import io
+import json
+
+from beantester import appinfo, exitcodes, legal
+from beantester.cli import run_cli
+from fakes import check
+
+
+def cli(argv):
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(argv, out=out, err=err)
+    return code, out.getvalue(), err.getvalue()
+
+
+# -- the texts resolve at run time, not just on disk ------------------------- #
+
+
+def test_the_licence_and_notices_resolve_through_resource_path():
+    """``_read`` swallows an OSError into "", so an unresolvable path is silent."""
+    licence = legal.license_text()
+    notices = legal.notices_text()
+    check("LICENSE is readable through resource_path (not an empty fallback)",
+          len(licence) > 1000, f"({len(licence)} chars)")
+    check("LICENSE really is the GPL text the project claims",
+          "GNU GENERAL PUBLIC LICENSE" in licence)
+    check("THIRD-PARTY-NOTICES is readable through resource_path",
+          len(notices) > 200, f"({len(notices)} chars)")
+
+
+def test_every_shipped_component_is_named_with_a_version_and_a_source():
+    """The obligation is not "a licence exists" - it is naming the exact version
+    the user was given, so they can fetch that source and replace it."""
+    rows = legal.component_rows()
+    names = [name for name, *_ in rows]
+    for required in ("WinDivert", "PyDivert", "psutil", "Python"):
+        check(f"{required} is declared", required in names, f"({names})")
+    for name, version, licence, url in rows:
+        check(f"{name} carries a version", bool(str(version).strip()))
+        check(f"{name} carries a licence", bool(str(licence).strip()))
+        check(f"{name} carries a source URL", str(url).startswith("http"), f"({url})")
+
+
+def test_the_report_carries_the_licence_the_components_and_the_no_telemetry_line():
+    report = legal.cli_report()
+    check("report opens with the licence itself",
+          "GNU GENERAL PUBLIC LICENSE" in report)
+    for name, version, _lic, url in legal.component_rows():
+        check(f"report names {name}", name in report)
+        check(f"report names the source of {name}", url in report)
+    check("report states there is no telemetry (convention 36)",
+          "Telemetry: none" in report, f"({report[-200:]!r})")
+
+
+# -- the flag ---------------------------------------------------------------- #
+
+
+def test_license_flag_prints_the_report_to_stdout_and_exits_ok():
+    code, out, err = cli(["--license"])
+    check("--license exits OK", code == exitcodes.OK, f"(code={code})")
+    check("the report goes to STDOUT (it is data, not log)",
+          "GNU GENERAL PUBLIC LICENSE" in out, f"({out[:120]!r})")
+    check("nothing of it leaks into stderr", "GENERAL PUBLIC" not in err)
+
+
+def test_license_flag_never_touches_the_driver():
+    """A licence audit must work on a machine with no WinDivert and no admin."""
+    code, out, _ = cli(["--license"])
+    check("--license succeeds without a driver", code == exitcodes.OK)
+    check("and without opening a session", "packets" not in out.lower())
+
+
+def test_license_as_json_is_one_parsable_record_with_every_component():
+    """A corporate licence audit is a script more often than a person, so the
+    machine-readable shape is part of the NDJSON contract, not a nicety."""
+    code, out, _ = cli(["--license", "--format", "json"])
+    check("--license --format json exits OK", code == exitcodes.OK, f"(code={code})")
+    lines = [l for l in out.splitlines() if l.strip()]
+    check("exactly one NDJSON record", len(lines) == 1, f"({len(lines)} lines)")
+
+    record = json.loads(lines[0])
+    check("the record names itself", record.get("event") == "license", f"({record.get('event')})")
+    check("it carries the project licence",
+          record.get("license") == appinfo.LICENSE_NAME, f"({record.get('license')})")
+    check("it states no telemetry", record.get("telemetry") is False)
+
+    shipped = {c["name"] for c in record.get("components", [])}
+    expected = {name for name, *_ in legal.COMPONENTS}
+    check("every component in the registry reaches the JSON", shipped == expected,
+          f"(missing={sorted(expected - shipped)}, extra={sorted(shipped - expected)})")
+    for component in record["components"]:
+        check(f"{component['name']} carries source + licence in JSON",
+              component.get("source", "").startswith("http")
+              and bool(component.get("license")), f"({component})")

--- a/tests/test_release_fixes.py
+++ b/tests/test_release_fixes.py
@@ -16,7 +16,7 @@ from beantester.engine import BeanEngine
 from beantester.scenario import load_scenario_file, parse_scenario
 from beantester.summary import settings_summary
 from beantester.targeting import ProcessTargeting
-from fakes import FakeDivert, FakePacket, check
+from fakes import FakeDivert, FakePacket, check, wait_until
 
 
 # -- the preview strip used to round fractions away --------------------------- #
@@ -42,9 +42,11 @@ def test_summary_does_not_advertise_limits_a_schedule_replaces():
 def test_the_session_clock_freezes_on_stop():
     engine = BeanEngine()
     engine.start("test", divert=FakeDivert([]))
-    time.sleep(0.05)
+    wait_until(lambda: engine.session_info()["elapsed"] > 0)
     engine.stop()
     first = engine.session_info()
+    # A fixed wait, deliberately: this asserts the clock does NOT move, and there
+    # is no condition to poll for the absence of a change.
     time.sleep(0.15)
     second = engine.session_info()
     check("elapsed stops growing after STOP", first["elapsed"] == second["elapsed"],
@@ -58,7 +60,7 @@ def test_a_link_outage_is_not_counted_as_loss():
     engine = BeanEngine()
     engine.core.set_flap(True, 10.0, 100.0)      # the link is down all the time
     engine.start("test", divert=FakeDivert([FakePacket(size=100) for _ in range(5)]))
-    time.sleep(0.2)
+    wait_until(lambda: engine.stats_snapshot()["drop_flap"] == 5)
     engine.stop()
     st = engine.stats_snapshot()
     check("outage drops have their own counter", st["drop_flap"] == 5, f"({st})")

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -16,7 +16,7 @@ import pytest
 
 from beantester import scenario_runner
 from beantester.scenario_runner import ScenarioRunner
-from fakes import check
+from fakes import check, wait_until
 
 
 class FakeEngine:
@@ -132,6 +132,8 @@ def test_a_looping_scenario_keeps_running_past_its_duration(spy_apply):
     runner = ScenarioRunner(engine)
     runner.start(FakeScenario(loop=True, duration=0.2), base_settings={})
     try:
+        # A fixed wait, deliberately: the assertion is that the loop is STILL
+        # running past its duration, and absence of an ending cannot be polled.
         time.sleep(0.45)            # well past the 0.2s duration
         check("a looping scenario is still running after its duration elapses",
               runner._thread.is_alive())
@@ -145,7 +147,7 @@ def test_the_runner_stops_when_the_engine_stops(spy_apply):
     engine = FakeEngine()
     runner = ScenarioRunner(engine)
     runner.start(FakeScenario(loop=True, duration=5.0), base_settings={})
-    time.sleep(0.15)
+    wait_until(lambda: bool(spy_apply))       # the runner has applied its first step
     engine.running = False          # engine went down; the runner must notice
     _join(runner)
     check("the runner exits once the engine is no longer running",

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -40,11 +40,16 @@ class _CountingTable:
     def snapshot(self):
         return dict(self.ports)
 
-    def name_of(self, pid):
+    def name_of(self, pid, cheap=False):
         return self._info.get(pid, ("", None))[0]
 
     def ancestors(self, pid, depth=8):
         return []
+
+    def warm_names(self):
+        """The watchdog calls this every tick; a double without it degrades the
+        engine silently (the exception is swallowed into crashlog)."""
+        return None
 
     # the engine's side of the PortTable surface (see _process_for / _pid_for)
     def refresh_if_stale(self, now=None, miss=False):

--- a/tests/test_tooltip_bubble.py
+++ b/tests/test_tooltip_bubble.py
@@ -1,0 +1,136 @@
+"""The tooltip bubble: ONE reused window, and it keeps out of the way.
+
+``gui/tooltip.py`` exists for a single reason, stated in its own docstring:
+Windows flashes an application's taskbar button whenever a new top-level window
+appears while the app is not in the foreground, so a fresh ``Toplevel`` per hover
+made an idle, STOPPED app light up its own icon at the user for no reason. The
+module's answer is one hidden bubble per toplevel, shown and moved and hidden
+again.
+
+Nothing guarded that (measured 2026-08-01: 39.9% line coverage, the whole
+show/hide lifecycle untouched). Rewriting ``_bubble_for`` to build a Toplevel per
+hover would have brought the taskbar flashing back with the suite fully green.
+"""
+from gui_harness import run_gui
+
+
+def test_one_bubble_is_reused_for_every_widget_in_a_window():
+    """The reason the module exists. A second Toplevel per hover is the bug."""
+    run_gui("""
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        tooltip._BUBBLES.clear()
+        first, second = ttk.Label(root, text="a"), ttk.Label(root, text="b")
+
+        w1 = tooltip._show_bubble(first, "explanation one", 10, 10, 20)
+        w2 = tooltip._show_bubble(second, "explanation two", 40, 60, 20)
+        assert w1 is not None and w2 is not None, (w1, w2)
+        assert w1 is w2, "a second hover must reuse the bubble, not build one"
+        assert len(tooltip._BUBBLES) == 1, tooltip._BUBBLES
+    """)
+
+
+def test_a_bubble_whose_window_died_is_rebuilt_not_reused():
+    """The cache is keyed by toplevel; a stale entry must not be handed out."""
+    run_gui("""
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        tooltip._BUBBLES.clear()
+        label = ttk.Label(root, text="a")
+        window, _ = tooltip._bubble_for(label)
+        window.destroy()
+
+        again, _ = tooltip._bubble_for(label)
+        assert again is not window, "a destroyed bubble must be replaced"
+        assert again.winfo_exists(), "and the replacement must be alive"
+    """)
+
+
+def test_no_bubble_is_shown_while_a_dropdown_holds_the_grab():
+    """The bubble would cover the very list the user just opened - its popdown
+    sits directly under the field the tooltip describes."""
+    run_gui("""
+        import fake_tk
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        tooltip._BUBBLES.clear()
+        label = ttk.Label(root, text="a")
+
+        fake_tk.GRAB[0] = root                      # a popdown is open
+        assert tooltip._show_bubble(label, "text", 10, 10) is None
+        assert tooltip.make_bubble(label, "text", 10, 10) is None
+
+        fake_tk.GRAB[0] = None
+        assert tooltip._show_bubble(label, "text", 10, 10) is not None
+    """)
+
+
+def test_an_empty_tooltip_shows_nothing_at_all():
+    run_gui("""
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        tooltip._BUBBLES.clear()
+        label = ttk.Label(root, text="a")
+        assert tooltip._show_bubble(label, "", 10, 10) is None
+        assert not tooltip._BUBBLES, "an empty text must not even build the window"
+    """)
+
+
+def test_hovering_shows_the_bubble_and_leaving_hides_it():
+    """The Tooltip state machine: schedule on Enter, show, hide on Leave. The
+    fake fires `after` callbacks only when asked, so `_show` is called directly."""
+    run_gui("""
+        import fake_tk
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        tooltip._BUBBLES.clear()
+        fake_tk.GRAB[0] = None
+        label = ttk.Label(root, text="a")
+        tip = tooltip.Tooltip(label, "the explanation")
+
+        assert tip.shown is False
+        tip._show()
+        assert tip.shown is True, "hovering long enough must show the bubble"
+
+        tip._hide()
+        assert tip.shown is False, "leaving must hide it again"
+    """)
+
+
+def test_a_retipped_label_shows_the_new_wording_not_the_old_one():
+    """Toggling "show only the targeted traffic" re-words the scope note; the
+    bubble under it is the LONGER version of that same sentence, so a stale
+    tooltip contradicts the line it is attached to."""
+    run_gui("""
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        label = ttk.Label(root, text="a")
+        tooltip.add_tooltip(label, "app.tabs.connections")
+        before = label._bnt_tooltip.text
+
+        tooltip.retip(label, "app.tabs.statistics")
+        after = label._bnt_tooltip.text
+        assert after != before, (before, after)
+        assert label._bnt_tooltip is not None
+
+        # retip on a label that never had one attaches instead of failing
+        plain = ttk.Label(root, text="b")
+        tooltip.retip(plain, "app.tabs.control")
+        assert getattr(plain, "_bnt_tooltip", None) is not None
+    """)
+
+
+def test_a_shortcut_is_advertised_on_its_own_line():
+    run_gui("""
+        from beantester.gui import tooltip
+        text = tooltip.tooltip_text("app.tabs.control", shortcut="F5")
+        assert text.endswith("\\n[F5]"), repr(text)
+        assert tooltip.tooltip_text("", shortcut="F5") == "[F5]"
+        assert tooltip.tooltip_text("") == ""
+    """)

--- a/tests/test_virtual_tables.py
+++ b/tests/test_virtual_tables.py
@@ -198,3 +198,79 @@ def test_event_table_is_virtualised_too():
         assert len(table.tree.get_children()) == table.window()
         assert len(table.tree.get_children()) < 100, "event table is not virtualised"
     """)
+
+
+def test_clicking_a_column_header_sorts_by_it_and_clicking_again_reverses():
+    """The table's primary interaction, and it had ZERO test coverage (measured
+    2026-08-01: `_clicked` was never called by anything in the suite).
+
+    The header command is what `refresh_headers` installs on every column, so the
+    test goes through the heading exactly the way a click does, rather than
+    calling the private method directly.
+    """
+    run_gui("""
+        table = app.pages["connections"].table
+        columns = list(table.columns)
+        first, second = columns[0], columns[1]
+        seen = []
+        table.on_sort = lambda state: seen.append(dict(state))
+
+        def click(col):
+            table.refresh_headers()
+            table.tree.headings[col]["command"]()
+
+        click(first)
+        assert table.sort["col"] == first, table.sort
+        assert seen and seen[-1]["col"] == first, seen
+
+        # the SAME column flips direction
+        was = table.sort["reverse"]
+        click(first)
+        assert table.sort["col"] == first and table.sort["reverse"] is not was, table.sort
+
+        # a DIFFERENT column starts from that column's default direction, it does
+        # not inherit the direction the previous one happened to be left in
+        table.sort["reverse"] = True
+        default = table.sort.get("default_reverse", False)
+        click(second)
+        assert table.sort["col"] == second, table.sort
+        assert table.sort["reverse"] == default, table.sort
+
+        assert len(seen) == 3, "every click must reach the on_sort callback"
+    """)
+
+
+def test_sorting_returns_the_viewport_to_the_top():
+    """A new order means the rows under the pointer are different anyway, and the
+    top is what the user looks at after sorting."""
+    run_gui("""
+        table = app.pages["connections"].table
+        table.sync([(str(i), ("p%d" % i, "TCP", "1.2.3.4", "443", "5000",
+                              "7", "0.5", "1.0", "0.1")) for i in range(400)])
+        table.set_offset(120)
+        assert table.offset > 0, table.offset
+
+        table.refresh_headers()
+        table.tree.headings[list(table.columns)[0]]["command"]()
+        assert table.offset == 0, "sorting must scroll back to the top"
+    """)
+
+
+def test_copying_with_headers_puts_the_column_names_on_the_first_line():
+    run_gui("""
+        table = app.pages["connections"].table
+        table.sync([("a", ("chrome.exe", "TCP", "1.2.3.4", "443", "5000",
+                           "7", "0.5", "1.0", "0.1"))])
+        table.select_keys(["a"])
+
+        plain = table.copy_text()
+        with_head = table.copy_text(header=True)
+        assert len(with_head.splitlines()) == len(plain.splitlines()) + 1, (
+            plain, with_head)
+        assert with_head.splitlines()[1] == plain, "the rows must be unchanged"
+        assert "chrome.exe" in with_head
+
+        # nothing selected copies nothing at all, rather than a lone header row
+        table.select_keys([])
+        assert table.copy_text() == "" and table.copy_text(header=True) == ""
+    """)

--- a/tests/test_wheel_and_scroll.py
+++ b/tests/test_wheel_and_scroll.py
@@ -1,0 +1,182 @@
+"""The wheel dispatcher and the scrollable container - the behaviour, not the wiring.
+
+``gui/scrollable.py`` carries three fixes for bugs a user hit, each written up in
+its docstring, and the suite guarded NONE of them (measured 2026-08-01, 44.5%
+line coverage):
+
+* the wheel used to work only over the bare pixels between panels, because the
+  old code tore its binding down on ``<Leave>``. The fix is ``_resolve``: hit-test
+  by pointer and walk UP the master chain to whatever owns that spot.
+* scrolling the page while the pointer passed over a combobox silently changed
+  the selected traffic filter or profile. The fix is ``_disarm_combobox_wheel``.
+* expanding a section pinned to the bottom edge revealed its content BELOW the
+  viewport. The fix is ``ensure_visible``.
+
+The one test that touched any of this replaced ``_resolve`` with a lambda, and
+the one that touched ``ensure_visible`` replaced it with a spy - both legitimate
+wiring tests, but between them the behaviour above never executed. See the note's
+rule about a test that stubs the very function the fault was in.
+"""
+from gui_harness import run_gui
+
+
+# -- _resolve: what is under the pointer ------------------------------------- #
+
+
+def test_the_wheel_finds_the_scrollable_that_owns_the_spot_under_the_pointer():
+    """The whole point of the rewrite: a control deep inside the page still
+    scrolls the PAGE, because _resolve walks up to the owning ScrollableFrame."""
+    run_gui("""
+        from tkinter import ttk
+        scroll = app.pages["control"].scroll
+
+        # the container itself, and anything nested inside it
+        kind, target = app._wheel._resolve(scroll.body)
+        assert (kind, target) == ("canvas", scroll), (kind, target)
+
+        deep = ttk.Entry(ttk.Frame(ttk.Frame(scroll.body)))
+        kind, target = app._wheel._resolve(deep)
+        assert (kind, target) == ("canvas", scroll), (kind, target)
+        assert target is scroll, "a nested control must scroll the page it sits on"
+    """)
+
+
+def test_a_widget_that_scrolls_itself_keeps_its_own_wheel():
+    """A Treeview with more rows than fit is 'native': the dispatcher must hand
+    the wheel to it, not scroll the page out from under it."""
+    run_gui("""
+        table = app.pages["connections"].table
+        table.tree._yview = (0.0, 0.4)          # 60% of the rows are off-screen
+        kind, target = app._wheel._resolve(table.tree)
+        assert kind == "native" and target is table.tree, (kind, target)
+
+        # ...but only while it actually has something to scroll
+        table.tree._yview = (0.0, 1.0)
+        kind, _ = app._wheel._resolve(table.tree)
+        assert kind != "native", "a fully visible table must not swallow the wheel"
+    """)
+
+
+def test_the_wheel_over_nothing_scrollable_does_nothing():
+    run_gui("""
+        from tkinter import ttk
+        loose = ttk.Frame(root)                  # not inside any ScrollableFrame
+        assert app._wheel._resolve(loose) == (None, None)
+        assert app._wheel._resolve(None) == (None, None)
+    """)
+
+
+def test_the_walk_up_the_master_chain_is_bounded():
+    """``_resolve`` follows ``master`` links; a cycle must not hang the UI thread."""
+    run_gui("""
+        class Loop:
+            pass
+        a, b = Loop(), Loop()
+        a.master, b.master = b, a               # a cycle, which Tk itself cannot make
+        assert app._wheel._resolve(a) == (None, None), "the walk must give up"
+    """)
+
+
+def test_the_wheel_scrolls_the_page_under_the_pointer():
+    """End to end through _on_wheel: a real delta moves the real container."""
+    run_gui("""
+        scroll = app.pages["control"].scroll
+        scroll.canvas._yview = (0.0, 0.5)       # there IS something to scroll
+        scroll.canvas.scrolled.clear()
+
+        event = type("E", (), {"delta": -120, "num": None, "widget": scroll.body,
+                               "x_root": 10, "y_root": 10})()
+        assert app._wheel._on_wheel(event) == "break", "a handled wheel must stop here"
+        assert any(s[0] == "scroll" for s in scroll.canvas.scrolled), scroll.canvas.scrolled
+    """)
+
+
+# -- the combobox fix -------------------------------------------------------- #
+
+
+def test_scrolling_over_a_combobox_cannot_change_its_value():
+    """ttk::combobox ships a CLASS binding that steps through its values, and
+    bindtags run it long before our dispatcher - so scrolling the Control page
+    with the pointer crossing a combobox silently changed the traffic filter."""
+    run_gui("""
+        disarmed = root.class_bindings
+        for sequence in ("<MouseWheel>", "<Button-4>", "<Button-5>"):
+            for widget_class in ("TCombobox", "TSpinbox"):
+                key = (widget_class, sequence)
+                assert key in disarmed, "not disarmed: " + str(key)
+                # replaced with a no-op that returns None, NOT "break": the event
+                # must keep travelling to the `all` bindtag where we scroll the page
+                assert disarmed[key](None) is None, str(key)
+    """)
+
+
+# -- ensure_visible ---------------------------------------------------------- #
+
+
+def test_expanding_a_section_at_the_bottom_edge_scrolls_it_into_view():
+    """The maths, not the call. Four cases on a viewport smaller than the body."""
+    run_gui("""
+        scroll = app.pages["control"].scroll
+        canvas, body = scroll.canvas, scroll.body
+
+        def geometry(total, view, widget_top, widget_height, at=0.0):
+            body.winfo_height = lambda: total
+            canvas.winfo_height = lambda: view
+            body.winfo_rooty = lambda: 0
+            canvas.canvasy = lambda _y: at
+            w = type("W", (), {"winfo_rooty": lambda self: widget_top,
+                               "winfo_height": lambda self: widget_height})()
+            canvas.scrolled.clear()
+            return w
+
+        # 1) below the viewport -> scrolls down far enough to show its bottom
+        w = geometry(total=1000, view=200, widget_top=500, widget_height=80)
+        scroll.ensure_visible(w, margin=10)
+        moves = [s for s in canvas.scrolled if s[0] == "moveto"]
+        assert moves, "a widget below the fold must be scrolled to"
+        assert 0.0 < moves[-1][1] <= 1.0, moves
+
+        # 2) already visible -> nothing happens
+        w = geometry(total=1000, view=600, widget_top=100, widget_height=50)
+        scroll.ensure_visible(w, margin=10)
+        assert not canvas.scrolled, "a visible widget must not move the page"
+
+        # 3) above the current position -> scrolls back up
+        w = geometry(total=1000, view=200, widget_top=50, widget_height=40, at=400)
+        scroll.ensure_visible(w, margin=10)
+        moves = [s for s in canvas.scrolled if s[0] == "moveto"]
+        assert moves and moves[-1][1] < 400 / 1000.0, moves
+
+        # 4) taller than the viewport -> show its START, not its end
+        w = geometry(total=2000, view=200, widget_top=800, widget_height=900)
+        scroll.ensure_visible(w, margin=10)
+        moves = [s for s in canvas.scrolled if s[0] == "moveto"]
+        assert moves, "a tall widget must still be scrolled to"
+        assert abs(moves[-1][1] - (800 - 10) / 2000.0) < 0.01, (
+            "a widget taller than the viewport must be shown from its TOP: " + str(moves))
+    """)
+
+
+def test_everything_already_fitting_is_never_scrolled():
+    """Guards the early return: with no overflow there is nothing to reveal, and
+    moving the page anyway is the jump the user notices."""
+    run_gui("""
+        scroll = app.pages["control"].scroll
+        scroll.body.winfo_height = lambda: 300
+        scroll.canvas.winfo_height = lambda: 600      # viewport bigger than content
+        scroll.canvas.scrolled.clear()
+        widget = type("W", (), {"winfo_rooty": lambda self: 280,
+                                "winfo_height": lambda self: 40})()
+        scroll.ensure_visible(widget)
+        assert not scroll.canvas.scrolled, scroll.canvas.scrolled
+    """)
+
+
+def test_a_container_with_nothing_to_scroll_ignores_the_wheel():
+    run_gui("""
+        scroll = app.pages["control"].scroll
+        scroll.canvas._yview = (0.0, 1.0)             # everything fits
+        scroll.canvas.scrolled.clear()
+        scroll.scroll(-3)
+        assert not scroll.canvas.scrolled, scroll.canvas.scrolled
+    """)

--- a/tests/user_files.py
+++ b/tests/user_files.py
@@ -1,0 +1,35 @@
+"""Point every file the app writes for the USER at a throwaway directory.
+
+One place, two callers: ``gui_harness.run_gui`` (which builds an App per test in a
+subprocess) and ``smoke_gui.py``. It used to live only in the harness, so the smoke
+script - run by ``tests/test_gui_smoke.py`` and by CI - wrote the developer's real
+``bean_network_tester_ui.json`` and a ``crashes/`` folder into the repository root
+on every test run. Both are git-ignored, so nothing ever showed it: running the
+suite quietly reset the remembered window geometry, language and sort order.
+
+Call it BEFORE the App is built - the stores read their path at construction.
+"""
+import os
+import tempfile
+
+
+def redirect_to_temp(directory=None):
+    """Send UI state, profiles and the crash log to ``directory`` (a temp dir).
+
+    Returns the directory, so a caller can assert against it.
+    """
+    directory = directory or tempfile.mkdtemp(prefix="bnt-test-")
+
+    import beantester.gui.ui_state as ui_state
+    import beantester.gui.profiles as profiles
+    from beantester import crashlog
+
+    # The stores take their path as a default argument, which is what the App
+    # relies on; rebinding the default is what makes an already-imported module
+    # follow us without touching production code.
+    ui_state.UiStateStore.__init__.__defaults__ = (
+        os.path.join(directory, "ui.json"),)
+    profiles.ProfileStore.__init__.__defaults__ = (
+        os.path.join(directory, "profiles.json"),)
+    crashlog.app_dir = lambda: directory
+    return directory


### PR DESCRIPTION
## What and why

An engineering review of the test suite, followed by closing what it found. The suite was already
large and green (846 tests, 85.86%), so the review deliberately did not look for textbook gaps - it
looked for places where **a green run is not evidence**: guards that stub the very function the
fault was in, doubles that had drifted from the interfaces they stand in for, and a coverage number
that is wrong in both directions.

Every claim of the form "this test catches X" below was confirmed by planting X and watching the
test go red. Where coverage and mutation disagreed, mutation won.

| | before | after |
|---|---|---|
| tests | 846 | **887** |
| coverage | 85.86% | **87.74%** (gate raised 80 -> 83) |
| swallowed exceptions per run | 809 | **6**, all injected on purpose |
| files the suite left in the working tree | `ui.json` + `crashes/` | **none** |

### The four commits

**1. `test(doubles)` - three test doubles were silently degrading what they stand in for.**
`crashlog` writes every swallowed exception to `crashes/crashes.ndjson` (convention 30), so this
was fully visible for a long time - just never read. A full green run left 809 entries: 526 were a
missing `tk.call` on the tkinter double, which meant **Tk font scaling never ran in a single GUI
test**; 264 were a missing `Text.index`, so the log widget's own trim never executed and it grew
unbounded; 8 were port-table doubles without `warm_names`, so those engine tests ran against a
silently degraded watchdog - the exact mechanism the `warm_names` ADR is about.

Verified rather than assumed: `tk.call("tk", "scaling", 1.333)` now reaches the interpreter, 900
appends with `log_lines=500` leave 502 lines in the widget, and `tooltip._grab_active` answers
through its primary path.

**2. `test(harness)` - a green GUI test can no longer hide a swallowed fault.** `run_gui` now reads
`crashlog.recent()` back at the end of each subprocess and fails on anything not declared via
`allow_faults=(...)`. It lives in the subprocess so the failure carries the name of the test that
caused it. Checked both ways: a planted `crashlog.quiet` fault fails the test; the same fault,
declared, passes.

Also `tests/user_files.py`, shared by the harness, `smoke_gui.py` and a session fixture. The
redirect existed only inside the harness, so `smoke_gui.py` - run by `test_gui_smoke.py` and by CI
- overwrote the developer's real `bean_network_tester_ui.json` (window geometry, language, sort
order) and left a `crashes/` folder next to the sources on every run. Both git-ignored, so nothing
ever showed it.

**3. `test(gaps)` - the unguarded behaviours, and the gate.**

- **`crashlog.install()` claims every failure path; only one of three had a guard.** Gutting the
  main-thread and Tk-callback hooks left 106 tests green. Three new tests; both mutants now caught.
- **`--license` had zero coverage** - the one finding with legal rather than functional weight
  (convention 35). Existing tests check the legal files *exist in the tree*; the code reads them
  through `resource_path()`, and `legal._read` answers an `OSError` with `""`. A build that stopped
  resolving them would print an empty licence with the suite green. Also pins the
  `event="license"` NDJSON record against `legal.COMPONENTS`.
- **Three user-visible fixes in `gui/scrollable.py` had no guard at all.** The one existing test
  stubbed `_resolve`, the other stubbed `ensure_visible` - good wiring tests, but between them the
  behaviour never ran. Nine tests; three planted mutants each caught by the matching test.
- **The tooltip's whole reason for existing was unguarded** - one reused bubble per toplevel is
  what stops Windows flashing the taskbar button on every hover, and a rewrite back to one
  `Toplevel` per hover would have passed.
- **`SortableTree._clicked`** (sort by clicking a header) was called by nothing.
- **`winenv._quote` and `elevation_disabled`**: two pure functions at zero coverage, one building
  the elevated relaunch command line, the other the switch the automated GUI workflow runs on.

**4. `test(gui,flakiness)` - file actions, racing waits, one unscattered subject.**

- Save file / Load file / Save repro were the largest uncovered blocks in `gui/app.py`. The modules
  behind them are covered and write frozen on-disk formats; the App side was not tested at all.
- `fakes.wait_until` replaces ten fixed waits that raced an assertion. The worst read `core.loss`
  0.15 s into a 0.3 s window, so a stall longer than the gap made the "before" read land after the
  scenario step. Waits that assert something does **not** happen stay fixed - absence cannot be
  polled - each with a comment saying why. This buys reliability, not speed: ~1.3 s removed from a
  ~368 s run.
- Four flow-table tests moved into `test_core.py`. The wider scatter was measured before touching
  anything and mostly is not scatter.

### Things worth a second opinion

- **The `fake_tk` change moved GUI tests onto different branches of production code.**
  `icon._running_variant` switched from its fallback to its primary branch, and `gui/scaling.py`
  dropped 2.2 points because its `except` path stopped running. Nothing regressed - no assertion
  depended on either - and the new branches are the ones production takes on real Tk. Both
  `_running_variant` branches now have a guard.
- **Coverage misled in both directions** and the comment above `fail_under` now says so:
  `crashlog.py:396-398` reports as missing while mutation proves it guarded (coverage cannot see
  inside `threading.excepthook`), and lines behind a short-circuited `and` report as covered while
  nothing checks them.
- **Deliberately not written:** tests for `fields.off_value()` and the BOOL/SEED branches of
  `is_active()`. Both are reachable only through the section `toggle` mechanism, which no section
  uses today - a test there would guard dormant code.

## Checklist

- [x] `python -m pytest tests` passes locally. 887 passed, elevated shell, no known admin failures.
- [x] New behaviour has tests (see `tests/` for the style).
- [x] UI text goes through i18n keys, with **both** `lang/en.json` and `lang/pl.json` updated. No UI
      text changed.
- [x] User-facing changes noted in `CHANGELOG.md`; technical ones and new tests in
      `CHANGELOG-INTERNAL.md`, under `[Unreleased]`. Nothing user-facing here; all entries are
      internal.
- [x] Commits follow Conventional Commits (`type(scope): summary`).
- [x] No version bump - the owner closes a version via `VERSION.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
