### PR TITLE
fix(cli): a CI job can no longer hang, die silently, or be told a config is fine when it is not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ BeanNetworkTester-*.zip
 .claude/
 PROJECT_NOTES.md
 HISTORY_NOTES.md
+
+# Internal scripts kept between sessions: measurement rigs, probes, diagnostics.
+# Never shipped, never a CI dependency, backed up by the owner separately.
+# NOTE: `tools/` is a different thing and STAYS TRACKED - ci.yml runs
+# tools/ci_gui_render.py, so ignoring it would break the workflow on a fresh
+# clone. See internal_tools/README.md.
+internal_tools/

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,19 +17,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
-### Changed
-
-- **`internal_tools/` added to `.gitignore`** - a home for scripts kept between sessions
-  (measurement rigs, probes against the real driver, expensive diagnostics). Not shipped, never a
-  CI dependency, backed up by the owner separately; index and entry rule in
-  `internal_tools/README.md`. Only the `.gitignore` line is in this repo.
-  The alternative was the scratchpad, and the scratchpad does not survive a session: `PROJECT_NOTES`
-  rule 5 has been pointing at "`bench_ab.py` from that session's scratchpad" - a file that no longer
-  existed - so the same A/B rig kept being rebuilt without its interleaving or its drift canary.
-  **`tools/` is deliberately NOT covered by this and stays tracked**: `ci.yml` runs
-  `tools/ci_gui_render.py` on the Linux runner, so ignoring it would break the GUI render check on
-  a fresh clone. A script that becomes a CI dependency moves to `tools/`.
-
 ### BREAKING
 
 - **BREAKING:** **`load_config_file` rejects unknown keys** (`settings.py`), the same rule
@@ -184,6 +171,17 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   user hunting. Verified by mutation: disabling the two checks turns all three red.
 
 ### Changed
+
+- **`internal_tools/` added to `.gitignore`** - a home for scripts kept between sessions
+  (measurement rigs, probes against the real driver, expensive diagnostics). Not shipped, never a
+  CI dependency, backed up by the owner separately; index and entry rule in
+  `internal_tools/README.md`. Only the `.gitignore` line is in this repo.
+  The alternative was the scratchpad, and the scratchpad does not survive a session: `PROJECT_NOTES`
+  rule 5 has been pointing at "`bench_ab.py` from that session's scratchpad" - a file that no longer
+  existed - so the same A/B rig kept being rebuilt without its interleaving or its drift canary.
+  **`tools/` is deliberately NOT covered by this and stays tracked**: `ci.yml` runs
+  `tools/ci_gui_render.py` on the Linux runner, so ignoring it would break the GUI render check on
+  a fresh clone. A script that becomes a CI dependency moves to `tools/`.
 
 - **Coverage gate raised 80 -> 83** (convention 32). Measured with `COVERAGE_PROCESS_START` on
   2026-08-01: **87.43%**, up from 83.03% on 2026-07-21. The comment above `fail_under` now also

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -78,7 +78,19 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   `::test_an_explicit_duration_still_wins_over_the_scenario`,
   `::test_a_scenario_with_no_timeline_does_not_cut_the_run_short`,
   `::test_a_looping_scenario_runs_to_its_duration_not_to_its_timeline`,
-  `::test_a_scenario_that_cannot_end_the_run_says_so_up_front`.
+  `::test_a_scenario_that_cannot_end_the_run_says_so_up_front`,
+  `::test_the_loop_flag_takes_the_derived_ending_away_again` (``--loop`` is folded into
+  ``scen.loop`` BEFORE the end is planned, so reading the file's own flag instead of the effective
+  one would end a run the user asked to repeat),
+  `::test_an_engine_that_cannot_report_the_scenario_end_says_so`.
+  Those last two were written AFTER the code and so were never red; both were verified by mutation
+  instead. The second one paid for itself immediately: `_plan_the_end_of_the_scenario` used to log
+  the injected-engine case and then FALL THROUGH to the shared warning, telling the reader a
+  two-step file "has a single step, so there is no timeline". The branch is now an `if/elif/else`
+  where every reason is true for its case, and the test asserts the reason given is that one rather
+  than merely that some warning appeared. (Mutation also showed the two chunks composing: without
+  the guard the double raises `TypeError` into the new session handler and comes back as a coded
+  `RUNTIME` instead of a traceback.)
   The CLI tests cannot use `FakeClock` (the runner reads the wall clock on its own thread), so they
   run on real time with a budgeted `sleep` that raises `_NeverEnded` - a **`BaseException`**, since
   the new session handler below catches `Exception` and would otherwise swallow the signal and make

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -17,6 +17,19 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ## [Unreleased]
 
+### Changed
+
+- **`internal_tools/` added to `.gitignore`** - a home for scripts kept between sessions
+  (measurement rigs, probes against the real driver, expensive diagnostics). Not shipped, never a
+  CI dependency, backed up by the owner separately; index and entry rule in
+  `internal_tools/README.md`. Only the `.gitignore` line is in this repo.
+  The alternative was the scratchpad, and the scratchpad does not survive a session: `PROJECT_NOTES`
+  rule 5 has been pointing at "`bench_ab.py` from that session's scratchpad" - a file that no longer
+  existed - so the same A/B rig kept being rebuilt without its interleaving or its drift canary.
+  **`tools/` is deliberately NOT covered by this and stays tracked**: `ci.yml` runs
+  `tools/ci_gui_render.py` on the Linux runner, so ignoring it would break the GUI render check on
+  a fresh clone. A script that becomes a CI dependency moves to `tools/`.
+
 ### BREAKING
 
 - **BREAKING:** **`load_config_file` rejects unknown keys** (`settings.py`), the same rule

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -19,6 +19,45 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### BREAKING
 
+- **BREAKING:** **a finished scenario ends the CLI run** (`stop_reason: "scenario_done"`, a new
+  value of an existing NDJSON field, so it needs the owner's version bump).
+  `ScenarioRunner.finished` is set on the timeline-complete branch only (`scenario_runner.py`),
+  and `BeanEngine.scenario_finished()` exposes it; `cli._report_loop` returns `"scenario_done"`
+  when `cfg["stop_on_scenario"]` is set. **The end of a timeline is ASKED OF THE RUNNER, not
+  recomputed from `Scenario.duration` in the CLI** - the tail past the last step (`duration + 0.1`)
+  lives in the runner, and a second reader of the same fact drifts on the first edit ("Jedno
+  zrodlo prawdy").
+  `finished` deliberately means *the timeline ran out* and NOT *the runner stopped*: `stop()` and a
+  dead engine also end that loop, and reporting either as `scenario_done` would dress a faulted run
+  up as a clean one. `cli._plan_the_end_of_the_scenario` decides and announces; it declines for a
+  looping scenario and for `duration == 0` (a single step at `at: 0` is settings, not a timeline,
+  and would otherwise end the session inside 0.1 s), warning in both cases. An injected engine
+  without `scenario_finished` (public `engine=` seam) falls back to the old behaviour but SAYS so
+  at debug level, because a silent fallback would quietly restore the hang.
+  Measured before: a two-step non-looping scenario with no `--duration` was still sampling when a
+  hard timeout killed it at 12 s (exit 124). After: `exit 0, reason=scenario_done`.
+  Note the detection inherits the report loop's wake-up granularity - the run ends at the first
+  wake AFTER the timeline, so up to `--interval` late. That bound is the sleep-cap item, not this
+  one.
+  New tests: `tests/test_scenario_runner.py::test_a_completed_timeline_reports_that_it_finished`,
+  `::test_a_looping_runner_never_reports_finished`,
+  `::test_a_runner_the_engine_shut_down_did_not_finish`;
+  `tests/test_cli_runtime.py::test_a_finished_scenario_ends_the_run_even_without_a_duration`,
+  `::test_an_explicit_duration_still_wins_over_the_scenario`,
+  `::test_a_scenario_with_no_timeline_does_not_cut_the_run_short`,
+  `::test_a_looping_scenario_runs_to_its_duration_not_to_its_timeline`,
+  `::test_a_scenario_that_cannot_end_the_run_says_so_up_front`.
+  The CLI tests cannot use `FakeClock` (the runner reads the wall clock on its own thread), so they
+  run on real time with a budgeted `sleep` that raises `_NeverEnded` - a **`BaseException`**, since
+  the new session handler below catches `Exception` and would otherwise swallow the signal and make
+  a hang look like a clean `RUNTIME`. That is a hang turned into a named failure instead of a test
+  that stalls the suite.
+  Stability pass (convention/rule 8, the flag is read off-thread): 4.8M cold reads before any
+  runner exists - all `False`, no exceptions; 30 cycles x 8 concurrent readers - no within-runner
+  `True -> False`; runner swap and `stop_scenario` both leave `False`. (The first version of that
+  check counted transitions ACROSS runners and "found" hundreds of regressions - `start()` resets
+  the flag by design. The script was wrong, not the code.)
+
 - **BREAKING:** **`capture_narrowed` column in the statistics CSV.** New `App.CSV_SESSION_COLUMNS`
   (keyed by `session_info()` key, the way `CSV_COLUMNS` is keyed by counter key) and
   `_csv_session_value`, written between the timestamp and the counters. Booleans go out as
@@ -310,6 +349,26 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Fixed
 
+- **`run_cli` no longer lets an unforeseen exception escape as a traceback.** Convention 18 and the
+  `CliError` docstring both promise "never a raw traceback", and that held for the parse/validate
+  surface only: `test_cli_fuzz.py` runs every one of its cases under `--dry-run` ("pure contract
+  surface"), so the SESSION path - engine, threads, driver, report loop - had no guard at all.
+  Measured: a `RuntimeError` raised in `_report_loop` escaped `run_cli` with no `[bean] error:`
+  line, no `summary` record, and CPython's exit `1` (colliding with `RUNTIME`).
+  Two layers, deliberately, because they can do different amounts for the caller:
+  1. `except Exception` inside `_run_session` around the report loop - the engine is still alive
+     and the counters readable, so the run sets `RUNTIME`/`"fault"` and **still emits a complete
+     `summary`**, instead of leaving a truncated NDJSON file;
+  2. `except Exception` in `run_cli` as the last resort, for everything outside the session
+     (config load, building the result, a bug in this module) where nothing can be summarised.
+  Both go through `crashlog.record` (convention 30 - the only sanctioned swallow). `CliError` is a
+  `SystemExit`, so it passes both handlers untouched to its own, as before. The outer message names
+  its PHASE ("while finishing the run") because a fault in something the summary also needs trips
+  both handlers, and two identical lines read as two separate bugs.
+  New tests: `tests/test_cli_runtime.py::
+  test_an_unexpected_session_fault_is_a_coded_exit_with_a_full_summary` (asserts the complete
+  summary and `stop_reason == "fault"`) and `::test_a_fault_outside_the_session_is_still_a_coded_
+  exit` (asserts the two messages are distinguishable).
 - **The shared-port warning named the target's own program among the "other processes".** Reported
   from a real session targeting `chrome`. Not a regression from the handle-read change - verified
   field for field on both checkouts (matched pids, target ports, shared ports, co-owners and the

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -19,6 +19,38 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### BREAKING
 
+- **BREAKING:** **`load_config_file` rejects unknown keys** (`settings.py`), the same rule
+  `scenario.py` already applies to step keys and settings names. Was
+  `s.update({... if k in DEFAULT_SETTINGS})` - a silent filter. Touches a frozen on-disk format
+  ("Kontrakty publiczne"), so it needs the owner's version bump.
+  New i18n keys in BOTH files: `errors.config_unknown_setting`,
+  `errors.config_unknown_setting_hint` (the latter used only when there is exactly one unknown key
+  and `difflib.get_close_matches` finds a near miss - `latancy` -> `latency`, which is the whole
+  failure mode this closes).
+  **The recorded counter-argument was checked before changing this, and it is about a different
+  file.** `CHANGELOG-INTERNAL` on the `ui.json` store says unknown keys are kept on purpose,
+  because dropping them "would silently discard state written by a newer version". That reasoning
+  holds THERE: `ui.json` is written by the program and read key by key, so a typo is impossible and
+  forward compatibility is the only thing at stake. The traffic config file is hand-written (README
+  recipe 2 exists to validate hand-written ones in a pipeline), so a typo is the common case and
+  silence is the expensive answer. The forward-compat cost is real and is stated in the public
+  changelog rather than glossed.
+  `save_config_file` emits exactly the `DEFAULT_SETTINGS` key set, so nothing this tool writes is
+  affected - guarded now by `::test_every_file_this_tool_writes_still_loads`, which is what keeps
+  that true when a setting is renamed or dropped.
+  Consumers swept (rule 2): `cli.py:205` (already wraps `ValueError` -> `CONFIG(3)`, so free) and
+  `gui/app.py:1280` (already inside `try/except Exception` -> `dialogs.show_error`, so the dialog
+  path is free too - but it got its own guard, since a hand-written file is most likely to be
+  opened there). Profiles do NOT go through this path (`gui/profiles.py` + `PROFILE_FILE`), so they
+  are untouched.
+  Tests: `test_settings_config_scenario.py::
+  test_a_misspelled_setting_in_a_config_file_is_an_error_not_a_silent_default` (REPLACES
+  `::test_config_file_unknown_keys_ignored`, which pinned the old behaviour - and whose own check
+  message already said "rejected" while the code ignored),
+  `::test_every_file_this_tool_writes_still_loads`;
+  `test_cli_runtime.py::test_dry_run_catches_a_misspelled_setting_in_a_config_file`;
+  `test_gui_file_actions.py::test_a_misspelled_setting_reaches_the_user_as_a_dialog`.
+
 - **BREAKING:** **a finished scenario ends the CLI run** (`stop_reason: "scenario_done"`, a new
   value of an existing NDJSON field, so it needs the owner's version bump).
   `ScenarioRunner.finished` is set on the timeline-complete branch only (`scenario_runner.py`),
@@ -349,6 +381,14 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
 
 ### Fixed
 
+- **`--dry-run`'s prose narrowed to what it actually checks.** The comment above it called it "the
+  one thing a CI/CD pipeline runs to find out whether the next command will work", and the success
+  line said "Configuration is valid" full stop. Measured with `is_admin()` patched false: exit `0`
+  from the preflight, exit `7` from the very next real run. **The behaviour was deliberately left
+  alone** - `_run_session` keeps the elevation and pydivert gates, because validating a config on a
+  build agent and running it elsewhere is a legitimate pattern that widening the check would break.
+  Only the sentence changed, plus the `--doctor` + `--dry-run` pair in both READMEs.
+  Guard: `test_cli_runtime.py::test_dry_run_says_what_it_did_not_check`.
 - **`run_cli` no longer lets an unforeseen exception escape as a traceback.** Convention 18 and the
   `CliError` docstring both promise "never a raw traceback", and that held for the parse/validate
   surface only: `test_cli_fuzz.py` runs every one of its cases under `--dry-run` ("pure contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### BREAKING
 
+- **BREAKING:** **a scenario that ends now ends the run.** `--scenario` with a file that does not
+  loop and has a timeline (more than one step) used to print "Scenario finished." and then keep
+  the session going forever: without `--duration` there was nothing left to stop it. In a pipeline
+  that is a job that hangs to its own timeout, exits with a code this tool never produced, writes
+  no `summary` record, and leaves the WinDivert driver loaded. Such a run now stops when the
+  scenario does (`stop_reason: "scenario_done"`), and says so at the start: *"No --duration: this
+  run will stop when the scenario ends (about 85s)."*
+  **`--duration` still wins wherever you pass it**, so any command that already had one behaves
+  exactly as before. Two kinds of scenario have no end to derive - a looping one, and a
+  single-step one (which is settings, not a timeline) - and those keep running until you stop
+  them, but now say so instead of leaving you to find out.
+
 - **BREAKING:** **the statistics CSV has a new `capture_narrowed` column**, right after `time`.
   It says whether that row was measured with "Capture only the targeted traffic" in effect - and
   without it two rows under the same header could count completely different traffic with no way
@@ -45,6 +57,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **An unforeseen error during a run is now an exit code, not a stack trace.** The command line
+  promises that every way of ending has its own number - and it kept that promise everywhere
+  except the one place where a session actually runs. An unexpected failure inside the reporting
+  loop escaped as a raw Python traceback with exit code `1`, which is also the code for "the
+  session could not start", so a pipeline could not tell an internal bug from a driver that would
+  not open. Now it is reported as `runtime` (`1`) with a line saying what happened, **and the run
+  still writes its complete `summary` record** - a `--format json` file no longer ends mid-stream.
+  A failure while building the final report (rarer, and it takes the counters with it) says so in
+  its own words, so one fault never reads like two.
 - **The shared-port warning called your own target "another process".** Targeting `chrome` could
   answer *"other processes have port 5353 open too (Spotify.exe, adb.exe, **chrome.exe**,
   msedge.exe, svchost.exe)"* - listing the very program you were targeting among the strangers,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### BREAKING
 
+- **BREAKING:** **a misspelled setting in a config file is now an error.** `{"loss": 10, "latancy":
+  300}` used to load without a word: `--dry-run` answered *"Configuration is valid"*, exit `0`, and
+  the run then went out with **no latency at all**. In a pipeline that is a green job that impaired
+  less than it was told to, and nothing anywhere says so. An unknown setting is now a `config` (`3`)
+  error naming the key - and where there is an obvious near miss it says so: *"Unknown setting in
+  the config file: latancy. Did you mean 'latency'?"* This is the rule scenario files already
+  follow.
+  **Any file this program saved keeps loading** (`--save-config` writes exactly the settings it
+  knows). The one file that will now be refused is a hand-written one with a name this build does
+  not recognise - including, and this is the cost of the change, a config written by a **newer**
+  version that has a setting this one does not. The message names the key, so removing it is
+  enough.
+
 - **BREAKING:** **a scenario that ends now ends the run.** `--scenario` with a file that does not
   loop and has a timeline (more than one step) used to print "Scenario finished." and then keep
   the session going forever: without `--duration` there was nothing left to stop it. In a pipeline
@@ -57,6 +70,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **`--dry-run` no longer sounds like it checked more than it did.** It validates the settings; it
+  never asks whether this machine could actually run a capture, so on a box without Administrator
+  rights it answered *"Configuration is valid"* about a command that then exits `7`. Widening the
+  check would have broken a normal habit - validating a config on a build agent and running it
+  somewhere else - so the sentence changed instead: the success line now says it checked the
+  settings and not the machine, and points at `--doctor` for the other half. Both READMEs show the
+  pair.
 - **An unforeseen error during a run is now an exit code, not a stack trace.** The command line
   promises that every way of ending has its own number - and it kept that promise everywhere
   except the one place where a session actually runs. An unexpected failure inside the reporting

--- a/README.md
+++ b/README.md
@@ -986,7 +986,18 @@ leaves a broken network on the agent.
 ```bat
 BeanNetworkTester.exe --dry-run --config profiles/bad-3g.json
 ```
-Code `0` = the file is valid. `3` = there is an error (with a readable message on stderr).
+Code `0` = the file is valid. `3` = there is an error (with a readable message on stderr). A
+misspelled setting counts as an error and says which key it is - it used to be dropped in silence,
+so the check passed and the run then went out without that setting.
+
+`--dry-run` checks the **settings**, not the machine: it never asks about Administrator rights or
+about the driver, so it answers `0` on a build agent that could not actually run a capture. That is
+deliberate - validating a config in one place and running it in another is normal. When you want
+both halves answered, run the pair:
+
+```bat
+BeanNetworkTester.exe --doctor && BeanNetworkTester.exe --dry-run --config profiles/bad-3g.json
+```
 
 ### 3. A short, repeatable run with an artifact
 

--- a/README.md
+++ b/README.md
@@ -690,7 +690,7 @@ ranges, `!`, `>`, `<`, `>=`, `<=`, wildcards, `re:`, and `--dst-ip` additionally
 | `--config FILE` / `--save-config FILE` | load / save settings (JSON, shared with the GUI) |
 | `--scenario FILE` `--loop` | a timeline scenario (JSON) and looping it |
 | `--seed N` | randomness seed - the same run can be repeated |
-| `--duration N` | **run time in seconds** (0 = until Ctrl+C). The same field is in the GUI ("Session") |
+| `--duration N` | **run time in seconds** (0 = until Ctrl+C, or until a `--scenario` timeline runs out). The same field is in the GUI ("Session") |
 | `--row-limit N` | a **GUI-only** setting: max rows in the tables (0 = no limit, default 50 000). In headless CLI (no window) it does nothing - it is only saved to the config file and takes effect when that config is opened in the GUI. The "Row limit" field's equivalent |
 | `--interval N` | how often to report, in seconds (must be > 0) |
 | `--log-conns` | print the observed connections at the end |
@@ -1037,7 +1037,10 @@ for normal operation.
 ## Gotchas (read before filing a bug)
 
 - **`--duration` is a safety net, not just convenience.** Without it a session lasts until
-  `Ctrl+C` / STOP. In CI **always** pass `--duration`.
+  `Ctrl+C` / STOP. In CI **always** pass `--duration`. The one exception is a scenario with a
+  timeline: `--scenario` with a file that does not loop and has more than one step now ends the
+  run when the scenario ends, and says so at the start. A looping or single-step scenario has no
+  end to stop at, so it warns and keeps going until you stop it.
 - **No traffic = a green run.** If the filter catches not a single packet, the program works
   correctly and exits with code `0`. Want that to be an error -> `--fail-on-no-traffic`.
 - **The traffic filter and duration take effect only from START** (as in the GUI): "Apply changes"

--- a/README.pl.md
+++ b/README.pl.md
@@ -552,7 +552,7 @@ BeanNetworkTester.exe --simulate --duration 30 --format json > run.ndjson
 | `--config PLIK` / `--save-config PLIK` | wczytaj / zapisz ustawienia (JSON, wspólne z GUI) |
 | `--scenario PLIK` `--loop` | scenariusz na osi czasu (JSON) i jego zapętlenie |
 | `--seed N` | ziarno losowości - ten sam przebieg da się powtórzyć |
-| `--duration N` | **czas pracy w sekundach** (0 = do Ctrl+C). To samo pole jest w GUI (sekcja „Sesja”) |
+| `--duration N` | **czas pracy w sekundach** (0 = do Ctrl+C albo do końca osi czasu z `--scenario`). To samo pole jest w GUI (sekcja „Sesja”) |
 | `--row-limit N` | ustawienie **tylko dla GUI**: maks. wierszy w tabelach (0 = bez limitu, domyślnie 50 000). W samym CLI (bez okna) nic nie robi - jest jedynie zapisywane do pliku konfiguracji i działa dopiero, gdy ten config otworzysz w GUI. Odpowiednik pola „Limit wierszy” |
 | `--interval N` | co ile sekund raportować (musi być > 0) |
 | `--log-conns` | wypisz na końcu zaobserwowane połączenia |
@@ -895,7 +895,10 @@ Ikonę można wygenerować ponownie skryptem z użyciem Pillow (`pip install pil
 ## Co może zaskoczyć (przeczytaj, zanim zgłosisz błąd)
 
 - **`--duration` to bezpiecznik, nie tylko wygoda.** Bez niego sesja trwa do `Ctrl+C` / STOP.
-  W CI **zawsze** podawaj `--duration`.
+  W CI **zawsze** podawaj `--duration`. Jedyny wyjątek to scenariusz z osią czasu: `--scenario`
+  z plikiem, który się nie zapętla i ma więcej niż jeden krok, kończy teraz przebieg razem ze
+  scenariuszem i mówi o tym na starcie. Scenariusz zapętlony albo jednokrokowy nie ma się na czym
+  zatrzymać, więc ostrzega i trwa, dopóki go nie zatrzymasz.
 - **Zero ruchu = zielony przebieg.** Jeśli filtr nie złapie ani jednego pakietu, program działa
   poprawnie i kończy się kodem `0`. Chcesz, żeby to był błąd → `--fail-on-no-traffic`.
 - **Filtr ruchu i czas trwania działają tylko od STARTU** (jak w GUI): „Zastosuj zmiany” ich nie rusza.

--- a/README.pl.md
+++ b/README.pl.md
@@ -848,7 +848,18 @@ więc żaden „zawieszony” krok nie zostawi zepsutej sieci na agencie.
 ```bat
 BeanNetworkTester.exe --dry-run --config profiles/bad-3g.json
 ```
-Kod `0` = plik jest poprawny. `3` = jest błąd (z czytelnym komunikatem na stderr).
+Kod `0` = plik jest poprawny. `3` = jest błąd (z czytelnym komunikatem na stderr). Literówka w
+nazwie ustawienia też jest błędem i program mówi, o który klucz chodzi - wcześniej znikała po
+cichu, więc sprawdzenie przechodziło, a przebieg szedł bez tego ustawienia.
+
+`--dry-run` sprawdza **ustawienia**, nie maszynę: nie pyta ani o uprawnienia administratora, ani o
+sterownik, więc odpowie `0` także na agencie, który realnie nie uruchomiłby przechwytu. Tak ma być
+- walidowanie konfiguracji w jednym miejscu i uruchamianie jej w innym to normalny układ. Gdy
+chcesz odpowiedzi na obie połowy, uruchom parę:
+
+```bat
+BeanNetworkTester.exe --doctor && BeanNetworkTester.exe --dry-run --config profiles/bad-3g.json
+```
 
 ### 3. Krótki, powtarzalny przebieg z artefaktem
 

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -724,13 +724,21 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
             log.info(f"Saved settings to {cfg['save_config']}")
             return exitcodes.OK
         if args.dry_run:
-            # The scenario is part of the configuration, and --dry-run is the
-            # "check it before I run it" gate - the one thing a CI/CD pipeline
-            # runs to find out whether the next command will work. It used to be
-            # loaded only once the session started, so --dry-run reported
-            # "Configuration is valid" about a file it had never opened: a
-            # truncated, empty or non-object scenario passed the check with exit
-            # OK and then failed the real run with SCENARIO(4).
+            # What this gate checks is the CONFIGURATION: every value, every
+            # expression, the schedule, and the scenario file. What it does NOT
+            # check is the MACHINE - it never asks about Administrator rights or
+            # about pydivert, so on a box without them it answers OK about a
+            # command that will exit PERMISSION(7) or RUNTIME(1). That is on
+            # purpose: validating a config on a build agent and running it on
+            # another machine is a normal thing to do, and widening the check
+            # would break it. The success line names --doctor for the other half,
+            # so the pair answers the question this one alone cannot.
+            #
+            # The scenario is part of the configuration and used to be loaded
+            # only once the session started, so --dry-run reported "Configuration
+            # is valid" about a file it had never opened: a truncated, empty or
+            # non-object scenario passed the check with exit OK and then failed
+            # the real run with SCENARIO(4).
             if cfg["scenario"]:
                 try:
                     scen = load_scenario_file(cfg["scenario"])
@@ -740,7 +748,9 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
                 log.debug(f"scenario: {len(scen.steps)} steps, "
                           f"{scen.duration:.0f}s, loop={scen.loop or cfg['loop']}")
             _log_effective_settings(log, cfg)
-            log.info("Configuration is valid (--dry-run: nothing was started).")
+            log.info("Configuration is valid (--dry-run: nothing was started). "
+                     "This checks the settings, not the machine - run --doctor "
+                     "for Administrator rights and the WinDivert driver.")
             return exitcodes.OK
 
         return _run_session(args, cfg, log, sleep, clock, engine)

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -138,7 +138,9 @@ def build_arg_parser():
     # default=None (NOT 0): --duration is a setting now, so a flag that is not
     # given must not override a --config file with a zero
     p.add_argument("--duration", type=float, default=None,
-                   help="run time [s], 0 = until Ctrl+C (also settable in the GUI)")
+                   help="run time [s], 0 = until Ctrl+C - or, with a --scenario "
+                        "that has a timeline, until that timeline runs out "
+                        "(also settable in the GUI)")
     p.add_argument("--row-limit", type=float, default=None,
                    help="most rows a GUI table will show, 0 = no limit "
                         "(the tables are virtualised, so this only bounds the "
@@ -463,8 +465,47 @@ def _report_loop(engine, cfg, log, sleep, clock, t0):
         verdict = state
         if deadline is not None and now >= deadline - 1e-9:
             return "duration"
+        # A scenario's timeline is an ending too, and without --duration it is the
+        # ONLY one the run has. It used to be nobody's: the runner thread ended,
+        # logged "Scenario finished." and left the session going forever - a CI
+        # job that hangs to its timeout, with no summary and (on a real run) the
+        # driver still loaded. Asked of the runner rather than derived from
+        # `scen.duration` here, so the tail past the last step stays in one place.
+        if cfg.get("stop_on_scenario") and engine.scenario_finished():
+            return "scenario_done"
         if not engine.is_running():         # the engine's own watchdog stopped it
             return engine.stop_reason or "fault"
+
+
+def _plan_the_end_of_the_scenario(log, cfg, scen, engine):
+    """Decide whether the scenario's own end may stop this run, and say so.
+
+    ``--duration`` is the user speaking and always wins; this only fills the gap
+    where there is no deadline at all. A scenario can end the run when it has a
+    timeline to run out of - which a looping one never does, and a single-step
+    one does not have (``Scenario.duration`` is the ``at`` of the last step, so
+    one step at 0 is duration 0 and would end the session inside a tenth of a
+    second: settings, not a timeline).
+
+    Where the run therefore cannot end by itself, that is said out loud. It has
+    always been true and was never mentioned - the log said "Running. Ctrl+C to
+    stop." and left the reader to discover the rest at the job timeout.
+    """
+    if cfg["duration"]:
+        return
+    # An injected engine (public seam) may be a double that predates this call.
+    # Falling back silently would quietly restore the hang, so it is reported.
+    if not callable(getattr(engine, "scenario_finished", None)):
+        log.debug("this engine cannot report the end of a scenario; "
+                  "the run will need --duration to stop")
+    elif not scen.loop and scen.duration > 0:
+        cfg["stop_on_scenario"] = True
+        log.info(f"No --duration: this run will stop when the scenario ends "
+                 f"(about {scen.duration:g}s).")
+        return
+    why = "it repeats" if scen.loop else "it has a single step, so there is no timeline"
+    log.warn(f"this scenario will not stop the run on its own ({why}) and there "
+             f"is no --duration, so the session keeps going until you stop it.")
 
 
 def _run_session(args, cfg, log, sleep, clock, engine):
@@ -515,6 +556,7 @@ def _run_session(args, cfg, log, sleep, clock, engine):
                      "no destination set). Capturing everything, as usual.")
 
     scenario_failed = None
+    cfg["stop_on_scenario"] = False
     if cfg["scenario"]:
         try:
             scen = load_scenario_file(cfg["scenario"])
@@ -522,6 +564,7 @@ def _run_session(args, cfg, log, sleep, clock, engine):
             engine.start_scenario(scen, cfg["settings"], log=log.info)
             log.debug(f"scenario: {len(scen.steps)} steps, "
                       f"{scen.duration:.0f}s, loop={scen.loop}")
+            _plan_the_end_of_the_scenario(log, cfg, scen, engine)
         except Exception as e:                 # a broken scenario is a failed run
             scenario_failed = e
             log.error(f"scenario error: {e}")
@@ -540,6 +583,21 @@ def _run_session(args, cfg, log, sleep, clock, engine):
         except _Terminated:
             log.warn("Terminated (SIGTERM).")
             code, stop_reason = exitcodes.TERMINATED, "terminated"
+        except Exception as exc:
+            # Anything unforeseen in the session is STILL a coded exit (the CI
+            # contract, convention 18). It used to escape run_cli outright: a
+            # traceback on stderr, no summary record at all, and CPython's own
+            # exit 1 - the same number as RUNTIME, so a job could not tell an
+            # unhandled bug from a driver that would not open.
+            # Caught HERE and not only at the top of run_cli because at this
+            # point the engine is alive and the counters are readable, so the
+            # run can still hand back a complete summary instead of a truncated
+            # NDJSON file. CliError is a SystemExit and passes straight through
+            # to its own handler, as before.
+            crashlog.record(exc, "cli")
+            log.error(f"unexpected failure in the session: "
+                      f"{type(exc).__name__}: {exc}")
+            code, stop_reason = exitcodes.RUNTIME, "fault"
         finally:
             engine.stop()
     else:
@@ -695,6 +753,20 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
     except _Terminated:
         log.warn("Terminated (SIGTERM).")
         return exitcodes.TERMINATED
+    except Exception as exc:
+        # Last resort. The session has its own handler (which can still emit a
+        # summary); this one covers everything outside it - loading a config,
+        # building the result, a bug in this module - where there is nothing
+        # left to report. The promise it keeps is the narrow one from the class
+        # docstring above: an exit CODE, never a raw traceback.
+        crashlog.record(exc, "cli")
+        # Worded to name its PHASE. A fault in something the summary also needs
+        # (the counters, say) trips the session handler first and then this one,
+        # and two identical "unexpected failure" lines read like two separate
+        # bugs instead of one fault and the report it took down with it.
+        log.error(f"unexpected failure while finishing the run: "
+                  f"{type(exc).__name__}: {exc}")
+        return exitcodes.RUNTIME
     finally:
         # Unload the driver we loaded. A --simulate run never touched one, so this
         # is free where it does not matter; where it does, it is what makes the

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -493,17 +493,20 @@ def _plan_the_end_of_the_scenario(log, cfg, scen, engine):
     """
     if cfg["duration"]:
         return
-    # An injected engine (public seam) may be a double that predates this call.
-    # Falling back silently would quietly restore the hang, so it is reported.
     if not callable(getattr(engine, "scenario_finished", None)):
-        log.debug("this engine cannot report the end of a scenario; "
-                  "the run will need --duration to stop")
-    elif not scen.loop and scen.duration > 0:
+        # An injected engine (public seam) may be a double that predates this
+        # call. Falling back is right - crashing somebody's harness is not - but
+        # falling back SILENTLY would quietly restore the hang.
+        why = "this engine cannot report when a scenario ends"
+    elif scen.loop:
+        why = "it repeats"
+    elif not scen.duration:
+        why = "it has a single step, so there is no timeline"
+    else:
         cfg["stop_on_scenario"] = True
         log.info(f"No --duration: this run will stop when the scenario ends "
                  f"(about {scen.duration:g}s).")
         return
-    why = "it repeats" if scen.loop else "it has a single step, so there is no timeline"
     log.warn(f"this scenario will not stop the run on its own ({why}) and there "
              f"is no --duration, so the session keeps going until you stop it.")
 

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -515,6 +515,19 @@ class BeanEngine:
         if self._scenario_runner is not None:
             self._scenario_runner.stop()
 
+    def scenario_finished(self):
+        """True once a non-looping scenario has played its whole timeline.
+
+        The end of a timeline is the runner's fact (it owns the tail past the
+        last step), so callers ask instead of recomputing it from
+        ``Scenario.duration`` - a second reader of the same value drifts on the
+        first edit. False when there is no scenario, when it loops, and when the
+        runner ended for any other reason (``stop()``, or this engine going
+        down): those are endings, but not a scenario that completed.
+        """
+        runner = self._scenario_runner
+        return bool(runner is not None and runner.finished)
+
     # -- statistics / connection log ----------------------------------------- #
     def reset_stats(self):
         with self._slock:

--- a/beantester/scenario_runner.py
+++ b/beantester/scenario_runner.py
@@ -21,9 +21,16 @@ class ScenarioRunner:
         self.engine = engine
         self._stop = True
         self._thread = None
+        # Set by the runner thread, read by whoever owns the session. A plain
+        # bool on purpose (like ``_stop``): one writer, one transition, never
+        # back. It means ONE thing - the timeline ran out - and deliberately not
+        # "the runner is no longer running": ``stop()`` and a dead engine also
+        # end the loop, and neither of those is a scenario that completed.
+        self.finished = False
 
     def start(self, scenario, base_settings, log=lambda *_: None):
         self._stop = False
+        self.finished = False
         self._thread = threading.Thread(
             target=self._loop, args=(scenario, dict(base_settings), log),
             daemon=True)
@@ -59,6 +66,7 @@ class ScenarioRunner:
                     log(f"{T('log.scenario')} [{at:.0f}s]: {T('log.scenario_reset')}.")
             prev_t = t
             if not scenario.loop and t > scenario.duration + 0.1:
+                self.finished = True
                 log(T("log.scenario_finished"))
                 break
             time.sleep(0.1)

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -4,6 +4,7 @@ The shape of a setting (type, label, bounds, section, profile scope) lives in
 ``fields.FIELD_DEFS`` - this module only turns raw user input into a validated
 settings dict and applies it to an engine.
 """
+import difflib
 import json
 import socket
 
@@ -409,9 +410,30 @@ def load_config_file(path):
         # A settings file that is a JSON ARRAY is not exotic: it is what anything
         # writing one-entry-per-line produces.
         raise ValueError(f"expected a JSON object, got {type(data).__name__}")
+    # A name this build does not know used to be dropped in silence, which is the
+    # worst of the three possible answers: `{"loss": 10, "latancy": 300}` loaded
+    # clean, --dry-run called the file valid, and the run went out with latency 0.
+    # Nothing anywhere said so. ``scenario.py`` closed exactly this hole for its
+    # own keys; this is the same rule one file over, and this is the file people
+    # hand-write (the README has a recipe for validating them in a pipeline).
+    #
+    # The cost, stated plainly because it is real: a file from a NEWER build that
+    # carries a setting this one lacks now fails instead of loading the part it
+    # understands. That trade goes the other way for ``ui.json``, where unknown
+    # keys are kept on purpose - but that file is written by the program and read
+    # key by key, so a typo cannot happen and forward compatibility is the only
+    # thing at stake. Here a typo is the common case. Anything this tool wrote
+    # loads either way: ``save_config_file`` emits exactly the known key set.
+    unknown = [k for k in data if k not in DEFAULT_SETTINGS]
+    if unknown:
+        close = difflib.get_close_matches(unknown[0], DEFAULT_SETTINGS, n=1)
+        if len(unknown) == 1 and close:
+            raise ValueError(translate("errors.config_unknown_setting_hint", None,
+                                       field=unknown[0], suggestion=close[0]))
+        raise ValueError(translate("errors.config_unknown_setting", None,
+                                   field=", ".join(sorted(unknown))))
     s = dict(DEFAULT_SETTINGS)
-    s.update({k: _coerce_setting(k, v) for k, v in data.items()
-              if k in DEFAULT_SETTINGS})
+    s.update({k: _coerce_setting(k, v) for k, v in data.items()})
     return s
 
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -109,6 +109,8 @@
   "dialogs.start_failed": "Failed to start",
   "dialogs.values_numbers": "Values must be numbers.",
   "errors.bad_config_value": "Invalid value for '{field}' in the config file: {value}",
+  "errors.config_unknown_setting": "Unknown setting in the config file: {field}. Remove it or correct the spelling.",
+  "errors.config_unknown_setting_hint": "Unknown setting in the config file: {field}. Did you mean '{suggestion}'?",
   "errors.bad_filter_bounds": "Field '{field}': '{term}' is out of the allowed range ({min}-{max}).",
   "errors.bad_filter_compare": "Field '{field}': comparison '{term}' needs a number after the operator.",
   "errors.bad_filter_compare_name": "Field '{field}': comparison operators (>, <, >=, <=) work only with a PID (a number), not a process name - '{term}'.",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -109,6 +109,8 @@
   "dialogs.start_failed": "Nie udało się uruchomić",
   "dialogs.values_numbers": "Wartości muszą być liczbami.",
   "errors.bad_config_value": "Nieprawidłowa wartość pola '{field}' w pliku konfiguracji: {value}",
+  "errors.config_unknown_setting": "Nieznane ustawienie w pliku konfiguracji: {field}. Usuń je albo popraw pisownię.",
+  "errors.config_unknown_setting_hint": "Nieznane ustawienie w pliku konfiguracji: {field}. Czy chodziło o '{suggestion}'?",
   "errors.bad_filter_bounds": "Pole '{field}': '{term}' jest poza dozwolonym zakresem ({min}-{max}).",
   "errors.bad_filter_compare": "Pole '{field}': porównanie '{term}' wymaga liczby po operatorze.",
   "errors.bad_filter_compare_name": "Pole '{field}': operatory porównania (>, <, >=, <=) działają tylko z PID-em (liczbą), nie z nazwą procesu - '{term}'.",

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -491,6 +491,29 @@ def test_a_looping_scenario_runs_to_its_duration_not_to_its_timeline(tmp_path):
           f"({records[-1]['stop_reason']!r})")
 
 
+def test_the_loop_flag_takes_the_derived_ending_away_again(tmp_path):
+    """``--loop`` turns a finite file into an endless one, and it must be read.
+
+    ``_run_session`` does ``scen.loop = scen.loop or cfg["loop"]`` BEFORE the end
+    is planned, so a file that would otherwise stop the run must stop stopping it
+    the moment the flag is passed. Easy to get wrong by reading the file's own
+    ``loop`` instead of the effective one, and the failure would be a run that
+    ends while the user asked for it to repeat.
+    """
+    import pytest
+
+    scen = _scenario_file(tmp_path, "finite.json", {"loop": False, "steps": [
+        {"at": 0, "settings": {"loss": 5}},
+        {"at": 0.2, "settings": {"loss": 50}}]})
+    out, err = io.StringIO(), io.StringIO()
+    with pytest.raises(_NeverEnded):
+        run_cli(["--simulate", "--scenario", scen, "--loop", "--interval", "1"],
+                sleep=_budgeted_sleep(budget=12), out=out, err=err)
+    check("scenario: --loop takes the derived ending away",
+          "will not stop the run on its own" in err.getvalue(),
+          f"({err.getvalue()!r})")
+
+
 def test_a_scenario_that_cannot_end_the_run_says_so_up_front(tmp_path):
     """Half the fix for the hang is honesty about the half that still hangs.
 
@@ -696,6 +719,42 @@ def test_dry_run_validates_without_starting_anything():
 
     code, _, _ = cli(["--dry-run", "--dst-ip", "10.0.0.1-2001:db8::1"])
     check("--dry-run: an invalid config still fails", code == exitcodes.CONFIG)
+
+
+def test_dry_run_catches_a_misspelled_setting_in_a_config_file(tmp_path):
+    """The preflight's whole job: find out whether the next command will work.
+
+    MEASURED before: ``{"loss": 10, "latancy": 300}`` passed --dry-run with
+    "Configuration is valid" and exit 0, and the real run then went out with
+    latency 0 - a green pipeline that impaired less than it was told to.
+    """
+    path = tmp_path / "typo.json"
+    path.write_text(json.dumps({"loss": 10, "latancy": 300}), encoding="utf-8")
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(["--dry-run", "--config", str(path)], out=out, err=err)
+    check("preflight: a typo in the config file is CONFIG(3)",
+          code == exitcodes.CONFIG, f"(code={code})")
+    check("preflight: and the message names the key",
+          "latancy" in err.getvalue(), f"({err.getvalue()!r})")
+    check("preflight: a failed check writes nothing to the data channel",
+          not out.getvalue().strip(), f"({out.getvalue()!r})")
+
+
+def test_dry_run_says_what_it_did_not_check():
+    """It validates the CONFIGURATION; it is documented as answering more.
+
+    MEASURED: with ``is_admin()`` false, --dry-run returns 0 and says
+    "Configuration is valid" while the very next real run exits PERMISSION(7).
+    Widening the check would break validating a config on a build box and running
+    it elsewhere, so the honest fix is the sentence: say which half was checked
+    and name the command that does the other half.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(["--dry-run", "--loss", "10"], out=out, err=err)
+    check("preflight: a good config is still OK", code == exitcodes.OK,
+          f"(code={code})")
+    check("preflight: the success line points at --doctor for the environment",
+          "--doctor" in err.getvalue(), f"({err.getvalue()!r})")
 
 
 def test_print_config_dumps_the_effective_settings():

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -514,6 +514,43 @@ def test_the_loop_flag_takes_the_derived_ending_away_again(tmp_path):
           f"({err.getvalue()!r})")
 
 
+def test_an_engine_that_cannot_report_the_scenario_end_says_so(tmp_path):
+    """``engine=`` is a public seam, so the double may predate this feature.
+
+    Falling back to the old behaviour is right - the alternative is crashing on
+    somebody's test harness - but falling back QUIETLY would restore the hang
+    with nothing to explain it. The code claims it reports the fallback; this is
+    that claim being checked rather than believed.
+
+    The reason has to be the RIGHT one, too. The first version of this branch
+    fell through to the shared warning and told the user the scenario "has a
+    single step, so there is no timeline" - about a two-step file with a
+    perfectly good timeline. True-sounding prose next to correct code is the
+    failure this project spends the most effort on, and a test that only asserted
+    "some warning appeared" walked straight past it.
+    """
+    import pytest
+
+    from beantester.engine import BeanEngine
+
+    class _OlderDouble(BeanEngine):
+        scenario_finished = None          # an engine from before this existed
+
+    scen = _scenario_file(tmp_path, "finite.json", {"loop": False, "steps": [
+        {"at": 0, "settings": {"loss": 5}},
+        {"at": 0.2, "settings": {"loss": 50}}]})
+    out, err = io.StringIO(), io.StringIO()
+    with pytest.raises(_NeverEnded):
+        run_cli(["--simulate", "--scenario", scen, "--interval", "1"],
+                sleep=_budgeted_sleep(budget=12), engine=_OlderDouble(),
+                out=out, err=err)
+    log = err.getvalue()
+    check("scenario: an engine that cannot answer falls back to the old ending",
+          "cannot report when a scenario ends" in log, f"({log!r})")
+    check("scenario: and the reason given is that one, not a made-up one",
+          "single step" not in log and "it repeats" not in log, f"({log!r})")
+
+
 def test_a_scenario_that_cannot_end_the_run_says_so_up_front(tmp_path):
     """Half the fix for the hang is honesty about the half that still hangs.
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -11,6 +11,7 @@ timing tests run in microseconds instead of seconds.
 import io
 import json
 import os
+import time
 
 from beantester import cli as cli_module
 from beantester import exitcodes
@@ -373,6 +374,221 @@ def test_exit_code_runtime_without_pydivert():
     # branch was unreachable and the user never learned it was, say, [WinError 5].
     check("exit: and it says WHY, not just that something failed",
           "WinDivert could not be opened" in err.getvalue(), f"({err.getvalue()!r})")
+
+
+class _NeverEnded(BaseException):
+    """The report loop outlived its budget: this run does not end on its own.
+
+    ``BaseException``, not ``Exception``, and for a reason worth keeping: the
+    session now catches ``Exception`` to turn an unforeseen fault into a coded
+    exit (see the fault tests below), which swallowed this signal and made the
+    budget look like a clean RUNTIME. Cancellation-shaped exceptions have to
+    travel the way ``KeyboardInterrupt`` does - straight out.
+    """
+
+
+def _budgeted_sleep(budget=100, nap=0.05):
+    """A real sleep that turns "this run never ends" into a NAMED failure.
+
+    The scenario runner lives on its own thread and reads the wall clock, so the
+    ``FakeClock`` used elsewhere in this file cannot drive it. Real time it is -
+    but the regression under test is an INFINITE run, and a test that hangs
+    reports nothing. Raising ``_NeverEnded`` makes "it never ended" an outcome a
+    test can assert in either direction: a failure where the run should stop, and
+    an expectation where it genuinely cannot.
+    """
+    calls = [0]
+
+    def sleep(seconds):
+        calls[0] += 1
+        if calls[0] > budget:
+            raise _NeverEnded(f"{budget} report-loop naps and still going")
+        time.sleep(min(seconds, nap))
+    return sleep
+
+
+def _scenario_file(tmp_path, name, payload):
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def test_a_finished_scenario_ends_the_run_even_without_a_duration(tmp_path):
+    """Regression: it printed "Scenario finished." and then ran forever.
+
+    MEASURED 2026-08-01 before the fix: a two-step, non-looping scenario with no
+    --duration was still reporting samples when a hard timeout killed it at 12 s
+    (exit 124 - a code from `timeout`, not from this tool). In CI that is a job
+    that hangs to its timeout, with no summary record and, on a real run, with
+    the driver still loaded.
+    """
+    scen = _scenario_file(tmp_path, "two-steps.json", {"loop": False, "steps": [
+        {"at": 0, "settings": {"loss": 5}},
+        {"at": 0.2, "settings": {"loss": 50}}]})
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(["--simulate", "--scenario", scen, "--interval", "1",
+                    "--format", "json"],
+                   sleep=_budgeted_sleep(), out=out, err=err)
+    records = [json.loads(l) for l in out.getvalue().splitlines() if l.strip()]
+    check("scenario: a finished timeline ends the run", code == exitcodes.OK,
+          f"(code={code})")
+    check("scenario: the last record is the summary",
+          records and records[-1]["event"] == "summary",
+          f"({[r['event'] for r in records]})")
+    check("scenario: and it says WHY the run ended",
+          records[-1]["stop_reason"] == "scenario_done",
+          f"({records[-1]['stop_reason']!r})")
+
+
+def test_an_explicit_duration_still_wins_over_the_scenario(tmp_path):
+    """--duration is the user speaking; a derived end must never override it."""
+    scen = _scenario_file(tmp_path, "long.json", {"loop": False, "steps": [
+        {"at": 0, "settings": {"loss": 5}},
+        {"at": 30, "settings": {"loss": 50}}]})
+    out, err = io.StringIO(), io.StringIO()
+    code = run_cli(["--simulate", "--scenario", scen, "--duration", "0.3",
+                    "--interval", "1", "--format", "json"],
+                   sleep=_budgeted_sleep(), out=out, err=err)
+    records = [json.loads(l) for l in out.getvalue().splitlines() if l.strip()]
+    check("scenario: --duration wins", code == exitcodes.OK, f"(code={code})")
+    check("scenario: and the reason is the deadline, not the timeline",
+          records[-1]["stop_reason"] == "duration",
+          f"({records[-1]['stop_reason']!r})")
+
+
+def test_a_scenario_with_no_timeline_does_not_cut_the_run_short(tmp_path):
+    """A one-step scenario is settings, not a timeline - it must not end the run.
+
+    Degenerate but legal input: ``Scenario.duration`` is the ``at`` of the last
+    step, so a single step at 0 has duration 0 and the runner reports finished
+    within ~0.1 s. Ending the session there would turn "apply these settings"
+    into a run that exits immediately - a new bug in place of the old one.
+    """
+    scen = _scenario_file(tmp_path, "one-step.json", {"loop": False, "steps": [
+        {"at": 0, "settings": {"loss": 5}}]})
+    out, err = io.StringIO(), io.StringIO()
+    run_cli(["--simulate", "--scenario", scen, "--duration", "0.4",
+             "--interval", "1", "--format", "json"],
+            sleep=_budgeted_sleep(), out=out, err=err)
+    records = [json.loads(l) for l in out.getvalue().splitlines() if l.strip()]
+    check("scenario: a timeline-less scenario runs to the deadline",
+          records[-1]["stop_reason"] == "duration",
+          f"({records[-1]['stop_reason']!r})")
+
+
+def test_a_looping_scenario_runs_to_its_duration_not_to_its_timeline(tmp_path):
+    """A loop passes its ``duration`` over and over; that must not end the run."""
+    scen = _scenario_file(tmp_path, "looping.json", {"loop": True, "steps": [
+        {"at": 0, "settings": {"loss": 5}},
+        {"at": 0.2, "settings": {"loss": 50}}]})
+    out, err = io.StringIO(), io.StringIO()
+    run_cli(["--simulate", "--scenario", scen, "--duration", "0.5",
+             "--interval", "1", "--format", "json"],
+            sleep=_budgeted_sleep(), out=out, err=err)
+    records = [json.loads(l) for l in out.getvalue().splitlines() if l.strip()]
+    check("scenario: a looping run ends on its deadline",
+          records[-1]["stop_reason"] == "duration",
+          f"({records[-1]['stop_reason']!r})")
+
+
+def test_a_scenario_that_cannot_end_the_run_says_so_up_front(tmp_path):
+    """Half the fix for the hang is honesty about the half that still hangs.
+
+    A looping scenario has no end to derive and a one-step one has no timeline,
+    so with no --duration these runs genuinely go on forever - as they always
+    have. What was missing is anybody saying so: the run printed "Running.
+    Ctrl+C to stop." and left the reader to find out. ``_NeverEnded`` here is the
+    EXPECTED outcome, which is exactly why the warning has to be there.
+    """
+    import pytest
+
+    for name, payload in (
+            ("loops.json", {"loop": True, "steps": [
+                {"at": 0, "settings": {"loss": 5}},
+                {"at": 0.2, "settings": {"loss": 50}}]}),
+            ("single.json", {"loop": False, "steps": [
+                {"at": 0, "settings": {"loss": 5}}]})):
+        scen = _scenario_file(tmp_path, name, payload)
+        out, err = io.StringIO(), io.StringIO()
+        with pytest.raises(_NeverEnded):
+            run_cli(["--simulate", "--scenario", scen, "--interval", "1"],
+                    sleep=_budgeted_sleep(budget=12), out=out, err=err)
+        check(f"scenario: {name} warns that the run will not stop on its own",
+              "will not stop the run on its own" in err.getvalue(),
+              f"({err.getvalue()!r})")
+
+
+# --- an unforeseen fault is still a coded exit ------------------------------- #
+
+
+def test_an_unexpected_session_fault_is_a_coded_exit_with_a_full_summary():
+    """``cli.py`` promises "never a raw traceback"; the session path had no net.
+
+    ``test_cli_fuzz.py`` proves it for the PARSING surface only - every case
+    there runs under --dry-run. MEASURED 2026-08-01: a RuntimeError raised inside
+    the report loop escaped ``run_cli`` entirely - no ``[bean] error:`` line, no
+    summary record, a Python traceback and CPython's exit 1 (which collides with
+    RUNTIME, so a job could not even tell the two apart).
+    """
+    from beantester.engine import BeanEngine
+
+    class _FaultsMidRun(BeanEngine):
+        def __init__(self):
+            super().__init__()
+            self._passes = 0
+
+        def is_running(self):
+            self._passes += 1
+            if self._passes > 3:
+                raise RuntimeError("driver read failed mid-run")
+            return super().is_running()
+
+    out, err = io.StringIO(), io.StringIO()
+    clock = FakeClock()
+    code = run_cli(["--simulate", "--duration", "0", "--interval", "1",
+                    "--format", "json"], sleep=clock.sleep, clock=clock,
+                   engine=_FaultsMidRun(), out=out, err=err)
+    records = [json.loads(l) for l in out.getvalue().splitlines() if l.strip()]
+    check("fault: an unforeseen error is RUNTIME, not a traceback",
+          code == exitcodes.RUNTIME, f"(code={code})")
+    check("fault: it says what happened, on stderr",
+          "driver read failed mid-run" in err.getvalue(), f"({err.getvalue()!r})")
+    check("fault: the data channel still gets a complete summary",
+          records and records[-1]["event"] == "summary"
+          and "counters" in records[-1],
+          f"({[r['event'] for r in records]})")
+    check("fault: and the summary says the run faulted",
+          records[-1]["stop_reason"] == "fault", f"({records[-1]['stop_reason']!r})")
+
+
+def test_a_fault_outside_the_session_is_still_a_coded_exit():
+    """The last-resort backstop: even the summary path itself may not crash out.
+
+    Distinct from the test above: there the session is alive and can still be
+    summarised. Here the failure is in building the result, so there is nothing
+    to report - but a raw traceback and an uncoded exit are still forbidden.
+    """
+    from beantester.engine import BeanEngine
+
+    class _FaultsOnSummary(BeanEngine):
+        def stats_snapshot(self):
+            raise RuntimeError("counters went away")
+
+    out, err = io.StringIO(), io.StringIO()
+    clock = FakeClock()
+    code = run_cli(["--simulate", "--duration", "1", "--interval", "1"],
+                   sleep=clock.sleep, clock=clock, engine=_FaultsOnSummary(),
+                   out=out, err=err)
+    check("fault: a broken summary path is RUNTIME, not a traceback",
+          code == exitcodes.RUNTIME, f"(code={code})")
+    check("fault: and it still names the cause",
+          "counters went away" in err.getvalue(), f"({err.getvalue()!r})")
+    # One fault, two failed steps (the loop, then the report it needed the same
+    # broken call for). Both get a line, and the lines have to be TELLABLE APART
+    # or they read as two separate bugs.
+    lines = [l for l in err.getvalue().splitlines() if "unexpected failure" in l]
+    check("fault: each failed step is described as itself",
+          len(set(lines)) == len(lines), f"({lines})")
 
 
 def test_exit_code_interrupted_and_terminated():

--- a/tests/test_gui_file_actions.py
+++ b/tests/test_gui_file_actions.py
@@ -147,6 +147,37 @@ def test_a_config_of_the_wrong_shape_is_refused_too():
     """)
 
 
+def test_a_misspelled_setting_reaches_the_user_as_a_dialog():
+    """The CLI is not the only reader of a config file.
+
+    Unknown keys became an error so a typo cannot pass a pipeline's --dry-run in
+    silence. The same raise travels through "Load file" here, and the GUI half of
+    that change is worth its own guard: this window is where a hand-written file
+    is most likely to be opened, and the form must survive the refusal with the
+    values the user already had.
+    """
+    run_gui("""
+        import json, os, tempfile
+        from tkinter import filedialog
+        import beantester.gui.dialogs as dialogs
+
+        shown = []
+        dialogs.show_error = lambda parent, title, message: shown.append(message)
+
+        typo = os.path.join(tempfile.mkdtemp(), "typo.json")
+        with open(typo, "w", encoding="utf-8") as f:
+            json.dump({"loss": 10, "latancy": 300}, f)
+        filedialog.askopenfilename = lambda **k: typo
+
+        app.vars["loss"].set("33")
+        app.load_config_file()
+
+        assert shown, "a misspelled setting must be reported, not swallowed"
+        assert "latancy" in shown[0], f"the dialog must name the key: {shown[0]!r}"
+        assert float(app.vars["loss"].get()) == 33.0, "the form must survive it"
+    """)
+
+
 def test_a_repro_report_needs_a_session_before_it_can_be_saved():
     """Without a seed there is nothing to reproduce, so the app says so rather
     than writing a report that cannot be replayed."""

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -143,6 +143,52 @@ def test_a_looping_scenario_keeps_running_past_its_duration(spy_apply):
     check("stop() actually stops the loop", not runner._thread.is_alive())
 
 
+def test_a_completed_timeline_reports_that_it_finished(spy_apply):
+    """The runner is the only thing that knows when a timeline is over.
+
+    The CLI used to have no way to ask: a non-looping scenario ended, the runner
+    thread exited, and the session ran on forever (printing "Scenario finished."
+    while doing exactly that). Deriving the end from ``scenario.duration`` on the
+    caller's side would be a SECOND reader of the same fact - and the tail
+    (``duration + 0.1``) lives here, so the two would drift on the first edit.
+    """
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    check("a runner that has not started has not finished", not runner.finished)
+    runner.start(FakeScenario(loop=False, duration=0.3), base_settings={})
+    _join(runner)
+    check("a completed non-looping timeline reports finished", runner.finished)
+
+
+def test_a_looping_runner_never_reports_finished(spy_apply):
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    runner.start(FakeScenario(loop=True, duration=0.2), base_settings={})
+    try:
+        time.sleep(0.45)                      # well past the 0.2 s duration
+        check("a looping timeline never reports finished", not runner.finished)
+    finally:
+        runner.stop()
+        _join(runner)
+    check("and stopping it is still not 'finished'", not runner.finished)
+
+
+def test_a_runner_the_engine_shut_down_did_not_finish(spy_apply):
+    """"The engine went away" and "the timeline is over" are different endings.
+
+    Both end the runner's loop. Only the second one may end the session: if a
+    dead engine reported ``finished``, the CLI would report a clean
+    ``scenario_done`` for a run that actually faulted.
+    """
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    runner.start(FakeScenario(loop=False, duration=5.0), base_settings={})
+    wait_until(lambda: bool(spy_apply))
+    engine.running = False
+    _join(runner)
+    check("an engine shutdown is not a finished timeline", not runner.finished)
+
+
 def test_the_runner_stops_when_the_engine_stops(spy_apply):
     engine = FakeEngine()
     runner = ScenarioRunner(engine)

--- a/tests/test_settings_config_scenario.py
+++ b/tests/test_settings_config_scenario.py
@@ -3,6 +3,8 @@
 Ported 1:1 from the original monolithic suite; every ``check(...)`` from the
 270-assertion baseline is preserved as a pytest assertion.
 """
+import json
+
 from beantester import BeanEngine
 from fakes import check
 
@@ -92,18 +94,66 @@ def test_apply_settings_bad_schedule_fallback():
     check("apply: remaining settings applied despite the error", abs(sh.core.loss - 0.05) < 1e-9)
 
 
-def test_config_file_unknown_keys_ignored():
-    from beantester import load_config_file, DEFAULT_SETTINGS
-    import tempfile, os as _os, json as _json
-    path = _os.path.join(tempfile.gettempdir(), "ns_cfg_extra.json")
-    with open(path, "w", encoding="utf-8") as f:
-        _json.dump({"loss": 7, "nieznany_klucz": 123, "evil": "x"}, f)
-    loaded = load_config_file(path)
-    _os.remove(path)
-    check("config: unknown keys rejected",
-          "nieznany_klucz" not in loaded and "evil" not in loaded, f"({sorted(loaded)})")
-    check("config: missing keys filled with defaults",
+def test_a_misspelled_setting_in_a_config_file_is_an_error_not_a_silent_default(tmp_path):
+    """A typo used to be dropped in silence - the worst possible outcome.
+
+    ``{"loss": 10, "latancy": 300}`` loaded clean, ``--dry-run`` answered
+    "Configuration is valid", and the run then went out with latency 0. In a
+    pipeline that is a green job that impaired less than it was asked to, and
+    nothing anywhere says so. The scenario loader closed exactly this hole for
+    step keys and settings names; the config file is the same rule one file over,
+    and it is the one people hand-write (README recipe 2 exists to validate them).
+
+    This REPLACES ``test_config_file_unknown_keys_ignored``, which pinned the old
+    behaviour - and whose own check message already called it "rejected" while
+    the code was ignoring it.
+    """
+    from beantester import DEFAULT_SETTINGS, load_config_file
+    path = tmp_path / "typo.json"
+    path.write_text(json.dumps({"loss": 10, "latancy": 300}), encoding="utf-8")
+    raised = ""
+    try:
+        load_config_file(str(path))
+    except ValueError as e:
+        raised = str(e)
+    check("config: a misspelled setting is an error", raised, "(loaded clean)")
+    check("config: the error names the offending key", "latancy" in raised,
+          f"({raised!r})")
+    check("config: and points at the key that was meant", "latency" in raised,
+          f"({raised!r})")
+
+    many = tmp_path / "many.json"
+    many.write_text(json.dumps({"loss": 7, "zzz": 1, "evil": "x"}), encoding="utf-8")
+    raised = ""
+    try:
+        load_config_file(str(many))
+    except ValueError as e:
+        raised = str(e)
+    check("config: every unknown key is listed, not just the first",
+          "zzz" in raised and "evil" in raised, f"({raised!r})")
+
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"loss": 7}), encoding="utf-8")
+    loaded = load_config_file(str(good))
+    check("config: a valid partial file still fills the rest with defaults",
           set(loaded) == set(DEFAULT_SETTINGS) and loaded["loss"] == 7)
+
+
+def test_every_file_this_tool_writes_still_loads(tmp_path):
+    """The strictness above must never reject the tool's own output.
+
+    ``save_config_file`` writes exactly the ``DEFAULT_SETTINGS`` key set, so this
+    holds by construction today - and this test is what keeps it holding when a
+    setting is renamed or dropped, which is the one way the new rule could bite
+    a user who did nothing wrong.
+    """
+    from beantester import (DEFAULT_SETTINGS, load_config_file,
+                            save_config_file)
+    path = str(tmp_path / "written.json")
+    save_config_file(path, dict(DEFAULT_SETTINGS))
+    loaded = load_config_file(path)
+    check("config: a file this tool wrote round-trips",
+          set(loaded) == set(DEFAULT_SETTINGS), f"({sorted(loaded)})")
 
 
 def test_load_missing_files_raise():


### PR DESCRIPTION
Four holes in the CLI as a CI/CD interface, all found by auditing it as one and all measured
before and after. Two chunks plus a tooling change.

## The run never ends

`--scenario` with a file that does not loop and has a timeline used to print "Scenario
finished." and then keep the session going forever - without `--duration` there was nothing
left to stop it.

Measured before: a two-step non-looping scenario was still sampling when a hard timeout killed
it at 12 s (exit **124** - a code from `timeout`, not from this tool). In a pipeline that is a
job that hangs to its own timeout, writes no `summary` record, and on a real run leaves the
WinDivert driver loaded. After: `exit 0, reason=scenario_done`.

The end of a timeline is **asked of the runner** (`ScenarioRunner.finished` ->
`BeanEngine.scenario_finished`) rather than recomputed from `Scenario.duration` in the CLI: the
tail past the last step lives in the runner, and a second reader of the same fact drifts on the
first edit. `finished` means *the timeline ran out* and deliberately not *the runner stopped* -
`stop()` and a dead engine also end that loop, and reporting either as `scenario_done` would
dress a faulted run up as a clean one.

`--duration` still wins wherever it is passed. Two kinds of scenario have no end to derive - a
looping one, and a single-step one (settings, not a timeline) - and those keep running, but now
say so instead of leaving the reader to find out at the job timeout.

## The run dies without a code

An unforeseen exception inside a session escaped `run_cli` as a raw traceback with CPython's
exit `1` - the same number as `RUNTIME`, so a job could not tell an internal bug from a driver
that would not open. `test_cli_fuzz.py` proves the "always an exit code" contract for the
parsing surface only: every case there runs under `--dry-run`, so the session path had no guard.

Two layers, because they can do different amounts for the caller. Inside the session the engine
is still alive and the counters readable, so the run reports `RUNTIME`/`fault` and **still emits
a complete `summary`** instead of a truncated NDJSON file. `run_cli` carries a last-resort
handler for everything outside it. The outer message names its phase, because a fault in
something the summary also needs trips both and two identical lines read as two separate bugs.

## The preflight said yes to questions it had not asked

A misspelled setting in a `--config` file was dropped in silence. Measured: `{"loss": 10,
"latancy": 300}` loaded clean, `--dry-run` answered *"Configuration is valid"* with exit 0, and
the run then went out with latency 0 - a green job that impaired less than it was told to.
Unknown keys are now `CONFIG(3)` naming them, with a suggestion for a single near miss
(`latancy` -> did you mean `latency`). This is the rule scenario files already follow.

The recorded counter-argument was checked first and turned out to be about a different file: the
`ui.json` store keeps unknown keys on purpose so state from a newer version is not discarded.
That holds there - the program writes it and reads it key by key, so a typo cannot happen. The
traffic config file is hand-written, so a typo is the common case. The forward-compatibility
cost is real and is stated in the public changelog rather than glossed over. Nothing this tool
saves is affected, and a test keeps that true.

Second half is prose only. `--dry-run` never asks about Administrator rights or pydivert, so
with `is_admin()` false it returns 0 about a command that then exits `7`. Widening the check
would break validating a config on a build agent and running it elsewhere, so the behaviour
stands and the sentence changed: it now says it checked the settings and not the machine, and
names `--doctor` for the other half. Both READMEs show the pair.

## Tooling

`internal_tools/` added to `.gitignore` - a home for scripts kept between sessions. The
scratchpad does not survive one, and the cost is already on the record: the notes point at a
canonical `bench_ab.py` that has not existed for weeks, so the same A/B rig kept being rebuilt
without its interleaving or its drift canary. `tools/` is untouched and stays tracked, since
`ci.yml` runs `tools/ci_gui_render.py`.

## How this was checked

Guards were written **first** and confirmed red; the three added after the fact were verified by
**mutation** instead, since a test that was never red proves nothing. That paid off immediately:
the injected-engine test surfaced a warning of mine that told a two-step file it "has a single
step, so there is no timeline" - true-sounding prose next to correct code, which a test asserting
only "some warning appeared" would have walked past.

Both original defect measurements were re-run as acceptance tests, not just the suite.

Stability pass on the new cross-thread flag: 4.8M cold reads before any runner exists (all
False, no exceptions), 30 cycles x 8 concurrent readers with no within-runner regression, clean
state after a runner swap and after `stop_scenario`. The first version of that check counted
transitions ACROSS runners and "found" hundreds of regressions - `start()` resets the flag by
design. The script was wrong, not the code.

Consumers were swept with grep rather than assumed: `cli.py` already turns `ValueError` into
`CONFIG(3)` and `gui/app.py` already routes it to a dialog (both free, and the GUI got its own
guard anyway). Profiles do not go through that path.

Full suite green: exit 0, coverage 87.9% against the 83 gate. Documentation was written **before**
the last suite run, not after - for this suite prose is source.

## Needs the owner

`VERSION.txt` is still `0.4.0`. Two breaking changes here need a bump: `stop_reason` gains the
value `scenario_done`, and unknown keys in a config file change a frozen on-disk format.

## Known gaps, deliberately left

- `--dry-run --scenario` still does not say whether the command will terminate. The decision
  lives in `_run_session` and needs an engine; splitting it is its own change.
- `interval` is still not a settings key, so it cannot be carried in a `--config` file.
- The scenario end is detected at the first report-loop wake after the timeline, so up to
  `--interval` late. That bound is the sleep-cap item from the audit, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
