### PR TITLE
chore(release): close 0.4.0 and guard the release itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,20 @@ jobs:
 
       # gh is preinstalled on the runner - no third-party action, uses the job token.
       # A -rc/-beta/-alpha tag publishes as a "Pre-release"; a plain tag as "Latest".
+      #
+      # The body is this version's section of CHANGELOG.md, not --generate-notes.
+      # --generate-notes lists merged pull request titles, so the release page showed
+      # something nobody wrote and never showed the changelog at all - for 0.4.0 that
+      # would have been 43 PR titles. Extracting the section instead means the release
+      # page, a blog post and CHANGELOG.md are one text that cannot drift apart.
+      # The step above has already proved that section exists and is dated.
       - name: Publish the GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          flags=(--title "$TITLE" --generate-notes)
+          python tools/release_notes.py > RELEASE_NOTES.md
+          head -5 RELEASE_NOTES.md
+          flags=(--title "$TITLE" --notes-file RELEASE_NOTES.md)
           if [ "$PRERELEASE" = "true" ]; then flags+=(--prerelease); else flags+=(--latest); fi
           gh release create "$GITHUB_REF_NAME" "$ASSET" SHA256SUMS.txt "${flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,29 @@ jobs:
           else echo "PRERELEASE=false" >> "$GITHUB_ENV"; fi
           echo "TITLE=$ver" >> "$GITHUB_ENV"
 
+      # The step above proves the tag is LABELLED right. This one proves the release
+      # NOTES are, which is a different thing and had no check at all until 0.4.0:
+      # 43 commits landed after the v0.4.0-rc.1 tag and collected under [Unreleased],
+      # three of them BREAKING. Tagging v0.4.0 then would have passed the check above
+      # (the base still matched VERSION.txt) and published a changelog that dated
+      # 0.4.0 weeks earlier and filed three contract breaks as "not released yet".
+      # A pre-release tag is checked the same way: -rc.N ships the same notes.
+      - name: Check the changelogs are closed for this version
+        shell: bash
+        run: |
+          version="$(cat VERSION.txt)"
+          escaped="${version//./\\.}"
+          fail=0
+          for f in CHANGELOG.md CHANGELOG-INTERNAL.md; do
+            grep -qE "^## \[${escaped}\] +- +[0-9]{4}-[0-9]{2}-[0-9]{2}" "$f" \
+              || { echo "$f: no dated '## [$version] - YYYY-MM-DD' section"; fail=1; }
+            open="$(awk '/^## \[Unreleased\]/{u=1;next} /^## \[/{u=0} u && /^- /{n++} END{print n+0}' "$f")"
+            test "$open" = "0" \
+              || { echo "$f: [Unreleased] still holds $open entries - they would ship as $version while reading as unreleased"; fail=1; }
+          done
+          test "$fail" = "0" || exit 1
+          echo "changelogs closed for $version"
+
       # CI (ci.yml) already runs the full test suite on every push to master - i.e. on
       # exactly this commit - so the release does not re-test. It builds, smoke-tests the
       # exe and publishes. (Re-testing here would also need the dev deps and could hit

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -1052,6 +1052,23 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
     `SHA256SUMS.txt` that only that workflow produces.
   No new guard: the fix here is prose accuracy, and the honest mechanical guard for prose does not
   exist (PROJECT_NOTES rule 5). Both READMEs changed together, as convention requires.
+
+- **The user-facing `[0.4.0]` section was rewritten at a third of the length.** Measured before
+  touching it: **817 lines, 92 entries, 11 338 words, median 115 per entry, longest 342**. That is
+  not a release note, it is an internal log wearing one - convention 39 already says CHANGELOG.md
+  carries the EFFECT for a tester and CHANGELOG-INTERNAL.md carries the reasoning, and this file
+  holds **50 729 words** for the same version, so nothing was lost by cutting. Verified that claim
+  before cutting rather than assuming it: eight topics from the longest user-facing entries were
+  checked here first, including two that needed a second look under different names
+  (`effective_loss_pct`, `switch interval` / `THREAD_SWITCH`).
+  After: **346 lines, 67 entries, 4 023 words, median 65, longest 93.** Related fixes merged into
+  one entry each where they shared a subject (the 55 `Fixed` entries became 22), and a **short
+  lead block** was added above the first section - deliberately NOT a `### Highlights`, so it
+  cannot collide with convention 39's section vocabulary or the guards that read it.
+  🔴 **Six entries carrying `**BREAKING:**` were sitting inside `### Changed`** (profiles, the
+  connections table, the repro report's reset count, "Effective loss", the CSV columns, `--gui`).
+  They are now in `### BREAKING`, which is the whole point of that section existing first.
+  Past versions were left alone: `[0.3.0]` and `[0.2.0]` are published release notes.
   The CSV guard **failed on its first run and caught a real gap** - the docs abbreviated
   `delivered_in_scope_bytes_down / ..._up`, so the second name appeared nowhere - and
   `test_cli_docs.py::test_no_stale_app_flags_in_readmes` caught the new prose writing a literal

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -1106,6 +1106,38 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   with one entry (fail), the dated heading stripped of its date (fail), and an empty `[Unreleased]`
   (pass).
 
+- **The GitHub release body is now the changelog section, not `--generate-notes`.** New
+  `tools/release_notes.py` extracts `## [x.y.z]` from `CHANGELOG.md` (stdlib only - the release job
+  installs `requirements.txt` and PyInstaller, nothing else) and `release.yml` passes it as
+  `--notes-file`. `--generate-notes` lists merged PR titles, so the release page showed something
+  nobody wrote and never showed the changelog at all; for 0.4.0 that would have been 43 PR titles.
+  The same command is what you paste into a blog post, so there is no second copy to drift.
+  🔴 **It crashed on `[0.3.0]` and the crash is the interesting part.** `release.yml` runs on
+  **windows-latest**, where stdout still defaults to the ANSI code page, and `[0.3.0]` carries
+  U+25CF - so writing the notes as `str` raised `UnicodeEncodeError` and would have failed the
+  publish step, at the one moment nobody wants a surprise. `0.4.0` is pure ASCII and printed fine,
+  which is exactly why testing only the current version proves nothing. It writes UTF-8 bytes now.
+
+- **A word cap on user-facing changelog entries: `test_no_user_facing_entry_grows_into_an_essay`.**
+  100 words, `CHANGELOG.md` only, mutable sections only - the same scope and the same reasons as the
+  duplicate-heading guard. 100 rather than the ~40 most entries manage, because the few that carry a
+  behaviour change a reader must act on need the room, and splitting those into three entries is
+  worse than one long one. Verified by mutation both ways: a 130-word entry goes red, and `[0.3.0]`
+  keeps a 171-word entry while the suite stays green, which proves the scoping is real rather than
+  accidental.
+
+- **`test_release_notes_extract_every_released_version`** pins the extractor: every version yields a
+  non-empty body, the `## [x.y.z]` heading is dropped (gh sets the title), the body stops before the
+  next version, an unknown version returns `None` and the script exits non-zero with empty stdout.
+  🔴 **Two mutation-methodology traps, both hit here, both producing a false "caught".**
+  (1) `tools/release_notes.py` was UNTRACKED, so `git checkout -- <file>` restored nothing and the
+  four mutants accumulated - only the first was cleanly attributed. Re-run from an explicit
+  known-good copy, **one of the four turned out to SURVIVE**. (2) That survivor survived because the
+  test ran the subprocess only for `VERSION.txt`, which is ASCII, so it never fed the code the
+  character that breaks it. The test now runs the real process for **every** released version and
+  asserts that at least one section carries non-ASCII, so the encoding path cannot quietly stop
+  being exercised. A surviving mutant is information about the TEST, not only about the code.
+
 ### Fixed
 
 - **`SocketWatcher.reconcile()` let a STALE poller snapshot overwrite a newer SOCKET event

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -15,7 +15,7 @@ flags, exit codes, the NDJSON schema, on-disk file formats, or the facade's publ
 a `### BREAKING` section placed FIRST in that version, and each such line is prefixed with
 `**BREAKING:**`. A breaking change also requires a version bump by the owner (convention 34).
 
-## [Unreleased]
+## [0.4.0] - 2026-08-01
 
 ### BREAKING
 
@@ -169,6 +169,260 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   `::test_a_misspelled_scenario_key_is_an_error_not_a_silent_default` - the last one asserts the
   offending key is NAMED in the message, since "invalid scenario" without a name would leave the
   user hunting. Verified by mutation: disabling the two checks turns all three red.
+
+- **BREAKING:** **every preset was re-tuned against measured sources, and five were added**
+  (`presets.py`). The table is now 17 entries. Two systematic errors ran through the old values:
+  - **Latency was dialled as if it were a round trip.** `lat` is added to EVERY packet, and with
+    the default two-way filter that is both the request and the reply, so the delivered ping is
+    `2 x lat`. `presets.satellite` at 600 delivered a **1200 ms** ping against a real GEO figure of
+    683-684 ms (Ookla Q1 2025 medians for HughesNet and Viasat) - it is now 340. Same correction
+    for `lte` 45 -> 30, `roaming` 300 -> 200, `modem56k` 200 -> 100 and `3g` 150 -> 90 (UMTS is
+    100-200 ms RTT, not 300). `jit` deliberately was NOT halved: each packet draws its own
+    uniform, so the spread grows by sqrt(2), not 2 (measured: std 32.7 ms of RTT wobble at
+    `jit=40` against 23.1 ms per packet).
+  - **Three presets carried kbit/s numbers in a KB/s field, so they ran 8x fast.** `dsl` 1536/256
+    is the canonical ADSL pair in kbit/s; `3g` 384/128 is UMTS R99's. `3g` therefore delivered
+    3.1 Mbit/s - HSPA+, not the experience the preset is picked to reproduce. Also corrected:
+    `5g` upload (67 -> 21 Mbit/s; 5G upload runs 50-120% above 4G, not 6x), `weak_wifi` and `cafe`
+    (both were faster than most home DSL), and `terrible`, whose 2.1 Mbit/s made the WORST preset
+    faster than the 3G one.
+  - **New:** `presets.leo` (low-orbit satellite), `presets.distant` (fast pipe, high RTT, no loss -
+    the shape every other high-ping preset misses), `presets.bufferbloat` (idle-good link whose
+    queue is the impairment - the only preset that exercises `buffer`), `presets.metro` (periodic
+    tunnel outages; the only one that takes the link fully down long enough to force a RECONNECT)
+    and `presets.inflight` (satellite in-flight: 750 ms RTT and 7% median loss, measured over 45
+    flight-hours in "Mile High WiFi", WWW 2018).
+  - 🔴 **LEO carries a spike, NOT a flap, and that reversal came from the sources.** The first pass
+    described Starlink's 15 s handover as a link outage and justified the whole `flap` field with
+    it. Measurement says the reconfiguration stops transmission for 100 ms but the packets are
+    **QUEUED, not dropped** ("Making Sense of Constellations"), with the latency peak averaging
+    +74 ms ("A Multifaceted Look at Starlink Performance", WWW 2024). 100 ms out of every 15 000 is
+    0.67% of the timeline, hence `spike_prob=0.7, spike_ms=100` and no flap. Modelling it as loss
+    would have made the tool impair harder than the network it names.
+  - Every value in `PRESETS` now carries either a named source or an explicit **JUDGEMENT** marker
+    in the comment beside it (`weak_wifi`, `cafe`, `roaming`, `terrible` and the flap duty cycles
+    of `metro`/`inflight` are judgement - no canonical measurement exists for them). The source
+    block above `PRESETS` lists what was actually read. Rationale in PROJECT_NOTES rule 5: a number
+    describing the world outside this repo cannot be falsified by any test here, so it needs a
+    citation or an admission.
+  - Tests: `test_cli.py::test_cli_parsing_and_override` and
+    `test_cli_runtime.py::test_print_config_dumps_the_effective_settings` read the expected latency
+    from `PRESETS` instead of a hardcoded `150`. Both are about PRECEDENCE and about a preset
+    REACHING the dump; a copy of the value only ever fails when a preset is retuned.
+  - Names in both language files, and `presets.satellite` renamed to say **geostationary** so the
+    contrast with the new low-orbit entry is visible in the picker (the id is unchanged, so a
+    stored `ui.json` selection and any saved config keep working; `--preset "Satellite link"` and
+    `--preset "Lacze satelitarne"` do not, which is why this line is BREAKING). `presets.dsl` says
+    VDSL for the same reason - the numbers moved and the name should say which DSL it means.
+  - 🔴 **New guard: `test_presets_filters.py::test_every_preset_has_a_name_in_every_language`.**
+    `PRESETS` had no link to the language files at all - `fields.py` has had one since forever
+    (`test_field_registry.py::test_labels_and_tips_exist_in_every_language`), this registry did
+    not. Five presets were added, rendered as raw `presets.leo` in the picker and in `--preset`,
+    and the suite stayed entirely green.
+    The guard reads the language FILES rather than calling `translate()`, and that distinction was
+    found by mutation, not by reasoning: a key missing from Polish **falls back to the English
+    text**, which is not equal to the key, so the first version of this test passed unchanged when
+    the Polish `presets.leo` line was deleted. Re-verified after the fix - the same deletion now
+    fails with `presets: every id has a pl name (['presets.leo'])`. (`test_i18n_coverage` catches
+    the same deletion from the other side, by comparing key SETS; this one catches a preset id that
+    reaches neither file.)
+  - **All seven shipped `scenarios/*.json` recalculated onto the same scale.** They carried the two
+    errors the presets did - rates on the 8x scale (`down: 8000` as an "LTE baseline") and
+    latencies dialled as round trips - so a scenario and a preset described the same network with
+    different numbers. Latencies halved, rates mapped onto KB/s. The pleasant consequence: the
+    DELIVERED ping is now the number the file says, because halving `lat` is exactly what makes
+    `2 x lat` equal the author's intent - `cafe-wifi.json` said 40 and delivered 80; it now says 20
+    and delivers 40. `mobile-lte-to-3g.json` walks `presets.lte` (ping 60, 33.6 Mbit/s) down to
+    `presets.3g`'s bandwidth (0.8 Mbit/s) and back, so the file and the preset finally agree about
+    what "LTE" and "3G" mean. **Jitter was NOT halved**, in scenarios or presets: each packet draws
+    its own uniform, so the spread grows by sqrt(2), not 2, and the existing values remain
+    plausible read as per-packet figures. The shape of every story (the relative progression, the
+    reset points, the loop) is untouched - this was a recalculation, not a redesign.
+    Covered by the existing `test_shipped_scenarios.py`, which drives every file through the real
+    validator.
+  - **The profile picker was a hardcoded `width=24` characters** (`gui/pages/control.py`), against a
+    longest name of 34 (EN) and 35 (PL), so the popdown truncated in silence - ttk sizes a combobox
+    popdown from the widget and never from its contents. New `theme.popdown_width(values)` is the
+    other half of `popdown_height`: that one takes rows from how MANY values there are, this takes
+    characters from how LONG they are, capped at `POPDOWN_MAX_CHARS = 44` because a profile name is
+    whatever the user typed and the row also holds two buttons. Applied at build AND in
+    `App._sync_profile_widgets`, since saving a profile is how a long name enters the list.
+    Tests (`test_gui_layout.py`): `::test_the_profile_picker_fits_its_longest_name` and
+    `::test_the_profile_picker_regrows_when_a_long_profile_is_saved`.
+    **What each actually catches, measured rather than assumed.** Mutating ONE path leaves the
+    picker correct, because the other still sets the width - so the fit test only goes red when
+    BOTH are broken, which is the pre-fix state and exactly the reported bug: it fails with
+    `(24, 'Zapchane lacze domowe (bufferbloat)')`. The regrow test is the one that pins the sync
+    path on its own. The first version of the regrow test was also wrong and its own assertion said
+    so: it saved a profile SHORTER than the longest preset and expected the picker to grow
+    (`37 -> 37`), so the name in it is now deliberately longer than any built-in.
+  - New guard `test_readme_guards.py::test_both_readmes_list_every_preset_id`: the `--preset` id
+    list is typed by hand in both READMEs and nothing tied it to `PRESETS` - the same shape as the
+    project-layout guard right above it. Checks BOTH directions, because a renamed-away id leaves a
+    line pointing at a `--preset` value the CLI rejects. Verified by mutation (deleting
+    `presets.leo` from README.md fails with `missing: ['presets.leo']`).
+  - The two tests that pinned the old Polish name kept their POINT rather than being deleted: they
+    exist for the stroke-letter fold (`ł` does not decompose under NFD), so they moved to
+    `"Odlegly serwer (inny kontynent)"`, `"Zapchane lacze domowe (bufferbloat)"` and
+    `"Pociag / metro (tunele)"`. The `STROKE_LETTERS` comment in `presets.py` cited the old name as
+    its example and was updated with them.
+
+- **BREAKING:** **the profile scope grew from 7 fields to 12**, and the shape a profile is stored
+  in is now DERIVED from the field registry instead of a second hand-written table. `spike_prob`,
+  `spike_ms`, `flap_period`, `flap_down` and `buffer` are marked `in_profile=True` in
+  `fields.FIELD_DEFS`; `presets.PRESET_TO_SETTING` is built from `Field.in_profile` +
+  the new `Field.preset_key` (the frozen short keys `lat`/`jit` are now declared by the registry,
+  not translated by a second table). This reverses the "Variant A" decision that deliberately kept
+  a profile to the seven classic preset fields - flapping is PERIODIC and phase-locked to the
+  session start (`BeanCore.decide` step 5), so it is the one impairment that lets a profile
+  describe a link that drops out on a cadence, which no other profile field can express.
+  Consequences worth naming:
+  - `PROFILE_FIELDS` had **no production consumer** before this (only `test_field_registry.py`);
+    what a profile actually stored came from `PRESET_TO_SETTING` in another module, so the two
+    could drift with nothing to notice. `in_profile` is now the only switch.
+  - `preset_to_settings()` is **always complete**: a preset names only the fields it means, and
+    every other profile field comes back at its `DEFAULT_SETTINGS` value. A partial answer would
+    leave the previous profile's flapping on screen after picking a clean link.
+  - The fill is the field's **default, not zero**. `buffer` defaults to 1000 ms and 0 means
+    UNBOUNDED there, so a blanket zero-fill would have quietly reinstated the runaway token bucket
+    (`BeanCore.decide` step 11) on every preset pick. `settings_to_preset()` lost its hardcoded
+    `0` fallback for the same reason.
+  - `buffer` is the only profile field that cannot impair anything on its own: both of its readers
+    sit inside `if rate > 0` (`decide` steps 11 and 12), so with no speed limit it touches no
+    packet. It is in the profile because `down`/`up` are - the buffer is what decides whether that
+    same limit shows up as DELAY or as LOSS.
+  - Visible effect for existing presets: none of the twelve names a buffer, so picking one now sets
+    the buffer to 1000 ms explicitly where it previously left the widget alone.
+  - Tests: `test_field_registry.py::test_the_stored_profile_shape_follows_the_registry` (new - the
+    stored shape covers exactly `PROFILE_FIELDS`, the short keys stay short, every stored field has
+    a default); `test_validators_settings.py::test_a_preset_always_yields_every_profile_field`
+    (new - unnamed fields come back as defaults, not zero and not missing);
+    `test_passthrough.py::PRESET_OFF` is now derived from `IMPAIRMENT_OFF` intersected with the
+    profile scope, so an impairment joining the scope cannot be forgotten there, and `buffer` is
+    correctly excluded (demanding `buffer == 0` of a harmless preset would demand an unbounded
+    buffer). `test_profile_scope_is_derived` updated to the 12 fields.
+  - `presets.py` gained module-level imports of `fields` and `settings`. No cycle: nothing in
+    `settings`'s dependency chain imports `presets` (checked), and `test_layering.py` is green.
+
+- **BREAKING:** **`--preset` applies a preset through the shared mapping** (`cli.py`), instead of
+  the copy of it that hand-wrote the seven classic keys. The GUI has always used
+  `preset_to_settings`, so the two front ends applied different subsets of the same preset name;
+  the only guard, `test_cli.py::test_cli_english`, asserts `latency` and `down` and nothing else.
+  With the profile scope widened this also stopped being a silent difference: the copy indexed
+  `p["corrupt"]` directly, so the first preset naming only the fields it means would have taken the
+  CLI down with a `KeyError` (reproduced against the future `presets.leo` shape before the fix).
+  Documented precedence is unchanged (defaults < file < preset < flags), but a preset now carries
+  five more keys, so `--config f.json --preset presets.3g` resets `buffer`, `spike_*` and `flap_*`
+  to their defaults where it previously left the file's values in place - the same rule that has
+  always applied to `loss` and `down`.
+  Tests: `test_cli.py::test_a_preset_carries_every_profile_field_into_the_settings` (new) drives a
+  PROBE preset whose every profile field is non-default, because run against the twelve real
+  presets the check is vacuous - none of them names a buffer, a spike or a flap, so the old copy
+  left exactly the defaults the shared mapping fills in, and the test would pass against the code
+  it exists to reject. `::test_a_preset_that_names_only_some_fields_does_not_break_the_cli` (new)
+  covers the partial-preset `KeyError`. Both verified by mutation: reverting `cli.py` turns them
+  red with `buffer 1000 != 1007` and `KeyError: 'corrupt'` respectively.
+
+- **`ProfileStore._clean` falls back to each field's DEFAULT, not to zero** (`gui/profiles.py`).
+  `float(values.get(key, 0) or 0)` was correct only while every profile field defaulted to zero.
+  It does not any more: a `profiles.json` written before the scope widened has no `buffer` key, and
+  `buffer = 0` means an UNBOUNDED link buffer, so the old fill would have loaded every profile
+  saved by an earlier version as the runaway token bucket the bounded buffer exists to prevent -
+  silently, on settings the user had already saved. Absence (`null` and `""` included) now takes
+  `presets.PRESET_DEFAULTS[key]`; an explicit `0` in the file stays 0, because that is what "no cap
+  on the queue" looks like when it is meant. The on-disk format therefore needs NO migration and no
+  version field: it stays backward compatible (fewer keys read fine) and forward compatible (an
+  older build ignores keys it does not know, losing only the new fields).
+  Side effect of dropping `or 0`: a falsy non-numeric value (`[]`, `{}`) now drops the profile and
+  reports it via `store.problem`, where it used to load silently as 0. That matches what the module
+  promises - validate every entry, drop what it cannot use, and say so.
+  Tests (all new, `test_release_fixes.py`):
+  `::test_a_profile_from_before_the_wider_scope_loads_with_field_defaults` - a seven-key file loads
+  with its own values, `buffer` at the default and the impairments it never named off; verified by
+  mutation (restoring the blanket zero turns it red with `buffer 0.0`).
+  `::test_an_explicit_zero_buffer_is_not_the_same_as_a_missing_one` - the paired constraint that
+  makes the fallback usable; it is deliberately NOT a regression guard (it survives the mutation,
+  because both paths yield 0 there).
+  `::test_a_profile_round_trips_the_widened_scope` - save and load carry `flap_*`, `spike_*` and
+  `buffer`, through the same `settings_to_preset` call `App.save_profile` makes.
+
+- **BREAKING:** the effective-loss figure is redefined at both ends (audit F4). `gui/pages/stats.py`
+  and `repro.py` computed `100 * drop_loss / seen`. The numerator was the configured Loss alone,
+  ignoring `drop_rate`, `drop_flap`, `drop_block`, `drop_syn`, `drop_mtu`, `drop_nat`, `drop_rst`
+  and `drop_lan`; the denominator was every captured packet, including traffic outside the
+  targeting scope. Measured on this branch, driven through `BeanEngine` with `FakeDivert`:
+  a 50 KB/s cap with **zero** configured loss went from **0.0% to 99.9%** (`drop_rate=999` of
+  1000 packets), and 50% loss with a third of the traffic in scope went from **17.7% to 53.0%**
+  (`seen=900`, `scoped_seen=300`, `drop_loss=159`). Both reproduce the audit's shape (0.0% against
+  a real 90%, and 16.7% against the target application's 50.1%). `metrics.effective_loss_pct` and
+  `metrics.effective_corruption_pct` therefore change meaning; reports across this line are not
+  comparable. Additive alongside them: `metrics.packets_in_scope`, the `scoped_seen` counter in
+  `st` (so it also appears in NDJSON `summary.counters`), and the CSV column `packets_in_scope`
+  (`App.CSV_COLUMNS`). `_sample_record` in `cli.py` was deliberately left alone - it is a curated
+  subset, and the summary already carries the full counter dict.
+- **New single source in `engine.py`.** `DROP_BY_REASON` (the reason -> counter map, lifted out of
+  the capture loop), `IMPAIRMENT_DROP_KEYS` **derived from it**, `TOOL_DROP_KEYS`, and two pure
+  functions `impairment_loss_pct(stats)` / `corruption_pct(stats)` used by both the GUI and the
+  repro report. They take a stats dict, not an engine, so the GUI computes from the snapshot it
+  already holds and the tests need no session. `repro.py` and `gui/pages/stats.py` import them;
+  no layering rule is touched (`engine` imports neither).
+- **Why the tool's own drops are excluded**, recorded here because it is a judgement call:
+  `README.md` defines the term around a congested link ("that is how a congested link behaves"),
+  and `tips.stat_shutdown` says of queued-at-stop packets "They were not lost in the network".
+  There is also a hard reason: the delay queue holds out-of-scope packets too, so counting
+  `drop_overflow` against a `scoped_seen` denominator could produce a figure above 100%. As
+  defined, every counted drop happened to a packet that is in the denominator, so the result
+  cannot exceed 100%.
+- **Hot path measured, not assumed** (Win11 AMD64, CPython 3.14.6, 150k 1500 B packets through
+  `FakeDivert`, median of 5, benchmarked back to back against a `git worktree` of master).
+  Nothing-impaired path 149.7k -> **157.1k pkt/s** (ranges 145.7-155.4 vs 150.6-163.3: overlapping,
+  so read as no regression while gaining a third counter). 100%-loss path 234.5k ->
+  **267.8k pkt/s** (188.2-238.2 vs 234.1-274.2: the new minimum sits at the old maximum), which is
+  the dict literal no longer being built for every dropped packet.
+- **Two deliberate rearrangements in the capture loop.** (1) `seen`, `bytes_*_total` and
+  `scoped_seen` now share ONE `_slock` acquisition, placed after `decide()` because scope is not
+  knowable before it - fewer acquisitions per packet than before the counter was added. If
+  `decide()` ever raised, the packet would go uncounted where it used to be counted; it does not
+  raise (`Matcher.matches()` is documented never to) and if it did, the capture thread dies and
+  the session fail-stops. (2) `DROP_BY_REASON` at module scope instead of a literal per drop.
+- New tests in `tests/test_engine.py`, all verified by mutation (four mutants, each caught with
+  the pre-fix number): `test_effective_loss_counts_every_impairment_not_just_the_loss_setting`
+  (reverting the numerator gives `pct=0.0` against `drop_rate=999`),
+  `test_effective_loss_measures_the_traffic_that_was_targeted` (reverting the denominator gives
+  `pct=17.7`; never bumping `scoped_seen` gives `scoped_seen=0`), and
+  `test_every_drop_counter_and_drop_reason_is_classified` - a mechanical guard that every
+  `drop_*` counter in `reset_stats()` is in `IMPAIRMENT_DROP_KEYS` or `TOOL_DROP_KEYS`, and that
+  every reason `Decision(True, ...)` can carry in `core.py` routes through `DROP_BY_REASON`. That
+  last one is the guard against F4's actual failure mode: a counter that exists, is correct, and
+  is simply not part of the sum.
+- i18n: new key `tips.eff_loss` in `lang/en.json` + `lang/pl.json` (the session row had **no**
+  tooltip at all, which is part of why the figure could lie unnoticed); `SESSION_ROWS` in
+  `gui/pages/stats.py` now names it. README EN + PL gained a bullet defining the figure; the
+  existing prose about a speed limit causing loss above the set percentage was left untouched -
+  it was already true, and now the number finally agrees with it.
+
+- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
+  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
+  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
+  while `--help` advertised "force the GUI". On real WinDivert that meant
+  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
+  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
+  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
+  to stderr and stdout stays clean.
+- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
+  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
+  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
+  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
+  than widening it.
+- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
+  loss and getting zero without being told is the class of quiet lie this project removes), and
+  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
+  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
+  than declined.
+- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
+  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
+- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
+- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
 
 ### Changed
 
@@ -775,264 +1029,6 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   freezes it into the bundle: letting them drift means CI smoke-tests one artefact and users
   download another.
 
-## [0.4.0] - 2026-07-30
-
-### BREAKING
-
-- **BREAKING:** **every preset was re-tuned against measured sources, and five were added**
-  (`presets.py`). The table is now 17 entries. Two systematic errors ran through the old values:
-  - **Latency was dialled as if it were a round trip.** `lat` is added to EVERY packet, and with
-    the default two-way filter that is both the request and the reply, so the delivered ping is
-    `2 x lat`. `presets.satellite` at 600 delivered a **1200 ms** ping against a real GEO figure of
-    683-684 ms (Ookla Q1 2025 medians for HughesNet and Viasat) - it is now 340. Same correction
-    for `lte` 45 -> 30, `roaming` 300 -> 200, `modem56k` 200 -> 100 and `3g` 150 -> 90 (UMTS is
-    100-200 ms RTT, not 300). `jit` deliberately was NOT halved: each packet draws its own
-    uniform, so the spread grows by sqrt(2), not 2 (measured: std 32.7 ms of RTT wobble at
-    `jit=40` against 23.1 ms per packet).
-  - **Three presets carried kbit/s numbers in a KB/s field, so they ran 8x fast.** `dsl` 1536/256
-    is the canonical ADSL pair in kbit/s; `3g` 384/128 is UMTS R99's. `3g` therefore delivered
-    3.1 Mbit/s - HSPA+, not the experience the preset is picked to reproduce. Also corrected:
-    `5g` upload (67 -> 21 Mbit/s; 5G upload runs 50-120% above 4G, not 6x), `weak_wifi` and `cafe`
-    (both were faster than most home DSL), and `terrible`, whose 2.1 Mbit/s made the WORST preset
-    faster than the 3G one.
-  - **New:** `presets.leo` (low-orbit satellite), `presets.distant` (fast pipe, high RTT, no loss -
-    the shape every other high-ping preset misses), `presets.bufferbloat` (idle-good link whose
-    queue is the impairment - the only preset that exercises `buffer`), `presets.metro` (periodic
-    tunnel outages; the only one that takes the link fully down long enough to force a RECONNECT)
-    and `presets.inflight` (satellite in-flight: 750 ms RTT and 7% median loss, measured over 45
-    flight-hours in "Mile High WiFi", WWW 2018).
-  - 🔴 **LEO carries a spike, NOT a flap, and that reversal came from the sources.** The first pass
-    described Starlink's 15 s handover as a link outage and justified the whole `flap` field with
-    it. Measurement says the reconfiguration stops transmission for 100 ms but the packets are
-    **QUEUED, not dropped** ("Making Sense of Constellations"), with the latency peak averaging
-    +74 ms ("A Multifaceted Look at Starlink Performance", WWW 2024). 100 ms out of every 15 000 is
-    0.67% of the timeline, hence `spike_prob=0.7, spike_ms=100` and no flap. Modelling it as loss
-    would have made the tool impair harder than the network it names.
-  - Every value in `PRESETS` now carries either a named source or an explicit **JUDGEMENT** marker
-    in the comment beside it (`weak_wifi`, `cafe`, `roaming`, `terrible` and the flap duty cycles
-    of `metro`/`inflight` are judgement - no canonical measurement exists for them). The source
-    block above `PRESETS` lists what was actually read. Rationale in PROJECT_NOTES rule 5: a number
-    describing the world outside this repo cannot be falsified by any test here, so it needs a
-    citation or an admission.
-  - Tests: `test_cli.py::test_cli_parsing_and_override` and
-    `test_cli_runtime.py::test_print_config_dumps_the_effective_settings` read the expected latency
-    from `PRESETS` instead of a hardcoded `150`. Both are about PRECEDENCE and about a preset
-    REACHING the dump; a copy of the value only ever fails when a preset is retuned.
-  - Names in both language files, and `presets.satellite` renamed to say **geostationary** so the
-    contrast with the new low-orbit entry is visible in the picker (the id is unchanged, so a
-    stored `ui.json` selection and any saved config keep working; `--preset "Satellite link"` and
-    `--preset "Lacze satelitarne"` do not, which is why this line is BREAKING). `presets.dsl` says
-    VDSL for the same reason - the numbers moved and the name should say which DSL it means.
-  - 🔴 **New guard: `test_presets_filters.py::test_every_preset_has_a_name_in_every_language`.**
-    `PRESETS` had no link to the language files at all - `fields.py` has had one since forever
-    (`test_field_registry.py::test_labels_and_tips_exist_in_every_language`), this registry did
-    not. Five presets were added, rendered as raw `presets.leo` in the picker and in `--preset`,
-    and the suite stayed entirely green.
-    The guard reads the language FILES rather than calling `translate()`, and that distinction was
-    found by mutation, not by reasoning: a key missing from Polish **falls back to the English
-    text**, which is not equal to the key, so the first version of this test passed unchanged when
-    the Polish `presets.leo` line was deleted. Re-verified after the fix - the same deletion now
-    fails with `presets: every id has a pl name (['presets.leo'])`. (`test_i18n_coverage` catches
-    the same deletion from the other side, by comparing key SETS; this one catches a preset id that
-    reaches neither file.)
-  - **All seven shipped `scenarios/*.json` recalculated onto the same scale.** They carried the two
-    errors the presets did - rates on the 8x scale (`down: 8000` as an "LTE baseline") and
-    latencies dialled as round trips - so a scenario and a preset described the same network with
-    different numbers. Latencies halved, rates mapped onto KB/s. The pleasant consequence: the
-    DELIVERED ping is now the number the file says, because halving `lat` is exactly what makes
-    `2 x lat` equal the author's intent - `cafe-wifi.json` said 40 and delivered 80; it now says 20
-    and delivers 40. `mobile-lte-to-3g.json` walks `presets.lte` (ping 60, 33.6 Mbit/s) down to
-    `presets.3g`'s bandwidth (0.8 Mbit/s) and back, so the file and the preset finally agree about
-    what "LTE" and "3G" mean. **Jitter was NOT halved**, in scenarios or presets: each packet draws
-    its own uniform, so the spread grows by sqrt(2), not 2, and the existing values remain
-    plausible read as per-packet figures. The shape of every story (the relative progression, the
-    reset points, the loop) is untouched - this was a recalculation, not a redesign.
-    Covered by the existing `test_shipped_scenarios.py`, which drives every file through the real
-    validator.
-  - **The profile picker was a hardcoded `width=24` characters** (`gui/pages/control.py`), against a
-    longest name of 34 (EN) and 35 (PL), so the popdown truncated in silence - ttk sizes a combobox
-    popdown from the widget and never from its contents. New `theme.popdown_width(values)` is the
-    other half of `popdown_height`: that one takes rows from how MANY values there are, this takes
-    characters from how LONG they are, capped at `POPDOWN_MAX_CHARS = 44` because a profile name is
-    whatever the user typed and the row also holds two buttons. Applied at build AND in
-    `App._sync_profile_widgets`, since saving a profile is how a long name enters the list.
-    Tests (`test_gui_layout.py`): `::test_the_profile_picker_fits_its_longest_name` and
-    `::test_the_profile_picker_regrows_when_a_long_profile_is_saved`.
-    **What each actually catches, measured rather than assumed.** Mutating ONE path leaves the
-    picker correct, because the other still sets the width - so the fit test only goes red when
-    BOTH are broken, which is the pre-fix state and exactly the reported bug: it fails with
-    `(24, 'Zapchane lacze domowe (bufferbloat)')`. The regrow test is the one that pins the sync
-    path on its own. The first version of the regrow test was also wrong and its own assertion said
-    so: it saved a profile SHORTER than the longest preset and expected the picker to grow
-    (`37 -> 37`), so the name in it is now deliberately longer than any built-in.
-  - New guard `test_readme_guards.py::test_both_readmes_list_every_preset_id`: the `--preset` id
-    list is typed by hand in both READMEs and nothing tied it to `PRESETS` - the same shape as the
-    project-layout guard right above it. Checks BOTH directions, because a renamed-away id leaves a
-    line pointing at a `--preset` value the CLI rejects. Verified by mutation (deleting
-    `presets.leo` from README.md fails with `missing: ['presets.leo']`).
-  - The two tests that pinned the old Polish name kept their POINT rather than being deleted: they
-    exist for the stroke-letter fold (`ł` does not decompose under NFD), so they moved to
-    `"Odlegly serwer (inny kontynent)"`, `"Zapchane lacze domowe (bufferbloat)"` and
-    `"Pociag / metro (tunele)"`. The `STROKE_LETTERS` comment in `presets.py` cited the old name as
-    its example and was updated with them.
-
-- **BREAKING:** **the profile scope grew from 7 fields to 12**, and the shape a profile is stored
-  in is now DERIVED from the field registry instead of a second hand-written table. `spike_prob`,
-  `spike_ms`, `flap_period`, `flap_down` and `buffer` are marked `in_profile=True` in
-  `fields.FIELD_DEFS`; `presets.PRESET_TO_SETTING` is built from `Field.in_profile` +
-  the new `Field.preset_key` (the frozen short keys `lat`/`jit` are now declared by the registry,
-  not translated by a second table). This reverses the "Variant A" decision that deliberately kept
-  a profile to the seven classic preset fields - flapping is PERIODIC and phase-locked to the
-  session start (`BeanCore.decide` step 5), so it is the one impairment that lets a profile
-  describe a link that drops out on a cadence, which no other profile field can express.
-  Consequences worth naming:
-  - `PROFILE_FIELDS` had **no production consumer** before this (only `test_field_registry.py`);
-    what a profile actually stored came from `PRESET_TO_SETTING` in another module, so the two
-    could drift with nothing to notice. `in_profile` is now the only switch.
-  - `preset_to_settings()` is **always complete**: a preset names only the fields it means, and
-    every other profile field comes back at its `DEFAULT_SETTINGS` value. A partial answer would
-    leave the previous profile's flapping on screen after picking a clean link.
-  - The fill is the field's **default, not zero**. `buffer` defaults to 1000 ms and 0 means
-    UNBOUNDED there, so a blanket zero-fill would have quietly reinstated the runaway token bucket
-    (`BeanCore.decide` step 11) on every preset pick. `settings_to_preset()` lost its hardcoded
-    `0` fallback for the same reason.
-  - `buffer` is the only profile field that cannot impair anything on its own: both of its readers
-    sit inside `if rate > 0` (`decide` steps 11 and 12), so with no speed limit it touches no
-    packet. It is in the profile because `down`/`up` are - the buffer is what decides whether that
-    same limit shows up as DELAY or as LOSS.
-  - Visible effect for existing presets: none of the twelve names a buffer, so picking one now sets
-    the buffer to 1000 ms explicitly where it previously left the widget alone.
-  - Tests: `test_field_registry.py::test_the_stored_profile_shape_follows_the_registry` (new - the
-    stored shape covers exactly `PROFILE_FIELDS`, the short keys stay short, every stored field has
-    a default); `test_validators_settings.py::test_a_preset_always_yields_every_profile_field`
-    (new - unnamed fields come back as defaults, not zero and not missing);
-    `test_passthrough.py::PRESET_OFF` is now derived from `IMPAIRMENT_OFF` intersected with the
-    profile scope, so an impairment joining the scope cannot be forgotten there, and `buffer` is
-    correctly excluded (demanding `buffer == 0` of a harmless preset would demand an unbounded
-    buffer). `test_profile_scope_is_derived` updated to the 12 fields.
-  - `presets.py` gained module-level imports of `fields` and `settings`. No cycle: nothing in
-    `settings`'s dependency chain imports `presets` (checked), and `test_layering.py` is green.
-
-- **BREAKING:** **`--preset` applies a preset through the shared mapping** (`cli.py`), instead of
-  the copy of it that hand-wrote the seven classic keys. The GUI has always used
-  `preset_to_settings`, so the two front ends applied different subsets of the same preset name;
-  the only guard, `test_cli.py::test_cli_english`, asserts `latency` and `down` and nothing else.
-  With the profile scope widened this also stopped being a silent difference: the copy indexed
-  `p["corrupt"]` directly, so the first preset naming only the fields it means would have taken the
-  CLI down with a `KeyError` (reproduced against the future `presets.leo` shape before the fix).
-  Documented precedence is unchanged (defaults < file < preset < flags), but a preset now carries
-  five more keys, so `--config f.json --preset presets.3g` resets `buffer`, `spike_*` and `flap_*`
-  to their defaults where it previously left the file's values in place - the same rule that has
-  always applied to `loss` and `down`.
-  Tests: `test_cli.py::test_a_preset_carries_every_profile_field_into_the_settings` (new) drives a
-  PROBE preset whose every profile field is non-default, because run against the twelve real
-  presets the check is vacuous - none of them names a buffer, a spike or a flap, so the old copy
-  left exactly the defaults the shared mapping fills in, and the test would pass against the code
-  it exists to reject. `::test_a_preset_that_names_only_some_fields_does_not_break_the_cli` (new)
-  covers the partial-preset `KeyError`. Both verified by mutation: reverting `cli.py` turns them
-  red with `buffer 1000 != 1007` and `KeyError: 'corrupt'` respectively.
-
-- **`ProfileStore._clean` falls back to each field's DEFAULT, not to zero** (`gui/profiles.py`).
-  `float(values.get(key, 0) or 0)` was correct only while every profile field defaulted to zero.
-  It does not any more: a `profiles.json` written before the scope widened has no `buffer` key, and
-  `buffer = 0` means an UNBOUNDED link buffer, so the old fill would have loaded every profile
-  saved by an earlier version as the runaway token bucket the bounded buffer exists to prevent -
-  silently, on settings the user had already saved. Absence (`null` and `""` included) now takes
-  `presets.PRESET_DEFAULTS[key]`; an explicit `0` in the file stays 0, because that is what "no cap
-  on the queue" looks like when it is meant. The on-disk format therefore needs NO migration and no
-  version field: it stays backward compatible (fewer keys read fine) and forward compatible (an
-  older build ignores keys it does not know, losing only the new fields).
-  Side effect of dropping `or 0`: a falsy non-numeric value (`[]`, `{}`) now drops the profile and
-  reports it via `store.problem`, where it used to load silently as 0. That matches what the module
-  promises - validate every entry, drop what it cannot use, and say so.
-  Tests (all new, `test_release_fixes.py`):
-  `::test_a_profile_from_before_the_wider_scope_loads_with_field_defaults` - a seven-key file loads
-  with its own values, `buffer` at the default and the impairments it never named off; verified by
-  mutation (restoring the blanket zero turns it red with `buffer 0.0`).
-  `::test_an_explicit_zero_buffer_is_not_the_same_as_a_missing_one` - the paired constraint that
-  makes the fallback usable; it is deliberately NOT a regression guard (it survives the mutation,
-  because both paths yield 0 there).
-  `::test_a_profile_round_trips_the_widened_scope` - save and load carry `flap_*`, `spike_*` and
-  `buffer`, through the same `settings_to_preset` call `App.save_profile` makes.
-
-- **BREAKING:** the effective-loss figure is redefined at both ends (audit F4). `gui/pages/stats.py`
-  and `repro.py` computed `100 * drop_loss / seen`. The numerator was the configured Loss alone,
-  ignoring `drop_rate`, `drop_flap`, `drop_block`, `drop_syn`, `drop_mtu`, `drop_nat`, `drop_rst`
-  and `drop_lan`; the denominator was every captured packet, including traffic outside the
-  targeting scope. Measured on this branch, driven through `BeanEngine` with `FakeDivert`:
-  a 50 KB/s cap with **zero** configured loss went from **0.0% to 99.9%** (`drop_rate=999` of
-  1000 packets), and 50% loss with a third of the traffic in scope went from **17.7% to 53.0%**
-  (`seen=900`, `scoped_seen=300`, `drop_loss=159`). Both reproduce the audit's shape (0.0% against
-  a real 90%, and 16.7% against the target application's 50.1%). `metrics.effective_loss_pct` and
-  `metrics.effective_corruption_pct` therefore change meaning; reports across this line are not
-  comparable. Additive alongside them: `metrics.packets_in_scope`, the `scoped_seen` counter in
-  `st` (so it also appears in NDJSON `summary.counters`), and the CSV column `packets_in_scope`
-  (`App.CSV_COLUMNS`). `_sample_record` in `cli.py` was deliberately left alone - it is a curated
-  subset, and the summary already carries the full counter dict.
-- **New single source in `engine.py`.** `DROP_BY_REASON` (the reason -> counter map, lifted out of
-  the capture loop), `IMPAIRMENT_DROP_KEYS` **derived from it**, `TOOL_DROP_KEYS`, and two pure
-  functions `impairment_loss_pct(stats)` / `corruption_pct(stats)` used by both the GUI and the
-  repro report. They take a stats dict, not an engine, so the GUI computes from the snapshot it
-  already holds and the tests need no session. `repro.py` and `gui/pages/stats.py` import them;
-  no layering rule is touched (`engine` imports neither).
-- **Why the tool's own drops are excluded**, recorded here because it is a judgement call:
-  `README.md` defines the term around a congested link ("that is how a congested link behaves"),
-  and `tips.stat_shutdown` says of queued-at-stop packets "They were not lost in the network".
-  There is also a hard reason: the delay queue holds out-of-scope packets too, so counting
-  `drop_overflow` against a `scoped_seen` denominator could produce a figure above 100%. As
-  defined, every counted drop happened to a packet that is in the denominator, so the result
-  cannot exceed 100%.
-- **Hot path measured, not assumed** (Win11 AMD64, CPython 3.14.6, 150k 1500 B packets through
-  `FakeDivert`, median of 5, benchmarked back to back against a `git worktree` of master).
-  Nothing-impaired path 149.7k -> **157.1k pkt/s** (ranges 145.7-155.4 vs 150.6-163.3: overlapping,
-  so read as no regression while gaining a third counter). 100%-loss path 234.5k ->
-  **267.8k pkt/s** (188.2-238.2 vs 234.1-274.2: the new minimum sits at the old maximum), which is
-  the dict literal no longer being built for every dropped packet.
-- **Two deliberate rearrangements in the capture loop.** (1) `seen`, `bytes_*_total` and
-  `scoped_seen` now share ONE `_slock` acquisition, placed after `decide()` because scope is not
-  knowable before it - fewer acquisitions per packet than before the counter was added. If
-  `decide()` ever raised, the packet would go uncounted where it used to be counted; it does not
-  raise (`Matcher.matches()` is documented never to) and if it did, the capture thread dies and
-  the session fail-stops. (2) `DROP_BY_REASON` at module scope instead of a literal per drop.
-- New tests in `tests/test_engine.py`, all verified by mutation (four mutants, each caught with
-  the pre-fix number): `test_effective_loss_counts_every_impairment_not_just_the_loss_setting`
-  (reverting the numerator gives `pct=0.0` against `drop_rate=999`),
-  `test_effective_loss_measures_the_traffic_that_was_targeted` (reverting the denominator gives
-  `pct=17.7`; never bumping `scoped_seen` gives `scoped_seen=0`), and
-  `test_every_drop_counter_and_drop_reason_is_classified` - a mechanical guard that every
-  `drop_*` counter in `reset_stats()` is in `IMPAIRMENT_DROP_KEYS` or `TOOL_DROP_KEYS`, and that
-  every reason `Decision(True, ...)` can carry in `core.py` routes through `DROP_BY_REASON`. That
-  last one is the guard against F4's actual failure mode: a counter that exists, is correct, and
-  is simply not part of the sum.
-- i18n: new key `tips.eff_loss` in `lang/en.json` + `lang/pl.json` (the session row had **no**
-  tooltip at all, which is part of why the figure could lie unnoticed); `SESSION_ROWS` in
-  `gui/pages/stats.py` now names it. README EN + PL gained a bullet defining the figure; the
-  existing prose about a speed limit causing loss above the set percentage was left untouched -
-  it was already true, and now the number finally agrees with it.
-
-- **BREAKING:** `--gui` combined with any other option now exits `USAGE(2)`. `args.gui` was
-  parsed and then **never read anywhere** - `cli.py::main` routes to the GUI only when argv is
-  empty or exactly `["--gui"]`, so every other combination fell through to a full CLI session
-  while `--help` advertised "force the GUI". On real WinDivert that meant
-  `--gui --loss 30 --duration 600` impaired the machine's network with no window and no STOP
-  control. The guard sits at the top of `run_cli`'s `try` block (before `--license` /
-  `--doctor` / `--cleanup-driver`) and uses the existing `CliError` path, so the message goes
-  to stderr and stdout stays clean.
-- Blast radius checked before the change: nothing in `tests/`, `smoke_gui.py`, `tools/` or the
-  launcher facade passes `--gui`; `test_cli_fuzz.py` builds `FLAGS` from `FIELD_DEFS`, so the
-  fuzzer never generates it; `test_cli_docs.py` compares flag NAMES, not help text. `USAGE` was
-  already in the fuzzer's `ACCEPTABLE` set, so the new outcome fits the CLI contract rather
-  than widening it.
-- Rejected alternatives: opening the GUI and silently dropping the other flags (asking for 30%
-  loss and getting zero without being told is the class of quiet lie this project removes), and
-  opening the GUI with the form PREFILLED from the flags. The second is genuinely nicer and is
-  still open - it needs `gui/app.py`, which is due for decomposition, so it is deferred rather
-  than declined.
-- New test: `tests/test_cli_runtime.py::test_gui_flag_combined_with_settings_is_a_usage_error`
-  - asserts `USAGE(2)`, the reason on stderr, and an empty stdout (the data-channel invariant).
-- Help text and the flag tables in both READMEs now state that the flag is valid on its own.
-- Version bump deliberately NOT taken (convention 34): the owner closes it in `VERSION.txt`.
-
 ### Fixed
 
 - **`SocketWatcher.reconcile()` let a STALE poller snapshot overwrite a newer SOCKET event
@@ -1100,6 +1096,7 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   expiry, the "events always win" over-fix, `collected()` stamping `clock()` instead of `_last`,
   the watchdog call removed, `owner_targeted` returning False) - all nine RED.
 - Four rows added to PROJECT_NOTES "Powierzchnia regresji".
+
 ### Fixed: the last three audit findings (F3, F4, F5)
 
 - **`_FlowTable.keep_for` could only ever RAISE the age window (F3/T5).** The rotation deadline was

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -996,6 +996,29 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   carries a few lines above - complete with the comment "Wait for the promise, not for the flag".
   That test was fixed after CI caught the same shape; this one was never given the same treatment.
 
+- **Three guards on the ACT of releasing, in `tests/test_version_and_release.py`.** The tree was
+  heavily guarded and the release was not: every rule about it lived in prose, and three of them
+  had already been broken in practice (see the `### CI` entry below and the folded `[Unreleased]`
+  block this version opens with).
+  - `::test_version_txt_has_a_dated_section_in_both_changelogs` - VERSION.txt must name a
+    `## [x.y.z] - YYYY-MM-DD` section in both files. Safe to run on every commit because
+    VERSION.txt carries the LAST released version while new entries collect under `[Unreleased]`.
+  - `::test_the_mutable_changelog_sections_have_no_duplicate_headings` - one `### Added` per
+    version, and only convention 39's names. Scoped to `CHANGELOG.md` and to the sections still
+    mutable (`[Unreleased]` and the VERSION.txt one): this file's headings carry information a type
+    vocabulary cannot hold, and `[0.3.0]` is a published release note whose duplicate `### Changed`
+    is not worth rewriting. The duplicates had been merged by hand twice (`61601ad`, `0aaa86a`) and
+    came back both times, because the only structural guard reads exactly one index of the section
+    list.
+  - `::test_ci_and_release_freeze_the_same_python` - `ci.yml`'s `build` job and `release.yml` must
+    freeze the same interpreter. Parsed by line scan, not PyYAML: PyYAML is not in
+    `requirements-dev.txt`, so importing it would make the test an ERROR on a fresh CI checkout.
+  **All three verified by mutation, seven mutants, all caught**: VERSION.txt bumped without its
+  section, the heading stripped of its date, a second `### Added`, a `### Security` outside the
+  vocabulary, `release.yml` drifted to 3.13, the `build` job renamed, and `python-version` turned
+  into a variable. The last two matter most - a guard that silently passes when the file moves
+  under it is not a guard.
+
 ### Docs
 
 - **Three registries gained a documented mirror, and a guard to keep it honest.** The scenario
@@ -1028,6 +1051,21 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   The two PyInstaller jobs must keep the same interpreter as each other, because PyInstaller
   freezes it into the bundle: letting them drift means CI smoke-tests one artefact and users
   download another.
+  **That last sentence is now a test** - `test_ci_and_release_freeze_the_same_python`. It was a
+  true, load-bearing statement with nothing behind it, which in this project means it survives
+  exactly until a session that never read it edits one of the two files.
+
+- **`release.yml` refuses to publish a release whose changelogs are still open.** The existing
+  step proves the tag is LABELLED right (its base equals VERSION.txt). The new one proves the
+  release NOTES are: both changelogs must carry a dated `## [x.y.z] - YYYY-MM-DD` section for
+  VERSION.txt, and `[Unreleased]` must hold no entries.
+  Placed in the workflow rather than in pytest because the second half cannot be always-on - during
+  ordinary development `[Unreleased]` is supposed to have entries - and because the tag push is the
+  one moment the check must not be skippable. An EMPTY `[Unreleased]` heading passes, since that is
+  the normal shape between releases.
+  Exercised against four trees before landing: the current one (pass), an `[Unreleased]` reopened
+  with one entry (fail), the dated heading stripped of its date (fail), and an empty `[Unreleased]`
+  (pass).
 
 ### Fixed
 

--- a/CHANGELOG-INTERNAL.md
+++ b/CHANGELOG-INTERNAL.md
@@ -1030,6 +1030,28 @@ a `### BREAKING` section placed FIRST in that version, and each such line is pre
   `conns.COLUMNS`, checked by i18n LABEL, since the label is what a reader has to find), and
   `::test_both_readmes_list_every_scenario_action_and_shipped_file` (over `ACTIONS`, `STEP_KEYS`,
   `FILE_KEYS` and the actual `scenarios/*.json` set).
+
+- **Four README drifts found by reading the prose the guards do NOT cover.** `test_readme_guards`
+  pins the layout tree, the `decide()` order, the presets, both CSV headers, the Connections
+  columns and the scenario set; `test_cli_docs` pins every flag. What is left is ordinary prose,
+  and that is where all four were:
+  - **An "Enable" checkbox in both READMEs that no longer exists.** Verified before changing it,
+    not assumed: no i18n key for it anywhere in `lang/*.json`, and no section passes `toggle=` in
+    `fields.py` (the `Section.toggle` mechanism survives, unused). Replaced with the case that
+    really happens, `overridden_by` on `down`/`up` under a schedule.
+  - **"Target process ... requires `psutil`" is false on Windows.** Measured by blocking the
+    import with a `MetaPathFinder` and re-running: 310 ports mapped, 37 of 37 names resolved,
+    `make_targeting("claude")` found 99 ports. `psutil` is the off-Windows fallback, and it stays
+    in `requirements.txt` unconditionally. **A first attempt at this probe proved nothing** - it
+    used the removed `find_module` hook, which 3.14 ignores, so `psutil` imported anyway. The
+    probe printed that it had failed, which is the only reason it was not written up as a result.
+  - **The Tests section listed roughly half of `ci.yml`**, omitting the coverage gate, `--doctor`,
+    `--license`, the "driver ships next to the exe" check and, most notably, the **GUI render
+    check on real Tk under Xvfb in both languages** - the one step with no unit-test equivalent.
+  - **Neither README mentioned `release.yml`**, while telling users to verify the
+    `SHA256SUMS.txt` that only that workflow produces.
+  No new guard: the fix here is prose accuracy, and the honest mechanical guard for prose does not
+  exist (PROJECT_NOTES rule 5). Both READMEs changed together, as convention requires.
   The CSV guard **failed on its first run and caught a real gap** - the docs abbreviated
   `delivered_in_scope_bytes_down / ..._up`, so the second name appeared nowhere - and
   `test_cli_docs.py::test_no_stale_app_flags_in_readmes` caught the new prose writing a literal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,820 +5,349 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ## [0.4.0] - 2026-08-01
 
+**The short version.** This release is about numbers you can trust and targeting that catches what
+you aimed at. If you read nothing else:
+
+- **Aiming at a process now catches a connection from its first packet**, TCP and UDP alike.
+  "Drop SYN" combined with a process target previously did nothing at all, and DNS and QUIC walked
+  past untouched.
+- **"Effective loss" was wrong and is now right.** It counts every impairment, over the traffic you
+  aimed at. A session losing 90% of its traffic to a speed limit used to report 0.0%.
+- **Presets and the shipped scenarios were recalculated** against published measurements. Latency
+  was applied twice, and three presets were eight times too fast.
+- **A session moves about 1.3x more packets a second**, and a delay you ask for arrives without the
+  old few-millisecond surcharge.
+- **New: "Capture only the targeted traffic".** On a real run without it, the driver threw away 43%
+  of the traffic you had aimed at before this tool ever saw it.
+- **New: "Show only the targeted traffic"**, five new presets, a "Driver queue wait" reading, and a
+  warning when your target shares a port with another program.
+- **Config and scenario files now reject a typo** instead of ignoring it.
+- Plus a long list of fixes to the counters, the Connections table and session start/stop.
+
+**If you script this tool, read the BREAKING section**: presets, "Effective loss", profiles, the
+statistics CSV, the connections CSV and the reproduction report all changed shape or meaning.
+
 ### BREAKING
 
-- **BREAKING:** **a misspelled setting in a config file is now an error.** `{"loss": 10, "latancy":
-  300}` used to load without a word: `--dry-run` answered *"Configuration is valid"*, exit `0`, and
-  the run then went out with **no latency at all**. In a pipeline that is a green job that impaired
-  less than it was told to, and nothing anywhere says so. An unknown setting is now a `config` (`3`)
-  error naming the key - and where there is an obvious near miss it says so: *"Unknown setting in
-  the config file: latancy. Did you mean 'latency'?"* This is the rule scenario files already
-  follow.
-  **Any file this program saved keeps loading** (`--save-config` writes exactly the settings it
-  knows). The one file that will now be refused is a hand-written one with a name this build does
-  not recognise - including, and this is the cost of the change, a config written by a **newer**
-  version that has a setting this one does not. The message names the key, so removing it is
-  enough.
+- **A misspelled setting in a config file is now an error.** `"latancy": 300` used to load in
+  silence, so `--dry-run` said *"Configuration is valid"* and the run went out with no latency at
+  all. Unknown settings now fail with code `3`, naming the key and suggesting the near miss. Files
+  this tool saved keep loading. A hand-written file with an unknown name will not.
 
-- **BREAKING:** **a scenario that ends now ends the run.** `--scenario` with a file that does not
-  loop and has a timeline (more than one step) used to print "Scenario finished." and then keep
-  the session going forever: without `--duration` there was nothing left to stop it. In a pipeline
-  that is a job that hangs to its own timeout, exits with a code this tool never produced, writes
-  no `summary` record, and leaves the WinDivert driver loaded. Such a run now stops when the
-  scenario does (`stop_reason: "scenario_done"`), and says so at the start: *"No --duration: this
-  run will stop when the scenario ends (about 85s)."*
-  **`--duration` still wins wherever you pass it**, so any command that already had one behaves
-  exactly as before. Two kinds of scenario have no end to derive - a looping one, and a
-  single-step one (which is settings, not a timeline) - and those keep running until you stop
-  them, but now say so instead of leaving you to find out.
+- **A mistake in a scenario file now says so instead of doing nothing.** `"duraton"` used to leave a
+  reset at its default and `"lop"` used to turn looping off, both silently, so the tool looked like
+  it was ignoring your file. Unknown keys, in a step or at the top level, are now an error naming
+  the key. A correct file keeps working.
 
-- **BREAKING:** **the statistics CSV has a new `capture_narrowed` column**, right after `time`.
-  It says whether that row was measured with "Capture only the targeted traffic" in effect - and
-  without it two rows under the same header could count completely different traffic with no way
-  to tell them apart. Unlike the "show only the targeted traffic" switch, which the file sidesteps
-  by carrying both totals, this one changes what `packets_seen` counted at all, so no pair of
-  columns can undo it. **Your existing `bean_network_tester_stats.csv` is renamed with a timestamp
-  and a fresh one started** (the tool already does this whenever the columns change, so rows never
-  misalign under a stale header) - nothing is lost, but a script reading the file by column
-  position needs the offset.
+- **A scenario that ends now ends the run.** A non-looping scenario with a timeline used to print
+  "Scenario finished." and then run forever, which in a pipeline is a job that hangs to its own
+  timeout and writes no `summary`. Such a run now stops with `stop_reason: "scenario_done"` and says
+  so at the start. `--duration` still wins wherever you pass it.
 
-- **BREAKING:** **the old `reset_now` name for a scenario action is gone.** `reset_tcp` does the
-  same thing and is now the only action a scenario step can carry. A scenario file still using
-  `reset_now` will not load, and says which step to fix. The **"Reset TCP now" button is not
-  affected** - it never had anything to do with this name.
+- **The old `reset_now` scenario action is gone.** `reset_tcp` does the same thing and is now the
+  only action. A file still using `reset_now` will not load and says which step to fix. The
+  "Reset TCP now" button is unaffected.
 
-- **BREAKING:** **A mistake in a scenario file now says so instead of doing nothing.** A misspelled
-  key used to be accepted and ignored, which is the worst possible outcome: `"duraton"` quietly left
-  a reset at its 3-second default, `"lop"` quietly turned looping off, and in both cases the tool
-  looked like it was ignoring your file. Unknown keys - in a step and at the top level - are now an
-  error naming the key, the same way an unknown *setting* name has always been. `duration` is
-  validated too: it has to be a number of seconds and it only means something next to an `action`.
-  A file that was correct keeps working; one that was quietly half-working will now tell you where.
+- **The presets were wrong and are now checked against published measurements.** Latency was set as
+  if it were a ping, but it is added in both directions, so "Satellite link" at 600 ms delivered a
+  1200 ms ping. Three presets held kilo**bits** where the field wants kilo**bytes**, making them
+  eight times too fast. **If you scripted `--preset`, your traffic changes.** Ids are unchanged, but
+  `--preset "Satellite link"` is now "Satellite (geostationary)".
 
-- **BREAKING:** **The presets were wrong, and they are now checked against published measurements.**
-  Two mistakes ran through the whole list. Every latency was set as if it were a ping, but the delay
-  is added to each packet in **both** directions - so "Satellite link" at 600 ms was handing you a
-  1200 ms ping, against the ~680 ms a real geostationary link has. And three presets held speeds in
-  kilo**bits** where the field wants kilo**bytes**, which made them eight times too fast: "3G
-  network" delivered 3 Mbit/s, which is not what anybody picks that preset to feel. Both are fixed
-  throughout, and every value now carries a source (or an honest note that no measurement exists,
-  as for "weak Wi-Fi") in `beantester/presets.py`. **If you scripted `--preset`, the traffic you get
-  will change.** Two names changed with them: "Satellite link" is now "Satellite (geostationary)",
-  and "Home DSL" says VDSL. The ids did not change, so saved configs and profiles are unaffected -
-  but `--preset "Satellite link"` no longer resolves.
+- **The shipped scenarios in `scenarios/` were recalculated** the same way, so a scenario and a
+  preset describe the same network with the same numbers. The ping you get is now the number written
+  in the file.
 
-- **BREAKING:** **The shipped scenarios in `scenarios/` were recalculated** the same way, so a
-  scenario and a preset finally describe the same network with the same numbers. A pleasant side
-  effect: the ping you get is now the number written in the file.
+- **"Effective loss" now means what its name says, and your numbers will change.** It used to be the
+  configured Loss percentage over every packet seen, ignoring speed limits, blocking, LAN cut, link
+  outages, resets, dropped SYNs and expired NAT. It now counts every impairment, over the traffic you
+  aimed at. `effective_loss_pct` and `effective_corruption_pct` moved with it, so reports from before
+  and after are not comparable.
 
-- **BREAKING:** **"Duplicated" now counts packets that were actually sent twice, not packets the
-  tool decided to duplicate.** With duplication on and the tool under enough load to fill its
-  internal queue, the copy was quietly thrown away while the counter went up anyway. Measured on a
-  deliberately tiny queue: 40 packets in, **"Duplicated" read 40 while nothing at all reached the
-  wire**. The tile sits next to "Corrupted", which has always counted only the packets it really
-  changed, so this brings the two into line. Reports and NDJSON output from before and after this
-  change are not comparable on that field. Nothing else moved: the same packets are duplicated,
-  and the "Buffer overflow" tile already told you when the queue was the bottleneck.
+- **"Duplicated" counts packets actually sent twice, not packets the tool decided to duplicate.**
+  Under load the copy was thrown away while the counter rose anyway: 40 packets in, "Duplicated"
+  read 40, nothing reached the wire. This matches "Corrupted", which always counted only real
+  changes. Reports from before and after are not comparable on that field.
+
+- **Profiles now remember more of the link:** latency spikes, link outages (flapping) and the buffer,
+  on top of the original seven fields. Outages are why it was worth doing - a profile can finally
+  describe a link that cuts out. Old profiles load exactly as before. Picking a preset now clears
+  all of these, so "Perfect network" really does clear everything, and `--preset` finally does what
+  the window does.
+
+- **The Connections table now shows what arrived AND what was offered.** "down", "up" and "total"
+  held *captured* bytes under headings meaning delivered, so a row could read 5 MB while the
+  application got 0.4 MB. Those three are now delivered, and new **"down seen"** / **"up seen"**
+  hold what was captured. **The connections CSV changed shape**: the three old byte columns are
+  replaced by six `delivered_*` and `captured_*` ones, renamed rather than reused.
+
+- **The reproduction report's "connections reset" counted packets, not connections.** One reset
+  connection could report itself as 50. The report now carries three keys that answer three
+  questions: `connections_reset`, `rst_packets_dropped` and `rst_sent`. The statistics CSV gained a
+  matching `connections_reset` column. Nothing on screen changed.
+
+- **The statistics CSV gained `capture_narrowed` and `packets_in_scope` columns.** The first records
+  whether "Capture only the targeted traffic" was in effect, without which two rows under one header
+  can count completely different traffic. Your existing file is moved aside with a timestamp and a
+  fresh one started, as it already is whenever columns change, so no row misaligns. A script reading
+  by column position needs the new offsets.
+
+- **`--gui` no longer accepts any other option.** `--gui --loss 30 --duration 600` used to open no
+  window and quietly impair in the background, with no STOP button anywhere. It now stops with a
+  usage error (code `2`) and says what to do instead. If a script relied on this, delete `--gui`
+  from it.
 
 ### Added
 
-- **The README documents three things it never did**, in both languages:
-  - **The scenario file format** - the file and step keys, what may go in `settings`, the two
-    actions there are, the 1000-step limit, how looping restarts, and the 0.1 s tick.
-  - **The seven shipped scenarios**, a line each: what each one reproduces and what it is for
-    (which one kills the network mid-request, which one only touches DNS, which one is a one-shot).
-  - **Both CSV exports and all 17 Connections columns.** The two exports behave differently on
-    purpose - the statistics one appends and ignores the "targeted traffic only" switch, the
-    connections one overwrites and follows your search, sorting and that switch - and the
-    connections CSV does not reuse the table's labels, so there is a column-by-column map between
-    them.
+- **Five new presets:** Satellite (low orbit), Distant server (another continent), Congested home
+  link (bufferbloat), Train / metro (tunnels) and In-flight Wi-Fi. Two are worth a note: bufferbloat
+  only bites once you really saturate the link, and Train / metro is the only preset that takes the
+  connection fully down, so your application has to reconnect rather than just slow down.
 
-- **Five new presets**, each for a situation the old list could not describe:
-  - **Satellite (low orbit)** - Starlink-like. Fast and low-ping in the steady state; what marks it
-    out is the reconfiguration every 15 seconds, which briefly halts transmission and turns up as
-    an occasional ping spike rather than as lost packets.
-  - **Distant server (another continent)** - a fast, healthy link that is simply far away
-    (~120 ms of ping). The one that catches code written as if the server were in the next room.
-  - **Congested home link (bufferbloat)** - looks perfect when idle; the queue is the problem. Note
-    that **it only bites once your application really saturates the link** - send a trickle and you
-    will see an ordinary 8/1 Mbit/s link. Saturate the upload and watch ping climb towards two
-    seconds, which is the "the video call dies when somebody starts a backup" case.
-  - **Train / metro (tunnels)** - takes the connection fully down for 3 seconds out of every 30, so
-    your application has to reconnect rather than just slow down. Nothing else in the list does
-    that.
-  - **In-flight Wi-Fi** - the satellite kind: about 750 ms of ping and 7% loss, which is a measured
-    median rather than a worst case.
+- **"Show only the targeted traffic"** (Settings, off by default) points the counters, the chart, the
+  Connections table and the connections CSV at your target alone. It changes what you **see**, never
+  what is captured or impaired. Three things deliberately do not follow it: "Queue overflow",
+  "Dropped at stop" and "Send failed" always cover everything, because they count the tool's own
+  losses. The statistics CSV carries both totals instead. Reports and `--format json` are unchanged.
 
-- **You can now point Statistics, the chart and Connections at your target alone.** Settings gains
-  **"Show only the targeted traffic"** (off by default, so nothing changes unless you ask). With it
-  on, the counter grid, the throughput chart, the Connections table and the connections CSV export
-  all cover just the traffic your process / IP / port targeting selected - useful when the machine
-  is busy and the numbers you care about are buried in everything else. It changes what you **see**,
-  never what is captured and never what is impaired. Three things deliberately do not follow it, and
-  each says so where you would look:
-  - **"Queue overflow", "Dropped at stop" and "Send failed" always cover the full traffic**, because
-    they count packets *this tool* lost - including traffic you never targeted. Hiding those would
-    hide the tool's own damage, which is the opposite of the point.
-  - **The statistics CSV keeps both totals** in separate columns instead of following the switch: it
-    is an append log, and a column that means one thing in some rows and another in the rest cannot
-    be charted.
-  - **The reproduction report and `--format json` are unchanged** - they have always carried both
-    the captured and the in-scope numbers, so a saved run never depends on how the window was set
-    when it was made.
-  The note above the counters and above the Connections table re-words itself to say which of the
-  two you are looking at, and the chart caption names it too - so a screenshot cannot be misread.
+- **"Capture only the targeted traffic"** (`--narrow-filter`) pushes your destination IP and port
+  into WinDivert, so traffic that could never be impaired is not handed over at all. It is a
+  correctness fix, not just a speed one: measured on a real run, without it the driver threw away
+  **43% of the traffic you aimed at** before the tool saw it. It applies at START, and does nothing
+  for a process target, a wildcard or an `re:` pattern - the run says which.
 
-- **A new option lets the driver do the filtering, for when you are testing at high packet rates.**
-  Normally the tool receives every packet on the machine and hands almost all of them straight
-  back - measured on a real run, 1944 packets taken in and none of them even eligible to be
-  impaired. With **"Narrow the driver filter to the target"** (`--narrow-filter`) the destination
-  IP and port are pushed into WinDivert itself, so traffic that could never be impaired is not
-  handed over at all. Worth knowing before you switch it on: it takes effect **when a session
-  starts**, the destination fields are then fixed until you stop, and Statistics and Connections
-  cover only the narrowed traffic. It does nothing for a **process** target (Windows does not offer
-  the tool a process name at that level) and falls back silently-but-loudly to capturing everything
-  if your destination uses a wildcard or a `re:` pattern - the run says which of the two happened.
-  **It turned out to be more than a speed option, and this is the part worth reading twice.**
-  Measured on a real run with other traffic on the machine: without it, the driver was so busy
-  handing over traffic the tool was never going to touch that it **threw away 43% of the traffic
-  you actually aimed at, before the tool could see it** - so the session impaired less than it
-  reported, and worked out its percentages from what survived. With the option on, all of it
-  arrived and nothing was lost. If you test at high packet rates against a specific address or
-  port, this is the setting that makes your numbers mean what they say.
+- **"Driver queue wait (peak)"** in the Session tab shows how long packets waited inside WinDivert
+  before the tool saw them. That is the one delay the tool adds and counted nowhere. It is measured,
+  not estimated. Expect a fraction of a millisecond when idle; above 50 ms the log says so. Blank
+  under `--simulate`.
 
-- **The command line now says when the process you aimed at stops matching, instead of running on
-  in silence.** If your target exits - it crashed, or your test harness restarted it and Windows
-  gave it a new process id - everything from that moment on is left untouched. The run used to
-  carry on and finish green, with the only mention of your target being one line printed at the
-  start. Measured here against a real capture: aiming at a process id and then restarting that
-  program left five out of five of its new connections completely untouched, and nothing in the
-  output said so. The run now says it the moment it notices, and says so again if the target comes
-  back. Worth knowing which form to use: aiming by **name** recovers on its own within about half a
-  second of the restarted program opening its first connection, and only that first connection
-  escapes; aiming by **process id** never recovers, because that id no longer exists. If the
-  program under test restarts, aim by name.
-
-- **Every run with a process target now ends by saying how much of the captured traffic was
-  actually yours** - "In scope: 40 of 500 captured packets" - and calls it out when that number is
-  zero. A run in which your target caught nothing looks exactly like a run in which your
-  application coped, and those are opposite results. The existing `--min-packets` check cannot see
-  this: it catches a traffic filter that matched nothing, which is a different mistake. This is a
-  warning rather than a failure, because aiming at a program that happens to be quiet is a
-  perfectly ordinary thing to do.
-
-- **The session panel now shows how long packets waited inside the driver before the tool saw
-  them.** This is the one delay the tool adds and counted nowhere: it happens in WinDivert's queue,
-  ahead of the tool's own, so a tester measuring latency puts it down to their application or to
-  the network. It is not an estimate - the driver stamps every packet with a capture time, and the
-  tool now reads it 20 times a second. **"Driver queue wait (peak)"** in the Session tab holds the
-  worst one, and it goes into the reproduction report with everything else. On an idle machine
-  expect a fraction of a millisecond (measured here: 0.05-0.16 ms). Above 50 ms the log and the
-  event list say so, at most once every five seconds. It stays blank under `--simulate`, which has
-  no driver to wait in.
-
-- **A session now records the WinDivert queue it is running behind.** WinDivert has its own buffer,
-  ahead of this tool's, and nothing here ever read it - so a packet could sit in the driver for up
-  to two seconds (the default queue time), land on your measured latency, and appear in no counter
-  at all. The three values (length, time, size) are read when a session starts, written to the log,
-  and stored in the reproduction report as `session.driver_queue`, so a report from a machine you
-  do not have in front of you says which queue produced its numbers. Read on this machine:
-  4096 packets / 2000 ms / 4 MiB - and note the size limit binds first for full-size packets,
-  4 MiB / 1500 B = 2796 packets, not 4096. Nothing is changed about how the queue behaves; this is
-  about being able to see it. `--doctor` deliberately does not read them: the values need an open
-  handle, and opening one loads the driver, which would falsify the "windivert driver" line printed
-  in the same report.
+- **A session now records the WinDivert queue it ran behind** (length, time and size) in the log and
+  in the reproduction report, so a report from a machine you do not have in front of you says which
+  queue produced its numbers.
 
 - **The tool now warns when your target shares a port with another program.** Windows lets several
-  programs hold the same local port at once - that is how mDNS, SSDP and DHCP work - and this tool
-  decides what to break from the port number, so on those ports it genuinely cannot tell whose
-  traffic it is looking at. On this machine, four port numbers out of 127 were like that, and one
-  of them (5353, used for local device discovery) had **five** owners at the same time. The
-  consequence is real in both directions: aiming at one program could leave its own traffic on such
-  a port untouched, or sweep three other programs' traffic in with it. Nothing about that changed -
-  it cannot be fixed, because the port number simply does not say who sent the packet - but the
-  tool no longer keeps it to itself. Applying a target now says which port is shared and with whom,
-  so you know that part of the result is a coin toss. Ports that are not shared, which is where
-  your application's own traffic lives, are unaffected.
+  programs hold one local port - that is how mDNS, SSDP and DHCP work - and this tool decides what to
+  break from the port number. On this machine four ports out of 127 were shared, one of them by five
+  programs. Applying a target now names the port and who holds it, so you know that part of the
+  result is a coin toss.
+
+- **The command line says when your target stops matching**, instead of finishing green in silence.
+  Measured: aiming by process id and restarting the program left five out of five new connections
+  untouched with nothing in the output. Aiming by **name** recovers on its own and costs only the
+  first connection. Aiming by **process id** never recovers. If the program under test restarts, aim
+  by name.
+
+- **Every run with a process target ends by saying how much of the captured traffic was yours** -
+  "In scope: 40 of 500 captured packets" - and calls it out when that is zero. A run where your
+  target caught nothing looks exactly like a run where your application coped. It is a warning, not
+  a failure, because a quiet target is perfectly ordinary.
 
 ### Changed
 
-- **The checkbox is now called "Capture only the targeted traffic"** instead of "Narrow the driver
-  filter to the target". The old name described the machinery rather than what you get, and
-  "driver filter" means nothing unless you already know how the tool works. The `--narrow-filter`
-  flag is unchanged.
+- **The checkbox is now called "Capture only the targeted traffic"**, not "Narrow the driver filter
+  to the target". The old name described the machinery. The `--narrow-filter` flag is unchanged, and
+  its tooltip was rewritten to say what it does and when it will not apply.
 
-- **Semicolons are gone from the interface texts and both READMEs.** Twenty-one tooltips and about
-  eighty lines of documentation used them to join sentences, which is not how people write. They
-  are now full stops or commas. Code samples keep theirs, since there a semicolon is syntax.
+- **A session moves about a third more packets a second.** The tool handles packets on two threads,
+  and Python left one waiting up to 5 ms for its turn - that waiting, not the work, was the limit. A
+  session now asks for shorter turns and hands the setting back at STOP. Measured on loopback and a
+  real card: **1.33x to 1.36x, in 24 comparisons out of 24**, at slightly less processor time per
+  packet.
 
-- **The "Narrow the driver filter to the target" tooltip was rewritten.** It explained how the
-  option works rather than what it does, and it left out the part people most need: the option has
-  **no effect at all** if you target a process, or use a wildcard or an `re:` pattern in the
-  destination. It now says what it does, what changes in the Statistics and Connections tabs, and
-  when it will not apply.
-
-- **"Blocking (firewall)" now starts collapsed** on a fresh install, like the other advanced
-  panels. If you have used the tool before, your own collapsed/expanded choices are remembered and
-  nothing moves.
-
-- **"Spike chance" and "Spike size" moved from "Advanced (NAT / connections)" to
-  "Latency (ping)".** A spike is latency - an occasional large one - so it now sits next to the
-  steady value and the jitter around it, instead of among the NAT and connection knobs. Nothing
-  about how it works changed, and neither did its `--spike-prob` / `--spike-ms` flags or its place
-  in a saved profile.
-
-- The Latency and Jitter tooltips now say the thing that was easy to get wrong: **ping rises by
-  about twice the latency you set** (both the request and the reply are delayed), while jitter
-  widens the wobble by about 1.4x rather than doubling it. Both READMEs explain it too.
-
-- **BREAKING:** **Profiles now remember more of the link.** A profile used to store seven things
-  about a connection: loss, corruption, duplication, latency, jitter and the two speed limits. It
-  now also stores the latency spikes, the link outages (flapping) and the buffer. The outages are
-  the reason this was worth doing: they repeat on a fixed cadence, so a profile can finally describe
-  a link that cuts out every so often - a satellite handover, a flaky uplink - which none of the
-  other fields could say. Four things follow from it:
-  - **Profiles you saved with an earlier version load exactly as before.** The fields they never had
-    are simply off, and the buffer keeps its normal 1000 ms instead of quietly becoming unlimited.
-  - **Picking a preset or a profile now sets all of those fields at once.** None of the twelve
-    built-in presets mentions a spike, an outage or a buffer, so those go back to their defaults
-    rather than keeping whatever was left in the form: "Perfect network" now really does clear
-    everything. If you had dialled the buffer yourself, picking a preset resets it to 1000 ms.
-  - **`--preset` on the command line now does the same thing the window does.** It applied only the
-    original seven values, so the same preset name could produce different traffic depending on
-    which one you started it from.
-  - If you open a profile saved by this version in an older build, the new fields are ignored.
-
-- **BREAKING:** **The reproduction report's "connections reset" counted packets, not connections.**
-  It held the number of packets a reset connection swallows while it is held down, which for a
-  30 second cooldown on a busy connection is thousands against a handful of actual resets - one
-  reset connection could report itself as 50. The report now carries the three RST numbers as three
-  keys, because they answer three different questions: `connections_reset` (how many connections
-  were torn down), `rst_packets_dropped` (how much traffic that cost while they were held down) and
-  `rst_sent` (how many RST packets actually reached the network stack). The last two can differ
-  from the first - a connection is held down whether or not an RST could be built for it - and that
-  gap is worth seeing. The statistics CSV gained a `connections_reset` column to match. Nothing on
-  screen changed: the live "RST reset" tile always said "packets" in its tooltip and was right.
-
-- **BREAKING:** **The Connections table now tells you what arrived AND what was offered.** The
-  "down", "up" and "total" columns held the bytes the tool *captured* - under headings the session
-  panel uses for what actually arrived. Those are the same number only while you are impairing
-  nothing: with a speed limit in place a row could read 5 MB received while its application had
-  received 0.4 MB. Those three columns are now the **delivered** bytes, agreeing with "Downloaded
-  (MB)" in the session panel, and two new columns - **"down seen"** and **"up seen"** - hold what
-  was captured. The gap between the pairs is the damage done to that connection, which is the
-  number you were probably trying to read off this table in the first place. Every one of them has
-  a tooltip saying which is which, because the headings alone cannot carry it. The footer sums the
-  delivered columns, and says so. **The connections CSV changed shape**: `download_bytes`,
-  `upload_bytes` and `total_bytes` are replaced by `delivered_down_bytes`, `delivered_up_bytes`,
-  `delivered_total_bytes`, `captured_down_bytes`, `captured_up_bytes` and `captured_total_bytes` -
-  renamed rather than reused, because a column that quietly changes meaning is worse than one that
-  disappears.
-
-- **BREAKING:** **"Effective loss" now means what its name says, and your numbers will change.**
-  It used to be the configured Loss percentage divided by every packet the tool saw, and both
-  halves of that were wrong. It ignored every other way the tool destroys traffic - a speed limit,
-  blocking, LAN cut, a link outage, a connection reset, a dropped SYN, an expired NAT mapping - so
-  a session losing 90% of its traffic to a bandwidth cap reported **0.0%**. And when you targeted
-  one application it still divided by the whole machine's traffic, so impairing that application
-  by 50% showed as **16.7%** while the application itself measured 50.1%. The figure now counts
-  every impairment, over the traffic you aimed at. `effective_loss_pct` and
-  `effective_corruption_pct` in the reproduction report moved the same way, so a report from
-  before this release is not comparable with one from after; the report also gained
-  `packets_in_scope`, and the session's NDJSON summary carries the same count. Packets the tool
-  itself threw away stay out of the figure on purpose: "Buffer overflow" and "Dropped at stop" are
-  the tool failing, not the link behaving badly, and they have their own counters. The number in
-  the session panel now has a tooltip saying exactly this - it had none before, which is part of
-  why it could be wrong for so long without anyone noticing.
-- **BREAKING:** the statistics CSV gained a `packets_in_scope` column. An existing `stats.csv`
-  from an older version is moved aside automatically and a fresh one started, exactly as it
-  already is whenever the columns change, so no row is ever silently misaligned against the
-  wrong header.
-
-- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
-  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
-  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
-  console you may not have been watching. It now stops immediately with a usage error (exit
-  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
-  settings from the command line. If a script of yours relied on the old behaviour, delete
-  `--gui` from it and it behaves exactly as before.
-
-- **A packet you did not ask to change now goes back on the wire exactly as it arrived - and the
-  session moves about 12% more traffic because of it.** The tool used to recompute every packet's
-  checksums before re-injecting it, including packets it had not touched at all. That was wasted
-  work, and it also meant a session with nothing configured did not quite pass traffic through
-  unchanged: modern network cards leave the checksum for the hardware to finish, so recomputing it
-  put different bytes on the wire than the ones that came in. Checksums are now recomputed only
-  when the tool actually edited the packet - which today means corruption - and for the reset (RST)
-  packets it builds itself. Measured comparing both behaviours inside the same session:
-  **1.12x more packets a second, in 8 comparisons out of 8**. Verified over a real network card,
-  not just loopback: 24 MiB of TCP through the tool arrived byte for byte, with a matching SHA-256.
-
-- **A session now moves noticeably more traffic - about a third more packets a second.** The tool
-  handles your packets on two threads: one takes them from the driver, the other puts them back on
-  the wire. Python makes those two take turns, and by default a thread that is ready to work can be
-  left waiting up to 5 milliseconds for its turn. That waiting, not the work itself, was the limit:
-  putting a packet back took 57 microseconds while the same call takes 27 with nothing else in the
-  way. A session now asks Python for shorter turns while it runs, and hands that setting back when
-  it stops. Measured on a real capture, comparing both settings inside the same session, on
-  loopback and over a real network card: **1.33x to 1.36x more packets a second, in 24 comparisons
-  out of 24** - and with slightly *less* processor time per packet, not more. The queue of packets
-  waiting to be re-injected stops backing up, which is what that number looks like from the other
-  side. **Nothing changes in what you configure or see**, and the delay you ask for is delivered
-  just as accurately as before: against a configured 10 ms, packets were late by 0.73 ms before
-  and 0.76 ms after, which is the same number twice.
+- **A packet you did not ask to change goes back on the wire exactly as it arrived**, and the session
+  moves about 12% more traffic for it. Checksums used to be recomputed for every packet, including
+  untouched ones, which also meant a session with nothing configured did not quite pass traffic
+  through unchanged. Measured: **1.12x more packets a second, 8 comparisons out of 8**, and 24 MiB of
+  TCP arrived byte for byte over a real card.
 
 - **Targeting a process no longer competes with the traffic it is measuring.** Working out which
-  connections belong to your target means asking Windows about its sockets, and that used to
-  happen on the same thread that handles your packets - dozens of times a second, because every
-  packet from every *other* application prompted another look. On a busy machine that stole time
-  from the capture itself, which is how a tester ends up measuring the tool instead of their
-  application. The lookup now runs on its own thread. Nothing changes in what you set or see;
-  a freshly opened connection still starts being impaired within tens of milliseconds, and STOP
-  stays immediate even while a lookup is in progress.
+  sockets belong to your target used to happen on the thread handling your packets, dozens of times a
+  second. It now runs on its own thread. A freshly opened connection is still impaired within tens of
+  milliseconds and STOP stays immediate.
+
+- **Semicolons are gone from the interface texts and both READMEs.** Twenty-one tooltips and about
+  eighty lines of documentation used them to join sentences, which is not how people write. Code
+  samples keep theirs, where a semicolon is syntax.
+
+- **"Spike chance" and "Spike size" moved to "Latency (ping)"** from "Advanced (NAT / connections)",
+  because a spike is latency. Nothing about how they work changed, nor their flags, nor their place
+  in a profile.
+
+- **"Blocking (firewall)" starts collapsed** on a fresh install, like the other advanced panels. If
+  you have used the tool before, your own choices are remembered.
+
+- **The Latency and Jitter tooltips say the thing that was easy to get wrong:** ping rises by about
+  twice the latency you set, because both the request and the reply are delayed, while jitter widens
+  the wobble by about 1.4x rather than doubling it. Both READMEs explain it too.
 
 ### Fixed
 
-- **`--dry-run` no longer sounds like it checked more than it did.** It validates the settings; it
-  never asks whether this machine could actually run a capture, so on a box without Administrator
-  rights it answered *"Configuration is valid"* about a command that then exits `7`. Widening the
-  check would have broken a normal habit - validating a config on a build agent and running it
-  somewhere else - so the sentence changed instead: the success line now says it checked the
-  settings and not the machine, and points at `--doctor` for the other half. Both READMEs show the
-  pair.
-- **An unforeseen error during a run is now an exit code, not a stack trace.** The command line
-  promises that every way of ending has its own number - and it kept that promise everywhere
-  except the one place where a session actually runs. An unexpected failure inside the reporting
-  loop escaped as a raw Python traceback with exit code `1`, which is also the code for "the
-  session could not start", so a pipeline could not tell an internal bug from a driver that would
-  not open. Now it is reported as `runtime` (`1`) with a line saying what happened, **and the run
-  still writes its complete `summary` record** - a `--format json` file no longer ends mid-stream.
-  A failure while building the final report (rarer, and it takes the counters with it) says so in
-  its own words, so one fault never reads like two.
-- **The shared-port warning called your own target "another process".** Targeting `chrome` could
-  answer *"other processes have port 5353 open too (Spotify.exe, adb.exe, **chrome.exe**,
-  msedge.exe, svchost.exe)"* - listing the very program you were targeting among the strangers,
-  which reads as targeting being broken. It was not: a program like Chrome runs several processes,
-  and the tool could only see the one that owns the port in the system's table. Those are now
-  marked *"same program as your target"* instead of being listed as somebody else.
-- **...and it offered two outcomes when it already knew which one applied.** The old line said the
-  tool "may break theirs as well, or miss the target's" - but the system's socket table decides
-  that, and the tool reads it. Now it says the one that is true: either *"on this one port their
-  traffic gets broken too"* or *"the target's traffic on this one port will be skipped"*, naming
-  which program holds the port instead.
-- **Shared ports now say what they are.** `5353` on its own reads like a fault. It is mDNS - the
-  protocol programs use to find devices on your network, and it is *meant* to be open in several
-  programs at once. The warning now writes `5353 (mDNS)`, `1900 (SSDP)`, `67 (DHCP)` and so on,
-  taking the names from your own machine's services list. Ports it has no name for stay plain
-  numbers.
+- **Aiming at a process missed the first packet of every new connection.** Measured: 20 fresh
+  connections with "Drop SYN" at 100% produced 20 successful connections and not one dropped SYN, so
+  **"Drop SYN" plus a process target did nothing at all**. The first packet is now checked against
+  the live socket map.
+  **What changes for you:** connections aimed at a process now take longer to open and a minority
+  fail outright, which is what a bad network does. If a test measured "time to first byte" under
+  impairment, expect it to move.
 
-- **The tool kept pausing itself and then warning you about WinDivert.** Every so often - on the
-  first Start, then roughly every 30 seconds, and far more often on a busy machine - it spent up to
-  half a second working out which program owns which connection. While that was going on it stopped
-  picking up packets, so they piled up inside the driver, and then it told you: *"WinDivert held a
-  packet for 105 ms ... the driver's queue is backing up ... narrow the traffic filter."*
-  Nothing was wrong with your filter and nothing was wrong with the driver. The delay was the tool's
-  own, so narrowing the filter could not have helped - and that half second landed on your traffic
-  without showing up in any counter, in a tool whose whole job is to control delay precisely.
-  Looking up those program names now takes about a millisecond instead of several hundred. Measured
-  over a 95-second session with programs constantly starting and stopping: the worst pile-up dropped
-  from 508 ms to 17 ms, and the warning stopped appearing. The process names in the Connections tab
-  are exactly as before. If you do see that warning now, it means what it says.
+- **Aiming at a process did not touch the first packet of a UDP exchange** - and DNS and QUIC take a
+  fresh port every time, so it did not touch them at all. If you tested a game, a video call or a
+  browser over QUIC and the impairment seemed weaker than configured, this is why. Ordinary TCP data
+  is deliberately still not re-checked: measuring showed it would cost throughput for nothing.
+
+- **The live "which app owns this port" map could be dragged backwards by a stale reading**, so a
+  connection was briefly credited to the wrong application. A periodic sweep of the socket table,
+  always a little behind, was applied on top of the live signal from the driver. Measured over 25
+  seconds of ordinary traffic: **919 times**. Readings are now weighed by when they were taken.
+
+- **Targeting could follow a process id after the process was gone**, and Windows hands those numbers
+  out again. A restarted target could come back under a remembered number and **not be impaired**,
+  while an unrelated program inheriting that number **was**. The tool now checks the process is still
+  the same one, and forgets it when it closes its last connection.
+
+- **Three fixes to short-lived and freshly opened connections.** Targeting now follows the system's
+  socket events instead of scanning a few times a second, so a connection that opens and closes
+  between two scans is no longer missed. The Connections table fills in the owning program from the
+  first packet instead of leaving the row blank. And setting a process target no longer makes the
+  first START pause for a second or two.
+
+- **The "impaired?" column now reflects the whole session, not just this instant.** It asked whether
+  the port was in the target *right now*, so a row flipped to "no" the moment its connection closed
+  and a run impairing all of Chrome looked like it caught almost nothing. The column, the row
+  highlight, the sort and the CSV now read one record, so they cannot disagree.
+
+- **The tool kept pausing itself and then blaming WinDivert.** Every so often it spent up to half a
+  second working out which program owns which connection, stopped collecting packets while it did,
+  and then told you the driver's queue was backing up and to narrow your filter. The delay was its
+  own. Measured over 95 seconds with programs constantly starting: the worst pile-up dropped from
+  **508 ms to 17 ms** and the warning stopped appearing.
+
+- **The "driver held a packet" warning described lost accuracy when what you were losing was
+  traffic.** Measured on a deliberately overloaded run: at 138,000 packets a second offered, the tool
+  moved about 14,000 and **91.75% was thrown away by the driver before the tool saw it**, while every
+  drop counter on screen read zero. The warning now says a full driver queue means dropped packets,
+  not just late ones.
 
 - **With "Capture only the targeted traffic" on, the Statistics and Connections tabs said the exact
-  opposite of the truth.** Both kept their usual line - "Counters cover ALL captured traffic" and
-  "All captured connections ... targeting decides what gets impaired, not what gets listed" - even
-  though the driver had been told to hand over nothing but your destination's traffic. The
-  checkbox's own tooltip promised the opposite ("the Statistics and Connections tabs then show only
-  that traffic"), and both READMEs contradicted themselves the same way, so there was no way to
-  tell from the screen which of the two you were looking at. **Both READMEs are corrected too**, and
-  now describe the two scope switches as the different things they are.
-  Both notes now say what the figures in front of you actually cover, including the case where a
-  **process target** is set as well: the tool then captures your destination's traffic from every
-  process and impairs one process's share of it, so the counters cover more than the impairment
-  does - and now they say so. The throughput chart's caption names its traffic too, because that is
-  the picture people screenshot and send on.
-  Hovering a note used to explain the OTHER state: the bubble was attached once and never updated,
-  so it kept describing the wording that had just been replaced. It follows the note now.
+  opposite of the truth**, keeping their "counters cover ALL captured traffic" line while the driver
+  had been told to hand over nothing else. The checkbox tooltip promised the opposite and both
+  READMEs contradicted themselves. Both notes, the chart caption and the READMEs now describe what
+  the figures actually cover, including the case where a process target is set as well.
 
-- **The two "only the targeted traffic" switches now sit in one "Scope" card, and it tells you
-  whether the first one will work.** They differ by a single word - **Capture** only the targeted
-  traffic against **Show** only the targeted traffic - and they used to be in separate panels a few
-  rows apart, so they read as two spellings of the same setting. Only one of them changes what the
-  tool takes in; the other changes what is on screen and can be flipped at any time. They are now
-  next to each other, with a line under them that says, **before you press START**, whether your
-  destination can actually be pushed down into the driver - and when it cannot, which forms do work
-  (a plain address, a list, a range, a CIDR) and which do not (a wildcard, an `re:` pattern, or
-  targeting only a process). While a session is running the line reports what **that session** did,
-  not what a restart would do.
+- **Four fixes to the Scope settings.** The two "only the targeted traffic" switches now sit in one
+  **Scope** card instead of separate panels a few rows apart, with a line that tells you **before
+  START** whether your destination can actually be narrowed. The Settings window scrolls, so no group
+  falls off the bottom. Starting a session logs which of the two outcomes you got. And the Session
+  panel gained a **"Capture"** row, so a saved run says which traffic it counted.
 
-- **The Settings window scrolls, so no group can fall off the bottom.** With the new Scope card
-  there was one panel too many for the window: "Behaviour" rendered as a bare header with nothing
-  under it, and there was no scrollbar and no sign that a whole group of preferences was still down
-  there. The window also opens taller. If yours already has a remembered size, it keeps it - the
-  content is reachable either way now.
+- **Three counters were lying about how much was lost.** "Buffer overflow" and "Dropped at stop"
+  charged for duplicate copies as well as packets, so a run duplicating everything reported nearly
+  twice as many dropped as captured. A connection's "dropped" count ignored packets its own queue
+  threw away. And packets the tool failed to re-inject left the arithmetic entirely - those now have
+  a **"Send failed"** counter, a banner and an event-log entry, throttled so they cannot flood the
+  log.
 
-- **The two Scope checkboxes sit together instead of drifting apart.** A blank line was reserved
-  between them (the space where "locked while a session runs" appears for the capture switch), which
-  pushed a pair you are meant to read together far enough apart to look like two unrelated settings.
-  The explanation lines now sit below both. The red "this destination cannot be narrowed" note is
-  shorter too - it no longer repeats the list of forms that do not work, which the checkbox's own
-  tooltip already spells out.
+- **Three tooltips were telling you things that were not true.** "Dropped" claimed to count link
+  outages, which have had their own counter for a while. "Downloaded (MB)" promised a figure that
+  never appeared. And "Effective loss" read as "never reached the far end" when it measures damage
+  done on this machine - loss out in the network never arrives here, so nothing here can count it.
+  No numbers changed.
 
-- **The window now says whether "Capture only the targeted traffic" actually worked.** The option
-  quietly does nothing when the destination cannot be turned into a driver filter - a wildcard, an
-  `re:` pattern, only a process target, or no destination at all - and since capturing everything
-  is the safe fallback, nothing else about the run looked unusual. The command line has warned
-  about this since the option shipped. The window, the only place the checkbox is visible, said
-  nothing at all, either way. Starting a session now logs which of the two happened.
+- **The delay you set is the delay you get.** Windows rounds up the wait used to hold a packet back,
+  and it was a fixed surcharge rather than a percentage, so it barely showed at 100 ms and swamped
+  small settings. Measured with a plain `ping`: asking for 10 ms used to cost 12.6 ms extra and now
+  costs 1 ms, the same 1 ms as at 50 ms. Jitter below about 15 ms used to vanish into the noise.
 
-- **The Session panel says which traffic was captured.** New "Capture" row: *all traffic the filter
-  passes* or *narrowed to the destination*. Two runs with the same packet count could describe two
-  completely different worlds, and only the command line and the saved reproduction report ever
-  said which - the window never mentioned it anywhere.
+- **Long cut-offs and NAT blackouts now last as long as you set them.** The tool forgets a connection
+  it has not seen for a while, and a forgotten connection looks brand new - so a reset cooldown above
+  about half a minute resumed after roughly 30 seconds however long you asked for, and "NAT mapping
+  expiry" at 30 seconds never blocked a single packet.
 
-- **The throughput chart could be squeezed until it vanished.** On a narrow window the counter grid
-  reflows into more rows, took the height, and left the chart a black sliver under its own heading.
-  The "Live" tab now scrolls, so nothing on it can be pushed out of existence. One trade worth
-  knowing: the chart keeps a fixed height now instead of growing to fill a tall window.
-- **"Close" was cut in half at the bottom of the Settings window.** The button is now reserved
-  before the settings above it, so it is always there whatever the window is holding. The About
-  window had the same construction and was one longer translation away from the same bug.
-- **"Save profile..." opens with the cursor already in the name box.** It used to need a click
-  before you could type.
+- **"NAT mapping expiry" now really cuts the incoming direction.** The packet rejected for "the
+  mapping has expired" was itself counted as activity, so the mapping reopened on the spot: an app
+  that never sent a keep-alive lost about one packet every five seconds and otherwise worked, passing
+  a test it should have failed. Incoming traffic now stays cut until the application sends something.
 
-- **The profile picker cut long names off.** It was a fixed 24 characters wide, so
-  "Congested home link (bufferbloat)" showed up as "Congested home link (bufferb" with nothing on
-  screen saying the name went on - in both languages. It now sizes itself to its longest entry, and
-  regrows when you save a profile with a long name.
+- **"Reset connections" now works where it claimed to.** It no longer fires on a connection that is
+  still opening, where the forged reset carries no acknowledgement number and Windows is entitled to
+  ignore it - measured, the connection hung until its own timeout. And it now really resets **local
+  (loopback) connections**, which previously just went quiet for the cooldown while the tool reported
+  an RST as sent. Connections to other machines were never affected.
 
-- **The live "which app owns this port" map could be dragged backwards by a stale reading, so a
-  connection was briefly credited to the wrong application.** The tool learns who owns a socket
-  two ways: from the driver, the instant a socket opens or closes, and from a periodic sweep of
-  the system's socket table. The sweep is complete but always a little behind - it is taken up to
-  0.3 s before it is used - and it was being applied on top of the live signal, so it could undo
-  what the driver had just reported: put back a port that had already been closed, or name the
-  previous owner of a port that had just changed hands. Measured over 25 seconds of ordinary
-  traffic on a test machine, that happened **919 times**. Each one is a short window (up to about
-  0.4 s) in which the Connections table shows the wrong process for a flow - and, if you are aiming
-  at a process, in which a brand-new UDP exchange or a fresh connection can be judged against the
-  wrong application: either your target's traffic slips through, or somebody else's gets impaired.
-  Readings are now weighed by when they were actually taken, so the older one no longer wins. The
-  sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
-  from a socket event lost under heavy load.
+- **Ping traffic never appeared in the Connections tab**, which claims to list all of them - anything
+  without ports was silently left out. Thirty seconds of pinging left the tab empty while the
+  counters ticked up beside it. Portless traffic is now listed as one row per address with the port
+  cells empty.
 
-- **When the capture could not start, the tool told you the wrong reason.** If the WinDivert handle
-  failed to open - no Administrator rights, a driver blocked or held at a different version by
-  another tool, a filter the driver rejects - the tool went ahead and started the session anyway,
-  then reported `WinDivert handle is not open`. That is a symptom, and it names nothing. The actual
-  reason (for example `[WinError 5] Access is denied`) was written only to a diagnostic file nobody
-  is asked to read. Worse, the *helpful* messages both interfaces already had could never appear:
-  the command line has an error that quotes the real cause, and the window has a dialog with a "run
-  as Administrator" hint - which is exactly what a non-elevated user needed and never saw. Starting
-  now fails immediately, with the reason, and both of those work.
+- **The Connections tab could empty itself instead of dropping its oldest rows.** When many rows
+  carried the same timestamp they all fell on the same side of the "old" estimate, so far more went
+  than intended - in the extreme, everything. It now refuses to drop below the level it is trimming
+  to.
 
-- **The log could read backwards when a session died right after starting.** The "Start. Filter:
-  ..." line was written after the capture had already begun, so a session that failed in its first
-  moments printed the error and the fault *above* its own start line. Anyone reading the log to work
-  out what happened when was reading it out of order. It is now announced first.
+- **When the capture could not start, the tool told you the wrong reason.** A handle that failed to
+  open produced `WinDivert handle is not open` - a symptom naming nothing - while the real cause went
+  to a diagnostic file nobody reads. The helpful messages both interfaces already had, including the
+  window's "run as Administrator" hint, could therefore never appear. Starting now fails immediately,
+  with the reason.
 
-- **Turning NAT expiry off did not fully turn it off.** Switching it on tells the tool to remember
-  every connection for as long as the session lasts - it has to, or an expired mapping would quietly
-  reopen. Switching it back off was supposed to restore the normal "forget idle connections after
-  half a minute" behaviour, and did not: the tool kept every record for the rest of the run and only
-  released them when it ran out of room. Since every "Apply changes" re-sends all your settings, one
-  round trip through the NAT field was enough. Memory only - nothing was impaired differently.
+- **Four ways a session mishandled its own start and stop.** A failed start could leave the tool
+  holding your traffic without impairing it, refusing every later START. Ending a session kept hold
+  of your traffic for a moment while tidying up, so a connection could stall. STOP could take two
+  seconds in two different races. And the log could print a fault above its own "Start" line.
 
-- **The Connections tab could empty itself instead of dropping its oldest rows.** Once the table is
-  full the tool discards roughly the oldest tenth, working from a sampled estimate of "old". If a
-  lot of rows carried the same timestamp, they all fell on the same side of that estimate and far
-  more went than intended - in the extreme, everything. It now refuses to drop below the level it
-  is trimming to, whatever the estimate says.
+- **An unforeseen error during a run is now an exit code, not a stack trace.** A failure inside the
+  reporting loop escaped as a raw traceback with code `1`, which is also "the session could not
+  start", so a pipeline could not tell an internal bug from a driver that would not open. It is now
+  `runtime` (`1`) with a line saying what happened, **and the run still writes its complete
+  `summary`** - a `--format json` file no longer ends mid-stream.
 
-- **Stopping a session could file a crash report for nothing.** If STOP landed inside the
-  half-second housekeeping pass that keeps the socket map fresh, the tool tripped over its own
-  shutdown and wrote an entry into `crashes/`. Nothing was broken - the session stopped correctly
-  and traffic returned to normal - but anyone checking that folder after a run would find a report
-  for an ordinary STOP. It no longer happens.
+- **Three fixes to `--dry-run` and `--doctor` claiming more than they checked.** `--dry-run` said
+  "Configuration is valid" about a command that then exits `7`, so it now says which half it checked
+  and points at `--doctor`. It also reads your `--scenario` file now, which it never opened.
+  `--doctor` no longer calls a driver "not loaded" when Windows simply refused to let it look.
 
-- **Aiming at a process did not touch the first packet of a UDP exchange - and for DNS and QUIC
-  that meant it did not touch them at all.** Working out which connections belong to your target
-  means keeping a set of its ports, rebuilt in the background, and a brand-new port is not in it
-  yet. TCP had a way around this: a connection starts with a SYN, so one packet per connection was
-  checked against the live socket map. UDP has no SYN, so nothing was checked - and the traffic
-  where it matters takes a **fresh port every time**: every DNS query, every QUIC connection. Those
-  went past your target untouched, every one of them. They no longer do. If you have tested a game,
-  a video call or a browser over QUIC and the impairment seemed weaker than you configured, this is
-  why. Ordinary TCP data is deliberately still not re-checked - it does not need to be, and
-  measuring showed it would cost real throughput for nothing.
+- **Three fixes to the shared-port warning.** It listed your own target among the strangers, because
+  a program like Chrome runs several processes. It offered two possible outcomes when the socket
+  table already decides which one applies. And it printed bare numbers, so `5353` read like a fault
+  rather than mDNS. It now says `5353 (mDNS)`, names the program, and states the one outcome that is
+  true.
 
-- **The "the driver held a packet" warning told you about lost accuracy when what you were losing
-  was traffic.** It said the wait lands on the delay you are measuring - true, and not the half
-  that matters. Measured here on a deliberately overloaded run: with 138,000 packets a second
-  offered, the tool moved about 14,000 of them and **91.75% of the traffic was thrown away by the
-  driver before this tool ever saw it** - while every drop counter on screen still read zero,
-  because the tool cannot count what never reaches it. (The same load with the tool switched off
-  lost nothing at all, so that loss is the tool's presence, not the machine.) The warning now says
-  that a full driver queue means dropped packets, not just late ones, and tells you to narrow the
-  traffic filter. The session-start line about the queue says the same. If you have ever run a test
-  through this tool at a high packet rate and trusted the counters, this is the entry to read
-  twice.
+- **Three files could stop the program from starting, and no longer do.** A translation file with a
+  malformed header, a window-layout file with an entry in the wrong shape, and a `--config` file that
+  was valid JSON but not a set of settings - the last one reported the tool as having crashed. Each
+  is now skipped or reported clearly, and the rest of your setup is kept.
 
-- **Aiming at a process missed the first packet of every new connection - and your test results
-  will change because of it.** Working out which connections belong to your target means keeping a
-  set of its ports, and that set is rebuilt in the background. A connection opened a moment ago was
-  not in it yet, so its very first packet was waved through untouched, every time. Measured here:
-  20 fresh connections against a targeted process with "Drop SYN" at 100% produced 20 successful
-  connections and not one dropped SYN. **"Drop SYN" combined with process targeting therefore did
-  nothing at all** - the SYN is by definition the first packet, so it always escaped. The first
-  packet is now checked against the live socket map, so it is caught like any other.
+- **Four smaller interface fixes.** The throughput chart could be squeezed until it vanished on a
+  narrow window (the Live tab now scrolls). "Close" was cut in half at the bottom of the Settings
+  window. The profile picker cut long names off at 24 characters. And "Save profile..." opens with
+  the cursor already in the name box.
 
-  What changes for you: with loss (or blocking, or a link outage) aimed at a process, **connections
-  will now take noticeably longer to open**, because the SYN can be lost and TCP has to retransmit
-  it - and a minority will fail to open at all, which is what a bad network does. Before, every
-  connection opened at full speed and only then started suffering. If a test of yours measured
-  "time to first byte" under impairment, expect it to move.
-
-  Two limits worth knowing, both measured rather than guessed. The tool recognises your target by
-  the connections it currently has open, so **a program that has none open at the moment the tool
-  looks is invisible again**: over 20 fresh connections with "Drop SYN", a program keeping its
-  connections open was caught **19 times out of 20** (only the very first escaped, before it had
-  opened anything), while the same program closing each connection before starting the next was
-  caught **6 times out of 20**. So a browser or an app under test is covered; a script that opens
-  one connection, closes it and pauses will keep slipping through. And a program using UDP has no
-  SYN, so its first packet is not covered by any of this.
-
-- **"Reset connections" no longer fires on a connection that is still opening.** It could not have
-  worked there anyway: the reset packet the tool forges from a connection request carries no
-  acknowledgement number, and Windows is entitled to ignore exactly that - measured, the connection
-  hung until its own timeout instead of being reset. That combination was unreachable before the
-  change above; it would have become the normal case. Resets now fire on established connections,
-  where they were measured to work.
-
-- **"Reset connections" did nothing to local (loopback) connections - it just made them go
-  quiet.** Aim the tool at `127.0.0.1` traffic with resets switched on and the connection was not
-  reset: it stopped carrying anything for the length of the cooldown, so the application sat there
-  until its own timeout expired, while the tool reported an RST as sent. Anything talking to a
-  service on your own machine - a local server, a database, a dev proxy - was affected. It now
-  resets for real, which for a test that expects a broken connection is the difference between
-  "failed as designed" and "hung". Connections to other machines were never affected, and are
-  unchanged: that path was measured working (a connection reset 6.6 s after the tool was pointed
-  at it).
-
-- **A connection's "dropped" count ignored the packets the tool's own queue threw away.** The
-  figure was recorded a step too early - before the packet was even queued - so a session that
-  dropped 5 500 packets to a full delay queue could show `dropped = 0` on the very row it happened
-  to, and packets still waiting when you pressed STOP were never counted against their connection
-  at all. Both now land on the row they belong to.
-
-- **A failed "Export connections CSV" left a stray `.tmp` file next to the real one.** The export
-  writes to a temporary file and renames it, which is what makes it safe to overwrite the previous
-  export - but when the write failed, the half-written temp file stayed on disk. Nothing cleaned
-  it up, and the next export silently overwrote it, so it was litter you could find but not
-  explain. It is now removed on failure, exactly as the profile and config files already do, and a
-  failed export leaves the previous one untouched.
-
-- **STOP could take two seconds if a capture error happened to land at the same moment.** If the
-  capture side failed for its own reason a fraction of a second before you pressed STOP, the two
-  waited on each other until a two-second safety timeout expired. Nothing was lost or stuck - the
-  session did stop - but the button felt broken. The capture side now waits only for a session
-  that is still starting up, never for a stop that is already under way. Related: when two
-  failures land together, the report keeps the first one, which is the actual cause; it used to be
-  overwritten by the follow-up "a worker thread died", which says nothing useful on its own.
+- **Two things left litter behind.** A failed "Export connections CSV" left a stray `.tmp` file next
+  to the real one, and stopping a session could file a crash report in `crashes/` for an ordinary
+  STOP. Neither happens now.
 
 - **Starting a second scenario without stopping the first is no longer possible.** The engine
-  replaced the running scenario with the new one and left the old one running in the background,
-  unreachable: two scenarios then fought over the same settings with nothing on screen to say why.
-  Nothing in the program did this today - it starts one scenario per session - so this is a guard
-  rather than a bug you could have hit.
-
-- **Packets the tool failed to put back on the wire vanished from the numbers.** When re-injecting
-  a packet fails - the connection went down mid-session, the driver refused it - the packet is
-  gone. It had been counted as seen, it was never delivered, and nothing recorded it as lost, so
-  it simply left the arithmetic: a session could show packets climbing while the delivered total
-  stood still, with no counter explaining the gap. Every other way a packet can die here has had a
-  counter for a while; this one only had a line in the log. There is now a **"Send failed"**
-  counter next to "Buffer overflow" and "Dropped at stop", a warning banner when it happens, and
-  an entry in the event log so the reproduction report carries it too. Like the other two, it is
-  the tool failing rather than the link you asked it to simulate, so it stays out of "Effective
-  loss" - but it is in the seen/delivered/dropped arithmetic, where it belongs.
-
-- **A run of send failures no longer floods the log (and freezes the window with it).** The
-  message was written once per failed packet, and the window applies every queued line to the log
-  strip on the interface thread, so a burst of failures could lock up the window on top of losing
-  the packets. It is now written at most once every five seconds, carrying the running count and
-  the last error, exactly like the queue-overflow warning that has worked this way for a while.
-
-- **"Effective loss" now says whose loss it is.** The number counts what this tool broke, and the
-  tooltip said "how much of the traffic you aimed at never arrived" - which reads as "never
-  reached the far end". Those are different things, and the difference shows up the first time you
-  compare the tool against a real run: ping 30 packets, lose one reply out on the network, and the
-  connection row reads 59 packets with zero drops. Both numbers are right - 30 requests went out,
-  29 replies came back, and the tool broke none of them - but nothing on screen said so. The
-  tooltip and both READMEs now spell out that the figure measures damage done on this machine, and
-  that loss happening somewhere out in the network never reaches this machine, so nothing here can
-  count it. No numbers changed.
-
-- **Ping traffic never appeared in the Connections tab, which claims to list all of them.** The
-  note under the tab says "All captured connections" and the README says the same, but anything
-  without ports was silently left out - and ping (ICMP) has none. Thirty seconds of pinging with
-  the "Ping (ICMP)" traffic filter selected left the tab completely empty while the packet
-  counters ticked up beside it, which reads as a broken tool. Portless traffic is now listed as
-  one row per address, with the two port cells left empty. The process column usually stays empty
-  on those rows as well: a ping has no socket to trace back to an application, which is how ICMP
-  works rather than something missing here. In the command line, `--log-conns` prints `-` where
-  such a row has no port.
-
-- **"Buffer overflow" and "Dropped at stop" counted up to twice the packets they lost.** With
-  "Duplicate packets" switched on, the tool puts a second copy of the packet in its delay queue,
-  and both counters were charging for the copy as well as for the packet. A run that duplicated
-  everything reported nearly twice as many dropped as it ever captured, so the "Buffer overflow"
-  tile could show a bigger number than the "Packets" tile right beside it, and the overload
-  warning in the log quoted that inflated figure back at you. Both now count packets that never
-  arrived. A dropped copy is not one of them: your application receives one packet instead of
-  two, and one packet is what it would have received without the tool, so a copy that does not
-  fit no longer counts and no longer raises the overload warning on its own. Runs without
-  duplication are unaffected; figures from earlier runs with duplication are not comparable with
-  these, because the old ones were too high.
-
-- **Two tooltips were telling you things that were not true.** "Dropped" said it also counted
-  link outages - those have had their own counter for a while, so the tooltip was sending you to
-  the wrong number when working out where your packets went. "Downloaded (MB)" promised that
-  hovering would also show how much the app tried to download; nothing of the sort ever appeared.
-  Both now describe what the counter actually holds.
-
-- **Long connection cut-offs and NAT blackouts now last as long as you set them.** Two impairments
-  quietly stopped early, because the tool forgets a connection it has not seen for a while and a
-  forgotten connection looks brand new. "Reset connections" with a cooldown above about half a
-  minute resumed traffic after roughly 30 seconds however long you had asked for - a scenario
-  written as "the connection is down for two minutes" simply did not happen. "NAT mapping expiry"
-  was worse: at a 30 second timeout it never blocked a single packet, because the connection was
-  forgotten just before the incoming traffic arrived. Both now hold for exactly as long as
-  configured - a 120 second cooldown resets every 120 seconds, and an expired NAT mapping stays
-  shut until the application sends something, which is the behaviour the setting describes. The
-  tool's memory limits are unchanged.
-
-- **The delay you set is the delay you get.** Every configured delay used to arrive with several
-  milliseconds of padding on top, because of how Windows rounds up the wait the tool uses to hold
-  a packet back. It was a fixed surcharge rather than a percentage, so it barely showed at 100 ms
-  and swamped the small settings: with the tool asked for 10 ms, a ping measured about 12.6 ms of
-  extra round trip on top of the expected amount, and asking for 1 ms produced roughly seven times
-  that. Simulating a fast LAN, a game server or a VoIP hop is exactly where that hurt. The tool now
-  asks Windows for a fine-grained timer while a session runs, and gives it back at STOP. Measured
-  with a plain `ping`, 40 packets per setting: asking for 10 ms of delay now costs 1 ms more than
-  it should instead of 12.6 ms, and asking for 50 ms costs the same 1 ms more - the surcharge is
-  gone rather than merely smaller. Jitter benefits the same way: variation below about 15 ms used
-  to disappear into the timer's own noise.
-
-- **"NAT mapping expiry" now really cuts the incoming direction, instead of losing one packet
-  every few seconds.** This impairment is there to answer one question: does the application
-  notice its mapping is gone and send something to re-open it? It could not answer that. The
-  packet the tool rejected for "the mapping has expired" was itself counted as activity on that
-  connection, so the mapping came back on the spot and traffic flowed again for another whole
-  timeout - then one more packet was dropped, and so on. With `--nat-timeout 5` an app that never
-  sent a keep-alive lost about one packet every five seconds and otherwise carried on working, so
-  it passed a test it should have failed. Now incoming traffic stays cut until the application
-  actually sends something outbound, which is what re-opens the mapping on a real NAT. Nothing
-  changes when you leave the setting at 0 (off, the default).
-
-- **Short-lived connections now show which program they belong to.** The Connections table works
-  out the owning program by asking Windows which application holds each socket, and that answer
-  used to come from a list refreshed a few times a second. A connection that opened and finished
-  in between two of those refreshes was never on the list, so its row stayed blank in the Process
-  and PID columns - and brief connections like that are exactly what you get when a browser, or an
-  app you are testing, opens hundreds of them a minute. The tool is now told who owns a connection
-  the moment it is created, so the row is filled in from its very first packet. The program's name
-  can still appear a moment after its process number, because names are looked up in the
-  background, but the row no longer stays empty.
-
-- **A window you have moved now keeps its place when you switch language.** Changing the language
-  rebuilds the whole main window, and a smaller window open at the time - Settings, for example -
-  was torn down with it. It came back at the size and position it had the last time you closed it,
-  quietly throwing away wherever you had just dragged it. It now stays where you put it.
-
-- **Setting a process target no longer makes the first start pause.** Working out which process
-  owns each connection could take a second or two the first time, because it fell back to scanning
-  every process on the system. It now resolves only what it needs, so starting - and typing a
-  target - is quick, and the connections it catches settle in almost immediately instead of after
-  that pause.
-
-- **Targeting a process now catches its connections as they open, including short-lived ones.**
-  Working out which connections belong to your target used to mean scanning the system's socket
-  table a few times a second - so a connection that opened and closed between two scans (a browser
-  makes many) could slip through unimpaired, and pointing the tool at a busy app like Chrome caught
-  only some of its traffic. On Windows the tool now follows the system's socket events as they
-  happen, so a connection is impaired from the moment it opens - for outbound connections, before
-  its first packet even leaves. Without real WinDivert it falls back to the old scan. Nothing
-  changes in how you set a target.
-
-- **The "impaired?" column now reflects the whole session, not just this instant.** When you
-  targeted a process, the column asked "is this connection's port in the target *right now*" -
-  so the moment a connection closed (a browser closes hundreds a minute) its row flipped to
-  "no", and a run that was impairing all of Chrome looked like it was catching almost nothing.
-  The column now records whether a connection was in impairment scope at any point this session
-  and keeps saying "yes" after it closes. The row highlight, the column, the sort and the CSV
-  export all read that one record, so they can never disagree - a row is coloured exactly when
-  its column says "yes".
-
-- **One bad translation file no longer stops the whole program.** Language files are plain JSON
-  next to the program, and you can add your own. If one of them had a malformed `_meta` header -
-  the little block naming the language - the program refused to start at all, with a technical
-  error and no hint that a language file was to blame. Even asking it for its version failed. A
-  header it cannot read is now simply ignored: the translations in that file are still used, and
-  the language is named after the file.
-- **`--dry-run` now checks your scenario file as well.** That option exists to tell you whether a
-  run will work before you start it - but it never actually opened the scenario file, so a damaged,
-  empty or half-written scenario passed the check with "Configuration is valid" and then failed the
-  real run moments later. It now reads the scenario too and tells you straight away what is wrong
-  with it. A check that passes everything is worse than no check at all.
-- **A settings file in the wrong form now gives a clear message instead of crashing.** If you
-  pointed `--config` at a JSON file that was readable but not a set of settings - a list, say, or
-  a single value, which is what some tools produce - the program stopped with a raw Python error
-  and reported itself as having crashed. It now says what it expected and stops with the "bad
-  configuration" code, so a script running it can tell the difference between "your file is wrong"
-  and "the tool broke".
-- **A damaged window-layout file no longer stops the program from starting.** The program
-  remembers your window size, the page you were last on and which sections you had collapsed, in a
-  small file next to it. That file is yours to edit, and it also gets copied between machines - and
-  if an entry in it ended up the wrong shape, the program could fail to open at all, with an error
-  that gave no hint which file was to blame. Anything it cannot make sense of is now ignored, that
-  one setting goes back to its default, and the log tells you which entries were skipped. The rest
-  of your layout is kept.
-- **Ending a session now hands your network back at once, instead of a moment later.** When a run
-  finished - whether you pressed STOP or its time ran out - the tool stopped looking at packets
-  immediately, but kept its grip on your network traffic for a moment longer while it tidied up
-  after itself. In that moment Windows was still handing packets to something that was no longer
-  reading them, so a connection or two could stall right at the end of a run. The moment was
-  usually far too short to notice; if the tool happened to be busy working out which process you
-  were targeting, it stretched to about a quarter of a second. Your traffic is now let go first,
-  and the tidying up happens afterwards.
-- **Targeting could follow a process ID after the process was gone - and Windows hands those
-  numbers out again.** Two things went wrong once that happened, both silently. Restart the
-  application you are targeting and it could come back with a number the tool still remembered
-  under the old name, so **it was no longer impaired** - the run looked like the app coping when
-  really nothing was being done to it. And in the other direction, a completely different program
-  that happened to inherit the number **was impaired instead**, so an application you never named
-  had its network broken. The tool now checks that the process behind a number is still the same
-  one before it trusts what it remembers, and forgets a process the moment it closes its last
-  connection.
-- **`--doctor` could report a WinDivert driver as "not loaded" when it simply was not allowed
-  to look.** Windows refuses full access to some services even for an Administrator, and the
-  check treated that refusal as "the service is not there" - in the one command whose whole job
-  is to tell you the truth about your machine. It now asks only for permission to read the
-  state, which also means the driver line is accurate **without** running as Administrator. If
-  the state genuinely cannot be read, the line now says so and warns, instead of quietly
-  reporting a clean machine.
-- **`--cleanup-driver` explains a refusal instead of calling it "not installed".** Being told
-  "access denied - the service exists but this account may not remove it" points somewhere;
-  being told the service was never there does not.
-- **A session that fails to start now hands your network back and lets you try again.** Starting a
-  run sets up several background workers, and if your machine could not spare the resources for one
-  of them - most likely while you are already running the heavy load you are testing against - the
-  start failed halfway. The tool could be left holding your traffic without actually impairing it,
-  showing an error while quietly keeping its grip, and every later START was refused until you
-  killed the program. A failed start now releases your network immediately and leaves the tool
-  ready to start again, exactly as if you had never pressed START.
-- **STOP is immediate again when you press it just as a timed run ends.** If you hit STOP at the
-  same moment a run reached its set duration, the tool could sit on "stopping" for about two seconds
-  before the window went back to normal. Your network was already handed back at once - it was only
-  the button that lagged - but a STOP that looks stuck is exactly the wrong thing in a tool whose
-  whole job is undoing what you did to your own connection. It now finishes right away either way.
+  replaced the running one and left the old one going in the background, so two scenarios fought over
+  the same settings. Nothing in the program does this today, so it is a guard rather than a bug you
+  could have hit.
 
 ### Docs
 
-- **Both READMEs claimed slightly more than the tool does about brand-new connections.** They said
-  a connection is in scope "the moment it opens", which holds for a program the tool already
-  recognises but not for that program's *first* connection: until it owns at least one socket there
-  is nothing to recognise it by, so that one connection goes through untouched. Measured, so the
-  exception is now stated rather than implied, next to a new note on what to do about it - if the
-  program under test restarts, aim by **name** rather than by process id.
+- **Both READMEs now document the scenario file format, the seven shipped scenarios, both CSV exports
+  and all 17 Connections columns** - none of which were written down anywhere. The column meanings
+  existed only as tooltips, and the CSV headers only in the code.
 
-- **The process field's exclusions are now documented properly.** Writing `!chrome` means "impair
-  everything except chrome" - and "everything" includes any connection whose owning process could
-  not be identified yet, which every brand-new connection passes through. If you want one
-  application left alone, name the one you *do* want broken instead; then anything unidentified
-  passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
+- **Three corrections to what the READMEs claimed.** A connection is in scope "the moment it opens"
+  only for a program the tool already recognises, not for that program's *first* connection. An
+  exclusion like `!chrome` also covers every connection whose owner could not be identified, so do
+  not use one to protect an application - name the one you *do* want broken. And both files explained
+  greyed-out fields with an "Enable" checkbox that no longer exists.
 
-- **Both READMEs described a checkbox that does not exist.** They explained greyed-out fields with
-  "Period"/"Down percentage" going inactive when an **"Enable"** box is unchecked. Those boxes were
-  removed some time ago, so a reader was being sent to look for a control that is not there. The
-  paragraph now uses the case that really happens: "Download"/"Upload" grey out with a note when a
-  Schedule takes them over.
-
-- **What the automated checks actually cover, and what happens at release.** The Tests section
-  listed about half of what runs on every push. It now includes the coverage gate, the `--doctor`
-  and `--license` checks, the check that the WinDivert driver really shipped next to the exe, and
-  the one step no unit test can stand in for: a **GUI render check on real Tk** at the minimum
-  1366x768, **in every language**, which fails the build when a button's text is clipped. Polish
-  labels are longer than English ones, so that is where layouts break. There is also a short
-  description of how a release is produced, since the README asks you to verify the
-  `SHA256SUMS.txt` that workflow publishes.
-
-- **`psutil` is no longer described as what makes process targeting work.** "Target process" said
-  it *requires* `psutil`. On Windows the socket table and the process names come from the OS, and
-  targeting keeps working with `psutil` removed outright (measured: 310 ports mapped, 37 of 37
-  names resolved). It is the fallback used off Windows. The Requirements section also now says
-  plainly that installing from source works on Python 3.10 and newer while CI tests and builds on
-  3.14 only, which is the version frozen into the released `.exe`.
+- **The Requirements and Tests sections now match reality.** `psutil` is not what makes process
+  targeting work on Windows - the socket table and process names come from the OS, and targeting
+  keeps working without it. Source installs work on Python 3.10 and newer while CI tests and builds
+  on 3.14 only, which is the version frozen into the released `.exe`. The Tests section also now
+  covers the GUI render check and how a release is produced.
 
 ## [0.3.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Bean Network Tester.
 The format follows [Keep a Changelog](https://keepachangelog.com/); versions follow SemVer.
 
-## [Unreleased]
+## [0.4.0] - 2026-08-01
 
 ### BREAKING
 
@@ -55,6 +55,31 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   validated too: it has to be a number of seconds and it only means something next to an `action`.
   A file that was correct keeps working; one that was quietly half-working will now tell you where.
 
+- **BREAKING:** **The presets were wrong, and they are now checked against published measurements.**
+  Two mistakes ran through the whole list. Every latency was set as if it were a ping, but the delay
+  is added to each packet in **both** directions - so "Satellite link" at 600 ms was handing you a
+  1200 ms ping, against the ~680 ms a real geostationary link has. And three presets held speeds in
+  kilo**bits** where the field wants kilo**bytes**, which made them eight times too fast: "3G
+  network" delivered 3 Mbit/s, which is not what anybody picks that preset to feel. Both are fixed
+  throughout, and every value now carries a source (or an honest note that no measurement exists,
+  as for "weak Wi-Fi") in `beantester/presets.py`. **If you scripted `--preset`, the traffic you get
+  will change.** Two names changed with them: "Satellite link" is now "Satellite (geostationary)",
+  and "Home DSL" says VDSL. The ids did not change, so saved configs and profiles are unaffected -
+  but `--preset "Satellite link"` no longer resolves.
+
+- **BREAKING:** **The shipped scenarios in `scenarios/` were recalculated** the same way, so a
+  scenario and a preset finally describe the same network with the same numbers. A pleasant side
+  effect: the ping you get is now the number written in the file.
+
+- **BREAKING:** **"Duplicated" now counts packets that were actually sent twice, not packets the
+  tool decided to duplicate.** With duplication on and the tool under enough load to fill its
+  internal queue, the copy was quietly thrown away while the counter went up anyway. Measured on a
+  deliberately tiny queue: 40 packets in, **"Duplicated" read 40 while nothing at all reached the
+  wire**. The tile sits next to "Corrupted", which has always counted only the packets it really
+  changed, so this brings the two into line. Reports and NDJSON output from before and after this
+  change are not comparable on that field. Nothing else moved: the same packets are duplicated,
+  and the "Buffer overflow" tile already told you when the queue was the bottleneck.
+
 ### Added
 
 - **The README documents three things it never did**, in both languages:
@@ -67,6 +92,249 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
     connections one overwrites and follows your search, sorting and that switch - and the
     connections CSV does not reuse the table's labels, so there is a column-by-column map between
     them.
+
+- **Five new presets**, each for a situation the old list could not describe:
+  - **Satellite (low orbit)** - Starlink-like. Fast and low-ping in the steady state; what marks it
+    out is the reconfiguration every 15 seconds, which briefly halts transmission and turns up as
+    an occasional ping spike rather than as lost packets.
+  - **Distant server (another continent)** - a fast, healthy link that is simply far away
+    (~120 ms of ping). The one that catches code written as if the server were in the next room.
+  - **Congested home link (bufferbloat)** - looks perfect when idle; the queue is the problem. Note
+    that **it only bites once your application really saturates the link** - send a trickle and you
+    will see an ordinary 8/1 Mbit/s link. Saturate the upload and watch ping climb towards two
+    seconds, which is the "the video call dies when somebody starts a backup" case.
+  - **Train / metro (tunnels)** - takes the connection fully down for 3 seconds out of every 30, so
+    your application has to reconnect rather than just slow down. Nothing else in the list does
+    that.
+  - **In-flight Wi-Fi** - the satellite kind: about 750 ms of ping and 7% loss, which is a measured
+    median rather than a worst case.
+
+- **You can now point Statistics, the chart and Connections at your target alone.** Settings gains
+  **"Show only the targeted traffic"** (off by default, so nothing changes unless you ask). With it
+  on, the counter grid, the throughput chart, the Connections table and the connections CSV export
+  all cover just the traffic your process / IP / port targeting selected - useful when the machine
+  is busy and the numbers you care about are buried in everything else. It changes what you **see**,
+  never what is captured and never what is impaired. Three things deliberately do not follow it, and
+  each says so where you would look:
+  - **"Queue overflow", "Dropped at stop" and "Send failed" always cover the full traffic**, because
+    they count packets *this tool* lost - including traffic you never targeted. Hiding those would
+    hide the tool's own damage, which is the opposite of the point.
+  - **The statistics CSV keeps both totals** in separate columns instead of following the switch: it
+    is an append log, and a column that means one thing in some rows and another in the rest cannot
+    be charted.
+  - **The reproduction report and `--format json` are unchanged** - they have always carried both
+    the captured and the in-scope numbers, so a saved run never depends on how the window was set
+    when it was made.
+  The note above the counters and above the Connections table re-words itself to say which of the
+  two you are looking at, and the chart caption names it too - so a screenshot cannot be misread.
+
+- **A new option lets the driver do the filtering, for when you are testing at high packet rates.**
+  Normally the tool receives every packet on the machine and hands almost all of them straight
+  back - measured on a real run, 1944 packets taken in and none of them even eligible to be
+  impaired. With **"Narrow the driver filter to the target"** (`--narrow-filter`) the destination
+  IP and port are pushed into WinDivert itself, so traffic that could never be impaired is not
+  handed over at all. Worth knowing before you switch it on: it takes effect **when a session
+  starts**, the destination fields are then fixed until you stop, and Statistics and Connections
+  cover only the narrowed traffic. It does nothing for a **process** target (Windows does not offer
+  the tool a process name at that level) and falls back silently-but-loudly to capturing everything
+  if your destination uses a wildcard or a `re:` pattern - the run says which of the two happened.
+  **It turned out to be more than a speed option, and this is the part worth reading twice.**
+  Measured on a real run with other traffic on the machine: without it, the driver was so busy
+  handing over traffic the tool was never going to touch that it **threw away 43% of the traffic
+  you actually aimed at, before the tool could see it** - so the session impaired less than it
+  reported, and worked out its percentages from what survived. With the option on, all of it
+  arrived and nothing was lost. If you test at high packet rates against a specific address or
+  port, this is the setting that makes your numbers mean what they say.
+
+- **The command line now says when the process you aimed at stops matching, instead of running on
+  in silence.** If your target exits - it crashed, or your test harness restarted it and Windows
+  gave it a new process id - everything from that moment on is left untouched. The run used to
+  carry on and finish green, with the only mention of your target being one line printed at the
+  start. Measured here against a real capture: aiming at a process id and then restarting that
+  program left five out of five of its new connections completely untouched, and nothing in the
+  output said so. The run now says it the moment it notices, and says so again if the target comes
+  back. Worth knowing which form to use: aiming by **name** recovers on its own within about half a
+  second of the restarted program opening its first connection, and only that first connection
+  escapes; aiming by **process id** never recovers, because that id no longer exists. If the
+  program under test restarts, aim by name.
+
+- **Every run with a process target now ends by saying how much of the captured traffic was
+  actually yours** - "In scope: 40 of 500 captured packets" - and calls it out when that number is
+  zero. A run in which your target caught nothing looks exactly like a run in which your
+  application coped, and those are opposite results. The existing `--min-packets` check cannot see
+  this: it catches a traffic filter that matched nothing, which is a different mistake. This is a
+  warning rather than a failure, because aiming at a program that happens to be quiet is a
+  perfectly ordinary thing to do.
+
+- **The session panel now shows how long packets waited inside the driver before the tool saw
+  them.** This is the one delay the tool adds and counted nowhere: it happens in WinDivert's queue,
+  ahead of the tool's own, so a tester measuring latency puts it down to their application or to
+  the network. It is not an estimate - the driver stamps every packet with a capture time, and the
+  tool now reads it 20 times a second. **"Driver queue wait (peak)"** in the Session tab holds the
+  worst one, and it goes into the reproduction report with everything else. On an idle machine
+  expect a fraction of a millisecond (measured here: 0.05-0.16 ms). Above 50 ms the log and the
+  event list say so, at most once every five seconds. It stays blank under `--simulate`, which has
+  no driver to wait in.
+
+- **A session now records the WinDivert queue it is running behind.** WinDivert has its own buffer,
+  ahead of this tool's, and nothing here ever read it - so a packet could sit in the driver for up
+  to two seconds (the default queue time), land on your measured latency, and appear in no counter
+  at all. The three values (length, time, size) are read when a session starts, written to the log,
+  and stored in the reproduction report as `session.driver_queue`, so a report from a machine you
+  do not have in front of you says which queue produced its numbers. Read on this machine:
+  4096 packets / 2000 ms / 4 MiB - and note the size limit binds first for full-size packets,
+  4 MiB / 1500 B = 2796 packets, not 4096. Nothing is changed about how the queue behaves; this is
+  about being able to see it. `--doctor` deliberately does not read them: the values need an open
+  handle, and opening one loads the driver, which would falsify the "windivert driver" line printed
+  in the same report.
+
+- **The tool now warns when your target shares a port with another program.** Windows lets several
+  programs hold the same local port at once - that is how mDNS, SSDP and DHCP work - and this tool
+  decides what to break from the port number, so on those ports it genuinely cannot tell whose
+  traffic it is looking at. On this machine, four port numbers out of 127 were like that, and one
+  of them (5353, used for local device discovery) had **five** owners at the same time. The
+  consequence is real in both directions: aiming at one program could leave its own traffic on such
+  a port untouched, or sweep three other programs' traffic in with it. Nothing about that changed -
+  it cannot be fixed, because the port number simply does not say who sent the packet - but the
+  tool no longer keeps it to itself. Applying a target now says which port is shared and with whom,
+  so you know that part of the result is a coin toss. Ports that are not shared, which is where
+  your application's own traffic lives, are unaffected.
+
+### Changed
+
+- **The checkbox is now called "Capture only the targeted traffic"** instead of "Narrow the driver
+  filter to the target". The old name described the machinery rather than what you get, and
+  "driver filter" means nothing unless you already know how the tool works. The `--narrow-filter`
+  flag is unchanged.
+
+- **Semicolons are gone from the interface texts and both READMEs.** Twenty-one tooltips and about
+  eighty lines of documentation used them to join sentences, which is not how people write. They
+  are now full stops or commas. Code samples keep theirs, since there a semicolon is syntax.
+
+- **The "Narrow the driver filter to the target" tooltip was rewritten.** It explained how the
+  option works rather than what it does, and it left out the part people most need: the option has
+  **no effect at all** if you target a process, or use a wildcard or an `re:` pattern in the
+  destination. It now says what it does, what changes in the Statistics and Connections tabs, and
+  when it will not apply.
+
+- **"Blocking (firewall)" now starts collapsed** on a fresh install, like the other advanced
+  panels. If you have used the tool before, your own collapsed/expanded choices are remembered and
+  nothing moves.
+
+- **"Spike chance" and "Spike size" moved from "Advanced (NAT / connections)" to
+  "Latency (ping)".** A spike is latency - an occasional large one - so it now sits next to the
+  steady value and the jitter around it, instead of among the NAT and connection knobs. Nothing
+  about how it works changed, and neither did its `--spike-prob` / `--spike-ms` flags or its place
+  in a saved profile.
+
+- The Latency and Jitter tooltips now say the thing that was easy to get wrong: **ping rises by
+  about twice the latency you set** (both the request and the reply are delayed), while jitter
+  widens the wobble by about 1.4x rather than doubling it. Both READMEs explain it too.
+
+- **BREAKING:** **Profiles now remember more of the link.** A profile used to store seven things
+  about a connection: loss, corruption, duplication, latency, jitter and the two speed limits. It
+  now also stores the latency spikes, the link outages (flapping) and the buffer. The outages are
+  the reason this was worth doing: they repeat on a fixed cadence, so a profile can finally describe
+  a link that cuts out every so often - a satellite handover, a flaky uplink - which none of the
+  other fields could say. Four things follow from it:
+  - **Profiles you saved with an earlier version load exactly as before.** The fields they never had
+    are simply off, and the buffer keeps its normal 1000 ms instead of quietly becoming unlimited.
+  - **Picking a preset or a profile now sets all of those fields at once.** None of the twelve
+    built-in presets mentions a spike, an outage or a buffer, so those go back to their defaults
+    rather than keeping whatever was left in the form: "Perfect network" now really does clear
+    everything. If you had dialled the buffer yourself, picking a preset resets it to 1000 ms.
+  - **`--preset` on the command line now does the same thing the window does.** It applied only the
+    original seven values, so the same preset name could produce different traffic depending on
+    which one you started it from.
+  - If you open a profile saved by this version in an older build, the new fields are ignored.
+
+- **BREAKING:** **The reproduction report's "connections reset" counted packets, not connections.**
+  It held the number of packets a reset connection swallows while it is held down, which for a
+  30 second cooldown on a busy connection is thousands against a handful of actual resets - one
+  reset connection could report itself as 50. The report now carries the three RST numbers as three
+  keys, because they answer three different questions: `connections_reset` (how many connections
+  were torn down), `rst_packets_dropped` (how much traffic that cost while they were held down) and
+  `rst_sent` (how many RST packets actually reached the network stack). The last two can differ
+  from the first - a connection is held down whether or not an RST could be built for it - and that
+  gap is worth seeing. The statistics CSV gained a `connections_reset` column to match. Nothing on
+  screen changed: the live "RST reset" tile always said "packets" in its tooltip and was right.
+
+- **BREAKING:** **The Connections table now tells you what arrived AND what was offered.** The
+  "down", "up" and "total" columns held the bytes the tool *captured* - under headings the session
+  panel uses for what actually arrived. Those are the same number only while you are impairing
+  nothing: with a speed limit in place a row could read 5 MB received while its application had
+  received 0.4 MB. Those three columns are now the **delivered** bytes, agreeing with "Downloaded
+  (MB)" in the session panel, and two new columns - **"down seen"** and **"up seen"** - hold what
+  was captured. The gap between the pairs is the damage done to that connection, which is the
+  number you were probably trying to read off this table in the first place. Every one of them has
+  a tooltip saying which is which, because the headings alone cannot carry it. The footer sums the
+  delivered columns, and says so. **The connections CSV changed shape**: `download_bytes`,
+  `upload_bytes` and `total_bytes` are replaced by `delivered_down_bytes`, `delivered_up_bytes`,
+  `delivered_total_bytes`, `captured_down_bytes`, `captured_up_bytes` and `captured_total_bytes` -
+  renamed rather than reused, because a column that quietly changes meaning is worse than one that
+  disappears.
+
+- **BREAKING:** **"Effective loss" now means what its name says, and your numbers will change.**
+  It used to be the configured Loss percentage divided by every packet the tool saw, and both
+  halves of that were wrong. It ignored every other way the tool destroys traffic - a speed limit,
+  blocking, LAN cut, a link outage, a connection reset, a dropped SYN, an expired NAT mapping - so
+  a session losing 90% of its traffic to a bandwidth cap reported **0.0%**. And when you targeted
+  one application it still divided by the whole machine's traffic, so impairing that application
+  by 50% showed as **16.7%** while the application itself measured 50.1%. The figure now counts
+  every impairment, over the traffic you aimed at. `effective_loss_pct` and
+  `effective_corruption_pct` in the reproduction report moved the same way, so a report from
+  before this release is not comparable with one from after; the report also gained
+  `packets_in_scope`, and the session's NDJSON summary carries the same count. Packets the tool
+  itself threw away stay out of the figure on purpose: "Buffer overflow" and "Dropped at stop" are
+  the tool failing, not the link behaving badly, and they have their own counters. The number in
+  the session panel now has a tooltip saying exactly this - it had none before, which is part of
+  why it could be wrong for so long without anyone noticing.
+- **BREAKING:** the statistics CSV gained a `packets_in_scope` column. An existing `stats.csv`
+  from an older version is moved aside automatically and a fresh one started, exactly as it
+  already is whenever the columns change, so no row is ever silently misaligned against the
+  wrong header.
+
+- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
+  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
+  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
+  console you may not have been watching. It now stops immediately with a usage error (exit
+  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
+  settings from the command line. If a script of yours relied on the old behaviour, delete
+  `--gui` from it and it behaves exactly as before.
+
+- **A packet you did not ask to change now goes back on the wire exactly as it arrived - and the
+  session moves about 12% more traffic because of it.** The tool used to recompute every packet's
+  checksums before re-injecting it, including packets it had not touched at all. That was wasted
+  work, and it also meant a session with nothing configured did not quite pass traffic through
+  unchanged: modern network cards leave the checksum for the hardware to finish, so recomputing it
+  put different bytes on the wire than the ones that came in. Checksums are now recomputed only
+  when the tool actually edited the packet - which today means corruption - and for the reset (RST)
+  packets it builds itself. Measured comparing both behaviours inside the same session:
+  **1.12x more packets a second, in 8 comparisons out of 8**. Verified over a real network card,
+  not just loopback: 24 MiB of TCP through the tool arrived byte for byte, with a matching SHA-256.
+
+- **A session now moves noticeably more traffic - about a third more packets a second.** The tool
+  handles your packets on two threads: one takes them from the driver, the other puts them back on
+  the wire. Python makes those two take turns, and by default a thread that is ready to work can be
+  left waiting up to 5 milliseconds for its turn. That waiting, not the work itself, was the limit:
+  putting a packet back took 57 microseconds while the same call takes 27 with nothing else in the
+  way. A session now asks Python for shorter turns while it runs, and hands that setting back when
+  it stops. Measured on a real capture, comparing both settings inside the same session, on
+  loopback and over a real network card: **1.33x to 1.36x more packets a second, in 24 comparisons
+  out of 24** - and with slightly *less* processor time per packet, not more. The queue of packets
+  waiting to be re-injected stops backing up, which is what that number looks like from the other
+  side. **Nothing changes in what you configure or see**, and the delay you ask for is delivered
+  just as accurately as before: against a configured 10 ms, packets were late by 0.73 ms before
+  and 0.76 ms after, which is the same number twice.
+
+- **Targeting a process no longer competes with the traffic it is measuring.** Working out which
+  connections belong to your target means asking Windows about its sockets, and that used to
+  happen on the same thread that handles your packets - dozens of times a second, because every
+  packet from every *other* application prompted another look. On a busy machine that stole time
+  from the capture itself, which is how a tester ends up measuring the tool instead of their
+  application. The lookup now runs on its own thread. Nothing changes in what you set or see;
+  a freshly opened connection still starts being impaired within tens of milliseconds, and STOP
+  stays immediate even while a lookup is in progress.
 
 ### Fixed
 
@@ -168,35 +436,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   completely different worlds, and only the command line and the saved reproduction report ever
   said which - the window never mentioned it anywhere.
 
-### Changed
-
-- **The checkbox is now called "Capture only the targeted traffic"** instead of "Narrow the driver
-  filter to the target". The old name described the machinery rather than what you get, and
-  "driver filter" means nothing unless you already know how the tool works. The `--narrow-filter`
-  flag is unchanged.
-
-- **Semicolons are gone from the interface texts and both READMEs.** Twenty-one tooltips and about
-  eighty lines of documentation used them to join sentences, which is not how people write. They
-  are now full stops or commas. Code samples keep theirs, since there a semicolon is syntax.
-
-- **The "Narrow the driver filter to the target" tooltip was rewritten.** It explained how the
-  option works rather than what it does, and it left out the part people most need: the option has
-  **no effect at all** if you target a process, or use a wildcard or an `re:` pattern in the
-  destination. It now says what it does, what changes in the Statistics and Connections tabs, and
-  when it will not apply.
-
-- **"Blocking (firewall)" now starts collapsed** on a fresh install, like the other advanced
-  panels. If you have used the tool before, your own collapsed/expanded choices are remembered and
-  nothing moves.
-
-- **"Spike chance" and "Spike size" moved from "Advanced (NAT / connections)" to
-  "Latency (ping)".** A spike is latency - an occasional large one - so it now sits next to the
-  steady value and the jitter around it, instead of among the NAT and connection knobs. Nothing
-  about how it works changed, and neither did its `--spike-prob` / `--spike-ms` flags or its place
-  in a saved profile.
-
-### Fixed
-
 - **The throughput chart could be squeezed until it vanished.** On a narrow window the counter grid
   reflows into more rows, took the height, and left the chart a black sliver under its own heading.
   The "Live" tab now scrolls, so nothing on it can be pushed out of existence. One trade worth
@@ -207,261 +446,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 - **"Save profile..." opens with the cursor already in the name box.** It used to need a click
   before you could type.
 
-## [0.4.0] - 2026-07-30
-
-### BREAKING
-
-- **BREAKING:** **The presets were wrong, and they are now checked against published measurements.**
-  Two mistakes ran through the whole list. Every latency was set as if it were a ping, but the delay
-  is added to each packet in **both** directions - so "Satellite link" at 600 ms was handing you a
-  1200 ms ping, against the ~680 ms a real geostationary link has. And three presets held speeds in
-  kilo**bits** where the field wants kilo**bytes**, which made them eight times too fast: "3G
-  network" delivered 3 Mbit/s, which is not what anybody picks that preset to feel. Both are fixed
-  throughout, and every value now carries a source (or an honest note that no measurement exists,
-  as for "weak Wi-Fi") in `beantester/presets.py`. **If you scripted `--preset`, the traffic you get
-  will change.** Two names changed with them: "Satellite link" is now "Satellite (geostationary)",
-  and "Home DSL" says VDSL. The ids did not change, so saved configs and profiles are unaffected -
-  but `--preset "Satellite link"` no longer resolves.
-
-- **BREAKING:** **The shipped scenarios in `scenarios/` were recalculated** the same way, so a
-  scenario and a preset finally describe the same network with the same numbers. A pleasant side
-  effect: the ping you get is now the number written in the file.
-
-### Added
-
-- **Five new presets**, each for a situation the old list could not describe:
-  - **Satellite (low orbit)** - Starlink-like. Fast and low-ping in the steady state; what marks it
-    out is the reconfiguration every 15 seconds, which briefly halts transmission and turns up as
-    an occasional ping spike rather than as lost packets.
-  - **Distant server (another continent)** - a fast, healthy link that is simply far away
-    (~120 ms of ping). The one that catches code written as if the server were in the next room.
-  - **Congested home link (bufferbloat)** - looks perfect when idle; the queue is the problem. Note
-    that **it only bites once your application really saturates the link** - send a trickle and you
-    will see an ordinary 8/1 Mbit/s link. Saturate the upload and watch ping climb towards two
-    seconds, which is the "the video call dies when somebody starts a backup" case.
-  - **Train / metro (tunnels)** - takes the connection fully down for 3 seconds out of every 30, so
-    your application has to reconnect rather than just slow down. Nothing else in the list does
-    that.
-  - **In-flight Wi-Fi** - the satellite kind: about 750 ms of ping and 7% loss, which is a measured
-    median rather than a worst case.
-
-### Fixed
-
 - **The profile picker cut long names off.** It was a fixed 24 characters wide, so
   "Congested home link (bufferbloat)" showed up as "Congested home link (bufferb" with nothing on
   screen saying the name went on - in both languages. It now sizes itself to its longest entry, and
   regrows when you save a profile with a long name.
-
-### Changed
-
-- The Latency and Jitter tooltips now say the thing that was easy to get wrong: **ping rises by
-  about twice the latency you set** (both the request and the reply are delayed), while jitter
-  widens the wobble by about 1.4x rather than doubling it. Both READMEs explain it too.
-
-- **BREAKING:** **Profiles now remember more of the link.** A profile used to store seven things
-  about a connection: loss, corruption, duplication, latency, jitter and the two speed limits. It
-  now also stores the latency spikes, the link outages (flapping) and the buffer. The outages are
-  the reason this was worth doing: they repeat on a fixed cadence, so a profile can finally describe
-  a link that cuts out every so often - a satellite handover, a flaky uplink - which none of the
-  other fields could say. Four things follow from it:
-  - **Profiles you saved with an earlier version load exactly as before.** The fields they never had
-    are simply off, and the buffer keeps its normal 1000 ms instead of quietly becoming unlimited.
-  - **Picking a preset or a profile now sets all of those fields at once.** None of the twelve
-    built-in presets mentions a spike, an outage or a buffer, so those go back to their defaults
-    rather than keeping whatever was left in the form: "Perfect network" now really does clear
-    everything. If you had dialled the buffer yourself, picking a preset resets it to 1000 ms.
-  - **`--preset` on the command line now does the same thing the window does.** It applied only the
-    original seven values, so the same preset name could produce different traffic depending on
-    which one you started it from.
-  - If you open a profile saved by this version in an older build, the new fields are ignored.
-
-- **BREAKING:** **The reproduction report's "connections reset" counted packets, not connections.**
-  It held the number of packets a reset connection swallows while it is held down, which for a
-  30 second cooldown on a busy connection is thousands against a handful of actual resets - one
-  reset connection could report itself as 50. The report now carries the three RST numbers as three
-  keys, because they answer three different questions: `connections_reset` (how many connections
-  were torn down), `rst_packets_dropped` (how much traffic that cost while they were held down) and
-  `rst_sent` (how many RST packets actually reached the network stack). The last two can differ
-  from the first - a connection is held down whether or not an RST could be built for it - and that
-  gap is worth seeing. The statistics CSV gained a `connections_reset` column to match. Nothing on
-  screen changed: the live "RST reset" tile always said "packets" in its tooltip and was right.
-
-- **BREAKING:** **The Connections table now tells you what arrived AND what was offered.** The
-  "down", "up" and "total" columns held the bytes the tool *captured* - under headings the session
-  panel uses for what actually arrived. Those are the same number only while you are impairing
-  nothing: with a speed limit in place a row could read 5 MB received while its application had
-  received 0.4 MB. Those three columns are now the **delivered** bytes, agreeing with "Downloaded
-  (MB)" in the session panel, and two new columns - **"down seen"** and **"up seen"** - hold what
-  was captured. The gap between the pairs is the damage done to that connection, which is the
-  number you were probably trying to read off this table in the first place. Every one of them has
-  a tooltip saying which is which, because the headings alone cannot carry it. The footer sums the
-  delivered columns, and says so. **The connections CSV changed shape**: `download_bytes`,
-  `upload_bytes` and `total_bytes` are replaced by `delivered_down_bytes`, `delivered_up_bytes`,
-  `delivered_total_bytes`, `captured_down_bytes`, `captured_up_bytes` and `captured_total_bytes` -
-  renamed rather than reused, because a column that quietly changes meaning is worse than one that
-  disappears.
-
-- **BREAKING:** **"Effective loss" now means what its name says, and your numbers will change.**
-  It used to be the configured Loss percentage divided by every packet the tool saw, and both
-  halves of that were wrong. It ignored every other way the tool destroys traffic - a speed limit,
-  blocking, LAN cut, a link outage, a connection reset, a dropped SYN, an expired NAT mapping - so
-  a session losing 90% of its traffic to a bandwidth cap reported **0.0%**. And when you targeted
-  one application it still divided by the whole machine's traffic, so impairing that application
-  by 50% showed as **16.7%** while the application itself measured 50.1%. The figure now counts
-  every impairment, over the traffic you aimed at. `effective_loss_pct` and
-  `effective_corruption_pct` in the reproduction report moved the same way, so a report from
-  before this release is not comparable with one from after; the report also gained
-  `packets_in_scope`, and the session's NDJSON summary carries the same count. Packets the tool
-  itself threw away stay out of the figure on purpose: "Buffer overflow" and "Dropped at stop" are
-  the tool failing, not the link behaving badly, and they have their own counters. The number in
-  the session panel now has a tooltip saying exactly this - it had none before, which is part of
-  why it could be wrong for so long without anyone noticing.
-- **BREAKING:** the statistics CSV gained a `packets_in_scope` column. An existing `stats.csv`
-  from an older version is moved aside automatically and a fresh one started, exactly as it
-  already is whenever the columns change, so no row is ever silently misaligned against the
-  wrong header.
-
-- **BREAKING:** **`--gui` no longer accepts any other option.** Combining it with settings -
-  for example `--gui --loss 30 --duration 600` - used to open no window at all and quietly run
-  the impairment in the background instead, with no STOP button anywhere and only Ctrl+C in a
-  console you may not have been watching. It now stops immediately with a usage error (exit
-  code 2) and says what to do: launch the GUI with no arguments, or drop `--gui` to run those
-  settings from the command line. If a script of yours relied on the old behaviour, delete
-  `--gui` from it and it behaves exactly as before.
-
-### Changed
-
-- **A packet you did not ask to change now goes back on the wire exactly as it arrived - and the
-  session moves about 12% more traffic because of it.** The tool used to recompute every packet's
-  checksums before re-injecting it, including packets it had not touched at all. That was wasted
-  work, and it also meant a session with nothing configured did not quite pass traffic through
-  unchanged: modern network cards leave the checksum for the hardware to finish, so recomputing it
-  put different bytes on the wire than the ones that came in. Checksums are now recomputed only
-  when the tool actually edited the packet - which today means corruption - and for the reset (RST)
-  packets it builds itself. Measured comparing both behaviours inside the same session:
-  **1.12x more packets a second, in 8 comparisons out of 8**. Verified over a real network card,
-  not just loopback: 24 MiB of TCP through the tool arrived byte for byte, with a matching SHA-256.
-
-- **A session now moves noticeably more traffic - about a third more packets a second.** The tool
-  handles your packets on two threads: one takes them from the driver, the other puts them back on
-  the wire. Python makes those two take turns, and by default a thread that is ready to work can be
-  left waiting up to 5 milliseconds for its turn. That waiting, not the work itself, was the limit:
-  putting a packet back took 57 microseconds while the same call takes 27 with nothing else in the
-  way. A session now asks Python for shorter turns while it runs, and hands that setting back when
-  it stops. Measured on a real capture, comparing both settings inside the same session, on
-  loopback and over a real network card: **1.33x to 1.36x more packets a second, in 24 comparisons
-  out of 24** - and with slightly *less* processor time per packet, not more. The queue of packets
-  waiting to be re-injected stops backing up, which is what that number looks like from the other
-  side. **Nothing changes in what you configure or see**, and the delay you ask for is delivered
-  just as accurately as before: against a configured 10 ms, packets were late by 0.73 ms before
-  and 0.76 ms after, which is the same number twice.
-
-- **Targeting a process no longer competes with the traffic it is measuring.** Working out which
-  connections belong to your target means asking Windows about its sockets, and that used to
-  happen on the same thread that handles your packets - dozens of times a second, because every
-  packet from every *other* application prompted another look. On a busy machine that stole time
-  from the capture itself, which is how a tester ends up measuring the tool instead of their
-  application. The lookup now runs on its own thread. Nothing changes in what you set or see;
-  a freshly opened connection still starts being impaired within tens of milliseconds, and STOP
-  stays immediate even while a lookup is in progress.
-
-### Docs
-
-- **Both READMEs claimed slightly more than the tool does about brand-new connections.** They said
-  a connection is in scope "the moment it opens", which holds for a program the tool already
-  recognises but not for that program's *first* connection: until it owns at least one socket there
-  is nothing to recognise it by, so that one connection goes through untouched. Measured, so the
-  exception is now stated rather than implied, next to a new note on what to do about it - if the
-  program under test restarts, aim by **name** rather than by process id.
-
-- **The process field's exclusions are now documented properly.** Writing `!chrome` means "impair
-  everything except chrome" - and "everything" includes any connection whose owning process could
-  not be identified yet, which every brand-new connection passes through. If you want one
-  application left alone, name the one you *do* want broken instead; then anything unidentified
-  passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
-
-### Added
-
-- **You can now point Statistics, the chart and Connections at your target alone.** Settings gains
-  **"Show only the targeted traffic"** (off by default, so nothing changes unless you ask). With it
-  on, the counter grid, the throughput chart, the Connections table and the connections CSV export
-  all cover just the traffic your process / IP / port targeting selected - useful when the machine
-  is busy and the numbers you care about are buried in everything else. It changes what you **see**,
-  never what is captured and never what is impaired. Three things deliberately do not follow it, and
-  each says so where you would look:
-  - **"Queue overflow", "Dropped at stop" and "Send failed" always cover the full traffic**, because
-    they count packets *this tool* lost - including traffic you never targeted. Hiding those would
-    hide the tool's own damage, which is the opposite of the point.
-  - **The statistics CSV keeps both totals** in separate columns instead of following the switch: it
-    is an append log, and a column that means one thing in some rows and another in the rest cannot
-    be charted.
-  - **The reproduction report and `--format json` are unchanged** - they have always carried both
-    the captured and the in-scope numbers, so a saved run never depends on how the window was set
-    when it was made.
-  The note above the counters and above the Connections table re-words itself to say which of the
-  two you are looking at, and the chart caption names it too - so a screenshot cannot be misread.
-
-- **A new option lets the driver do the filtering, for when you are testing at high packet rates.**
-  Normally the tool receives every packet on the machine and hands almost all of them straight
-  back - measured on a real run, 1944 packets taken in and none of them even eligible to be
-  impaired. With **"Narrow the driver filter to the target"** (`--narrow-filter`) the destination
-  IP and port are pushed into WinDivert itself, so traffic that could never be impaired is not
-  handed over at all. Worth knowing before you switch it on: it takes effect **when a session
-  starts**, the destination fields are then fixed until you stop, and Statistics and Connections
-  cover only the narrowed traffic. It does nothing for a **process** target (Windows does not offer
-  the tool a process name at that level) and falls back silently-but-loudly to capturing everything
-  if your destination uses a wildcard or a `re:` pattern - the run says which of the two happened.
-  **It turned out to be more than a speed option, and this is the part worth reading twice.**
-  Measured on a real run with other traffic on the machine: without it, the driver was so busy
-  handing over traffic the tool was never going to touch that it **threw away 43% of the traffic
-  you actually aimed at, before the tool could see it** - so the session impaired less than it
-  reported, and worked out its percentages from what survived. With the option on, all of it
-  arrived and nothing was lost. If you test at high packet rates against a specific address or
-  port, this is the setting that makes your numbers mean what they say.
-
-- **The command line now says when the process you aimed at stops matching, instead of running on
-  in silence.** If your target exits - it crashed, or your test harness restarted it and Windows
-  gave it a new process id - everything from that moment on is left untouched. The run used to
-  carry on and finish green, with the only mention of your target being one line printed at the
-  start. Measured here against a real capture: aiming at a process id and then restarting that
-  program left five out of five of its new connections completely untouched, and nothing in the
-  output said so. The run now says it the moment it notices, and says so again if the target comes
-  back. Worth knowing which form to use: aiming by **name** recovers on its own within about half a
-  second of the restarted program opening its first connection, and only that first connection
-  escapes; aiming by **process id** never recovers, because that id no longer exists. If the
-  program under test restarts, aim by name.
-
-- **Every run with a process target now ends by saying how much of the captured traffic was
-  actually yours** - "In scope: 40 of 500 captured packets" - and calls it out when that number is
-  zero. A run in which your target caught nothing looks exactly like a run in which your
-  application coped, and those are opposite results. The existing `--min-packets` check cannot see
-  this: it catches a traffic filter that matched nothing, which is a different mistake. This is a
-  warning rather than a failure, because aiming at a program that happens to be quiet is a
-  perfectly ordinary thing to do.
-
-- **The session panel now shows how long packets waited inside the driver before the tool saw
-  them.** This is the one delay the tool adds and counted nowhere: it happens in WinDivert's queue,
-  ahead of the tool's own, so a tester measuring latency puts it down to their application or to
-  the network. It is not an estimate - the driver stamps every packet with a capture time, and the
-  tool now reads it 20 times a second. **"Driver queue wait (peak)"** in the Session tab holds the
-  worst one, and it goes into the reproduction report with everything else. On an idle machine
-  expect a fraction of a millisecond (measured here: 0.05-0.16 ms). Above 50 ms the log and the
-  event list say so, at most once every five seconds. It stays blank under `--simulate`, which has
-  no driver to wait in.
-
-- **A session now records the WinDivert queue it is running behind.** WinDivert has its own buffer,
-  ahead of this tool's, and nothing here ever read it - so a packet could sit in the driver for up
-  to two seconds (the default queue time), land on your measured latency, and appear in no counter
-  at all. The three values (length, time, size) are read when a session starts, written to the log,
-  and stored in the reproduction report as `session.driver_queue`, so a report from a machine you
-  do not have in front of you says which queue produced its numbers. Read on this machine:
-  4096 packets / 2000 ms / 4 MiB - and note the size limit binds first for full-size packets,
-  4 MiB / 1500 B = 2796 packets, not 4096. Nothing is changed about how the queue behaves; this is
-  about being able to see it. `--doctor` deliberately does not read them: the values need an open
-  handle, and opening one loads the driver, which would falsify the "windivert driver" line printed
-  in the same report.
-
-### Fixed
 
 - **The live "which app owns this port" map could be dragged backwards by a stale reading, so a
   connection was briefly credited to the wrong application.** The tool learns who owns a socket
@@ -477,33 +465,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   Readings are now weighed by when they were actually taken, so the older one no longer wins. The
   sweep still corrects the map when it genuinely is the newer of the two, which is what recovers
   from a socket event lost under heavy load.
-
-### BREAKING
-
-- **BREAKING:** **"Duplicated" now counts packets that were actually sent twice, not packets the
-  tool decided to duplicate.** With duplication on and the tool under enough load to fill its
-  internal queue, the copy was quietly thrown away while the counter went up anyway. Measured on a
-  deliberately tiny queue: 40 packets in, **"Duplicated" read 40 while nothing at all reached the
-  wire**. The tile sits next to "Corrupted", which has always counted only the packets it really
-  changed, so this brings the two into line. Reports and NDJSON output from before and after this
-  change are not comparable on that field. Nothing else moved: the same packets are duplicated,
-  and the "Buffer overflow" tile already told you when the queue was the bottleneck.
-
-### Added
-
-- **The tool now warns when your target shares a port with another program.** Windows lets several
-  programs hold the same local port at once - that is how mDNS, SSDP and DHCP work - and this tool
-  decides what to break from the port number, so on those ports it genuinely cannot tell whose
-  traffic it is looking at. On this machine, four port numbers out of 127 were like that, and one
-  of them (5353, used for local device discovery) had **five** owners at the same time. The
-  consequence is real in both directions: aiming at one program could leave its own traffic on such
-  a port untouched, or sweep three other programs' traffic in with it. Nothing about that changed -
-  it cannot be fixed, because the port number simply does not say who sent the packet - but the
-  tool no longer keeps it to itself. Applying a target now says which port is shared and with whom,
-  so you know that part of the result is a coin toss. Ports that are not shared, which is where
-  your application's own traffic lives, are unaffected.
-
-### Fixed
 
 - **When the capture could not start, the tool told you the wrong reason.** If the WinDivert handle
   failed to open - no Administrator rights, a driver blocked or held at a different version by
@@ -821,6 +782,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   before the window went back to normal. Your network was already handed back at once - it was only
   the button that lagged - but a STOP that looks stuck is exactly the wrong thing in a tool whose
   whole job is undoing what you did to your own connection. It now finishes right away either way.
+
+### Docs
+
+- **Both READMEs claimed slightly more than the tool does about brand-new connections.** They said
+  a connection is in scope "the moment it opens", which holds for a program the tool already
+  recognises but not for that program's *first* connection: until it owns at least one socket there
+  is nothing to recognise it by, so that one connection goes through untouched. Measured, so the
+  exception is now stated rather than implied, next to a new note on what to do about it - if the
+  program under test restarts, aim by **name** rather than by process id.
+
+- **The process field's exclusions are now documented properly.** Writing `!chrome` means "impair
+  everything except chrome" - and "everything" includes any connection whose owning process could
+  not be identified yet, which every brand-new connection passes through. If you want one
+  application left alone, name the one you *do* want broken instead; then anything unidentified
+  passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
 
 ## [0.3.0] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -798,6 +798,28 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   application left alone, name the one you *do* want broken instead; then anything unidentified
   passes through untouched. Both READMEs say so next to the equivalent note for `!53` on ports.
 
+- **Both READMEs described a checkbox that does not exist.** They explained greyed-out fields with
+  "Period"/"Down percentage" going inactive when an **"Enable"** box is unchecked. Those boxes were
+  removed some time ago, so a reader was being sent to look for a control that is not there. The
+  paragraph now uses the case that really happens: "Download"/"Upload" grey out with a note when a
+  Schedule takes them over.
+
+- **What the automated checks actually cover, and what happens at release.** The Tests section
+  listed about half of what runs on every push. It now includes the coverage gate, the `--doctor`
+  and `--license` checks, the check that the WinDivert driver really shipped next to the exe, and
+  the one step no unit test can stand in for: a **GUI render check on real Tk** at the minimum
+  1366x768, **in every language**, which fails the build when a button's text is clipped. Polish
+  labels are longer than English ones, so that is where layouts break. There is also a short
+  description of how a release is produced, since the README asks you to verify the
+  `SHA256SUMS.txt` that workflow publishes.
+
+- **`psutil` is no longer described as what makes process targeting work.** "Target process" said
+  it *requires* `psutil`. On Windows the socket table and the process names come from the OS, and
+  targeting keeps working with `psutil` removed outright (measured: 310 ports mapped, 37 of 37
+  names resolved). It is the fallback used off Windows. The Requirements section also now says
+  plainly that installing from source works on Python 3.10 and newer while CI tests and builds on
+  3.14 only, which is the version frozen into the released `.exe`.
+
 ## [0.3.0] - 2026-07-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -112,7 +112,16 @@ crash the app).
 
 - Windows 10/11 (64-bit), Python 3.10+ (with the tcl/tk option)
 - Administrator rights
-- `pydivert` (traffic capture), `psutil` (process targeting - optional)
+- `pydivert` (traffic capture), `psutil` (a fallback, see below)
+
+Installing from source works on Python 3.10 and newer. CI tests and builds on **3.14 only** -
+that is the version the released `.exe` is frozen with, so older ones are supported but not
+re-proven on every commit.
+
+`psutil` is installed with the tool but is not what makes process targeting work on Windows. There
+the socket table and the process names come straight from the OS, and targeting keeps working with
+`psutil` removed entirely (measured: 310 ports mapped, 37 of 37 names resolved). It is the fallback
+for everything else, which is how the engine's tests run on Linux with no driver at all.
 
 ## The window
 
@@ -174,8 +183,10 @@ While a session runs **two elements are locked** (they unlock on STOP): the **tr
 (applied only at START) and the **language selector** (changing language rebuilds the whole UI).
 The STOP button is red - it cannot be confused with START.
 
-Inactive fields (e.g. "Period"/"Down percentage" when "Enable" is unchecked) are **greyed out
-together with their labels** - you can see at a glance what is active and what is not.
+A field another setting has taken over is **greyed out together with its label**, with a note
+saying which setting took it - "Download"/"Upload" do this when a Schedule is set, because the
+throughput then comes from the schedule steps. You can see at a glance what is actually in
+effect.
 
 ### Keyboard shortcuts
 
@@ -216,7 +227,7 @@ behaves without internet access (e.g. no gateway/WAN, a captive portal).
 **Target process** - narrow the effect to chosen apps: process name (e.g. `chrome.exe`), PID, a
 comma-separated list, PID range, wildcard or regular expression - see
 [Filter syntax](#filter-syntax-process--ip--port). The rest of the machine's traffic stays
-untouched. Empty field = all traffic. Requires `psutil`.
+untouched. Empty field = all traffic.
 
 **Speed limit** - maximum throughput separately for download (inbound) and upload (outbound), in
 KB/s. 0 = no limit. Ping is small packets, so a speed limit barely changes it - to test the limit
@@ -1102,10 +1113,23 @@ The **CI/CD CLI contract** is guarded separately:
   a *fail-open* (releasing the driver = network returns), the GUI `_tick` survives an exception, the
   targeting thread never touches tkinter, closing the window always releases the engine.
 
-**GitHub Actions** runs the same tests on every push (`.github/workflows/ci.yml`): a Linux +
-**Windows** matrix, GUI smoke, exit-code assertions, an NDJSON check, and finally **an `.exe` build
-and a smoke test of the built file** (`--version`, `--simulate`, a bad config -> code 3) with a
-downloadable artifact.
+**GitHub Actions** runs the same tests on every push (`.github/workflows/ci.yml`), on a Linux +
+**Windows** matrix: the suite behind a **coverage gate**, the GUI smoke on the fake tkinter,
+exit-code assertions, an NDJSON check, `--doctor` and `--license`, and then **an `.exe` build with
+a smoke test of the built file** (`--version`, `--simulate`, a bad config -> code 3) plus a check
+that the WinDivert driver really shipped next to the exe, with a downloadable artifact.
+
+One step is worth knowing about because no unit test can do its job: a **GUI render check on real
+Tk** under a virtual screen, at the minimum supported 1366x768, **in every language**. It builds
+the actual window, walks every page, opens the About window and fails the build when any button is
+narrower than it asks to be, which is to say when its text is clipped. Polish labels are longer
+than English ones, so that is where layouts break, and it has caught breakage that was invisible
+in English.
+
+Releases go out through a second workflow (`.github/workflows/release.yml`) on a `v*` tag. It
+checks the tag against `VERSION.txt`, refuses to publish while the changelogs are still open,
+builds and smoke-tests the exe, then publishes the zip together with the `SHA256SUMS.txt` this
+README tells you to verify.
 
 ## Project layout
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -99,7 +99,17 @@ The UI is bilingual (Polish and English). On startup the language follows your s
 
 - Windows 10/11 (64-bit), Python 3.10+ (z opcją tcl/tk)
 - Uprawnienia administratora
-- `pydivert` (przechwytywanie ruchu), `psutil` (celowanie w proces - opcjonalne)
+- `pydivert` (przechwytywanie ruchu), `psutil` (rezerwa, patrz niżej)
+
+Instalacja ze źródeł działa na Pythonie 3.10 i nowszym. CI testuje i buduje **wyłącznie na 3.14** -
+to ta wersja jest zamrożona w wydawanym pliku `.exe`, więc starsze są wspierane, ale nie
+sprawdzane przy każdym commicie.
+
+`psutil` instaluje się razem z narzędziem, ale to nie on sprawia, że celowanie w proces działa na
+Windows. Tam tablica gniazd i nazwy procesów pochodzą wprost z systemu, a celowanie działa nawet
+po całkowitym usunięciu `psutila` (zmierzone: 310 zmapowanych portów, 37 z 37 rozwiązanych nazw).
+Jest rezerwą dla wszystkiego innego, dzięki czemu testy silnika chodzą na Linuksie zupełnie bez
+sterownika.
 
 ## Okno programu
 
@@ -129,7 +139,7 @@ Rozmiar i pozycja okna, wybrana zakładka, język, zwinięte sekcje, podział lo
 W trakcie działającej sesji **zablokowane są dwa elementy** (odblokowują się po STOP):
 **filtr ruchu** (stosowany tylko przy STARCIE) oraz **wybór języka** (zmiana języka przebudowuje całe UI). Przycisk STOP jest czerwony - nie da się go pomylić ze START.
 
-Nieaktywne pola (np. „Okres”/„Procent przerwy”, gdy „Włącz” jest odznaczone) są **wyszarzone razem z etykietami** - od razu widać, co jest aktywne, a co nie.
+Pole, które przejęło inne ustawienie, jest **wyszarzone razem z etykietą**, z notką mówiącą, co je przejęło - robią tak „Pobieranie”/„Wysyłanie”, gdy ustawisz Harmonogram, bo przepustowość bierze się wtedy z jego kroków. Od razu widać, co naprawdę działa.
 
 ### Skróty klawiaturowe
 
@@ -157,7 +167,7 @@ Pola liczbowe są sprawdzane **na żywo, razem z zakresem** (np. utrata 0-100%, 
 **Celuj w proces** - zawęź działanie do wybranych aplikacji: nazwa procesu (np. `chrome.exe`),
 PID, lista po przecinku, zakres PID, wildcard lub wyrażenie regularne - patrz
 [Składnia filtrów](#składnia-filtrów-proces--ip--port). Reszta ruchu na komputerze pozostaje
-nietknięta. Puste pole = cały ruch. Wymaga `psutil`.
+nietknięta. Puste pole = cały ruch.
 
 **Limit prędkości** - maksymalna przepustowość osobno dla pobierania (ruch przychodzący)
 i wysyłania (wychodzący), w KB/s. 0 = bez limitu. Ping to małe pakiety, więc limit prędkości
@@ -960,9 +970,23 @@ Osobno pilnowany jest **kontrakt CLI pod CI/CD**:
   wątek celowania nigdy nie dotyka tkintera, zamknięcie okna zawsze zwalnia silnik.
 
 Te same testy odpala automatycznie **GitHub Actions** przy każdym pushu
-(`.github/workflows/ci.yml`): macierz Linux + **Windows**, smoke GUI, asercje kodów wyjścia,
-sprawdzenie NDJSON, a na koniec **build `.exe` i smoke zbudowanego pliku** (`--version`,
-`--simulate`, błędna konfiguracja → kod 3) z artefaktem do pobrania.
+(`.github/workflows/ci.yml`), na macierzy Linux + **Windows**: cały suite za **bramką pokrycia**,
+smoke GUI na atrapie tkintera, asercje kodów wyjścia, sprawdzenie NDJSON, `--doctor` i `--license`,
+a na koniec **build `.exe` i smoke zbudowanego pliku** (`--version`, `--simulate`, błędna
+konfiguracja → kod 3) plus kontrola, że sterownik WinDivert naprawdę trafił obok exe, z artefaktem
+do pobrania.
+
+Jeden krok wart jest osobnego zdania, bo żaden test jednostkowy go nie zastąpi: **render GUI na
+prawdziwym Tk** pod wirtualnym ekranem, w minimalnej wspieranej rozdzielczości 1366x768 i **w
+każdym języku**. Buduje prawdziwe okno, obchodzi wszystkie strony, otwiera okno „O programie” i
+wywala build, gdy którykolwiek przycisk jest węższy, niż prosi, czyli gdy jego tekst jest ucięty.
+Polskie napisy są dłuższe od angielskich, więc to tam pękają układy, i ten krok złapał już
+uszkodzenia niewidoczne po angielsku.
+
+Wydania wychodzą drugim workflow (`.github/workflows/release.yml`), po wypchnięciu tagu `v*`.
+Sprawdza on tag wobec `VERSION.txt`, odmawia publikacji, dopóki changelogi są otwarte, buduje exe
+i robi jego smoke, a potem publikuje zip razem z plikiem `SHA256SUMS.txt`, którego weryfikację
+opisuje to README.
 
 ## Struktura projektu
 

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -132,3 +132,128 @@ def test_breaking_sections_come_first():
 
         check(f"{name}: every BREAKING section comes first in its version",
               not problems, f"({problems})")
+
+
+# --- the release itself, not the code in it --------------------------------- #
+#
+# Everything above guards the tree. These three guard the ACT of releasing, which
+# until 0.4.0 had no mechanical enforcement at all: the rules existed in prose
+# ("the owner closes a version by setting VERSION.txt", "the version in
+# release.yml and in ci.yml's build job must be the SAME") and three of them had
+# already been broken in practice. Prose is not a guard.
+
+
+CHANGELOG_FILES = ("CHANGELOG.md", "CHANGELOG-INTERNAL.md")
+DATED_VERSION_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\]\s+-\s+\d{4}-\d{2}-\d{2}\b")
+
+
+def _versions_in(name):
+    """-> {heading -> [section headings]} for every `## [...]` block."""
+    path = os.path.join(ROOT, name)
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+    blocks, current = {}, None
+    for line in lines:
+        if line.startswith("## ["):
+            current = line.strip()
+            blocks[current] = []
+        elif line.startswith("### ") and current:
+            blocks[current].append(line.strip())
+    return blocks
+
+
+def test_version_txt_has_a_dated_section_in_both_changelogs():
+    """VERSION.txt must name a released, DATED section in both changelogs.
+
+    The failure this closes is silent by construction: `release.yml` checks the
+    tag against VERSION.txt and nothing else, so a version bumped without its
+    changelog section being opened and dated publishes a release whose notes
+    describe a different version. Nothing on the way there is red.
+
+    It holds during ordinary development too, because VERSION.txt carries the
+    LAST released version while new entries collect under [Unreleased] - so this
+    is safe to run on every commit, not only at release time.
+    """
+    version = _version_txt()
+    for name in CHANGELOG_FILES:
+        headings = [h for h in _versions_in(name) if DATED_VERSION_RE.match(h)]
+        match = [h for h in headings
+                 if DATED_VERSION_RE.match(h).group(1) == version]
+        check(f"{name}: VERSION.txt {version} has a dated `## [{version}] - YYYY-MM-DD` section",
+              len(match) == 1, f"(found {match or headings[:3]})")
+
+
+def test_the_mutable_changelog_sections_have_no_duplicate_headings():
+    """One `### Added` per version, not three.
+
+    Scope is deliberate and narrow:
+
+    * only `CHANGELOG.md`, because `CHANGELOG-INTERNAL.md` is a chronological
+      technical log whose headings carry information a type vocabulary cannot
+      (`### ADR 2026-07-29: Nuitka ...`), and normalising those would delete
+      content;
+    * only the sections still MUTABLE - `[Unreleased]` and the one matching
+      VERSION.txt. Older versions are published release notes: `[0.3.0]` does
+      carry a duplicate `### Changed`, and rewriting notes people have already
+      read is worse than the duplicate.
+
+    Why it exists: the duplicates were merged by hand twice (commits `61601ad`,
+    `0aaa86a`) and came back both times, because the only structural guard
+    (`test_breaking_sections_come_first`) builds the section list and then looks
+    at exactly one index of it.
+    """
+    version = _version_txt()
+    blocks = _versions_in("CHANGELOG.md")
+    mutable = [h for h in blocks
+               if h == "## [Unreleased]"
+               or (DATED_VERSION_RE.match(h)
+                   and DATED_VERSION_RE.match(h).group(1) == version)]
+    check("CHANGELOG.md: there is a mutable section to check", bool(mutable),
+          "(neither [Unreleased] nor the VERSION.txt version was found)")
+
+    for heading in mutable:
+        sections = blocks[heading]
+        dupes = sorted({s for s in sections if sections.count(s) > 1})
+        check(f"CHANGELOG.md {heading}: no section heading appears twice",
+              not dupes, f"({dupes})")
+
+        unknown = sorted(set(sections) - {"### BREAKING", "### Added", "### Changed",
+                                          "### Fixed", "### Removed", "### Docs"})
+        check(f"CHANGELOG.md {heading}: only convention 39's section names",
+              not unknown, f"({unknown})")
+
+
+def test_ci_and_release_freeze_the_same_python():
+    """PyInstaller bakes the interpreter into the bundle, so `ci.yml`'s build job
+    and `release.yml` must use the SAME one - otherwise CI smoke-tests one
+    artefact and users download another.
+
+    That sentence was in PROJECT_NOTES and nothing enforced it. Parsed by line
+    scan rather than a YAML library on purpose: PyYAML is not in
+    requirements-dev.txt, so importing it would make this test an error on a
+    fresh CI checkout. The scan FAILS when it cannot find what it expects - a
+    guard that silently passes when the file moves under it is not a guard.
+    """
+    def python_versions(path, inside_job=None):
+        with open(os.path.join(ROOT, ".github", "workflows", path),
+                  encoding="utf-8") as f:
+            lines = f.read().splitlines()
+        if inside_job is not None:
+            starts = [i for i, ln in enumerate(lines)
+                      if re.match(r"^  [A-Za-z0-9_-]+:\s*$", ln)]
+            wanted = [i for i in starts if lines[i].strip() == f"{inside_job}:"]
+            check(f"{path}: the {inside_job!r} job is still there", len(wanted) == 1,
+                  f"(jobs found: {[lines[i].strip() for i in starts]})")
+            begin = wanted[0]
+            after = [i for i in starts if i > begin]
+            lines = lines[begin:after[0] if after else len(lines)]
+        found = re.findall(r'python-version:\s*"?([0-9][0-9.]*)"?', "\n".join(lines))
+        check(f"{path}: a literal python-version is declared", bool(found),
+              "(none found - did the key move or become a variable?)")
+        return set(found)
+
+    release = python_versions("release.yml")
+    build = python_versions("ci.yml", inside_job="build")
+    check("release.yml freezes exactly one Python", len(release) == 1, f"({release})")
+    check("ci.yml's build job and release.yml freeze the SAME Python",
+          release == build, f"(release={release} ci-build={build})")

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -6,6 +6,8 @@ a licence that did not make it into the tree, a VERSION.txt in the wrong shape.
 """
 import os
 import re
+import subprocess
+import sys
 
 from fakes import ROOT, check
 
@@ -183,6 +185,73 @@ def test_version_txt_has_a_dated_section_in_both_changelogs():
               len(match) == 1, f"(found {match or headings[:3]})")
 
 
+def _mutable_headings(blocks):
+    """The `## [...]` blocks still open to editing: [Unreleased] and VERSION.txt's.
+
+    Everything older is a published release note. `[0.3.0]` carries a duplicate
+    `### Changed` and entries far over the length cap below, and rewriting notes
+    people have already read is worse than leaving them.
+    """
+    version = _version_txt()
+    return [h for h in blocks
+            if h == "## [Unreleased]"
+            or (DATED_VERSION_RE.match(h)
+                and DATED_VERSION_RE.match(h).group(1) == version)]
+
+
+def test_no_user_facing_entry_grows_into_an_essay():
+    """A CHANGELOG.md entry is at most 100 words. It is a release note, not an ADR.
+
+    Convention 39 already says this file carries the EFFECT for a tester while
+    CHANGELOG-INTERNAL.md carries the reasoning, and nothing enforced it: the
+    [0.4.0] section reached **11 338 words across 92 entries, median 115, longest
+    342** before it was rewritten to 4 023 / 67 / 65 / 93. The owner's verdict was
+    the plain one - nobody will read that.
+
+    100 rather than the ~40 most entries manage, because the handful that carry a
+    behaviour change a reader must act on (what breaks, what to do instead) really
+    do need the room, and a cap that forces those into three entries is worse than
+    one long one. The cap is the ceiling, not the target.
+
+    CHANGELOG.md only, and only the mutable sections - same scope, same reasons,
+    as the duplicate-heading guard below.
+    """
+    path = os.path.join(ROOT, "CHANGELOG.md")
+    with open(path, encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    version, entry, offenders, entries = None, None, [], 0
+
+    def close(entry):
+        if not entry:
+            return
+        words = len(" ".join(entry).split())
+        if words > 100:
+            offenders.append((words, entry[0][:70]))
+
+    mutable = set(_mutable_headings(_versions_in("CHANGELOG.md")))
+    inside = False
+    for line in lines:
+        if line.startswith("## ["):
+            close(entry) if inside else None
+            entry, inside = None, line.strip() in mutable
+        elif inside and re.match(r"^- ", line):
+            close(entry)
+            entry = [line]
+            entries += 1
+        elif inside and line.startswith("### "):
+            close(entry)
+            entry = None
+        elif inside and entry is not None:
+            entry.append(line)
+    close(entry)
+
+    check("CHANGELOG.md: the mutable section has entries to measure", entries > 0,
+          "(none found - did the section markers change?)")
+    check(f"CHANGELOG.md: no entry over 100 words ({entries} checked)",
+          not offenders, f"({sorted(offenders, reverse=True)[:3]})")
+
+
 def test_the_mutable_changelog_sections_have_no_duplicate_headings():
     """One `### Added` per version, not three.
 
@@ -202,12 +271,8 @@ def test_the_mutable_changelog_sections_have_no_duplicate_headings():
     (`test_breaking_sections_come_first`) builds the section list and then looks
     at exactly one index of it.
     """
-    version = _version_txt()
     blocks = _versions_in("CHANGELOG.md")
-    mutable = [h for h in blocks
-               if h == "## [Unreleased]"
-               or (DATED_VERSION_RE.match(h)
-                   and DATED_VERSION_RE.match(h).group(1) == version)]
+    mutable = _mutable_headings(blocks)
     check("CHANGELOG.md: there is a mutable section to check", bool(mutable),
           "(neither [Unreleased] nor the VERSION.txt version was found)")
 
@@ -221,6 +286,83 @@ def test_the_mutable_changelog_sections_have_no_duplicate_headings():
                                           "### Fixed", "### Removed", "### Docs"})
         check(f"CHANGELOG.md {heading}: only convention 39's section names",
               not unknown, f"({unknown})")
+
+
+def test_release_notes_extract_every_released_version():
+    """`tools/release_notes.py` is what the release page shows, so it is load-bearing.
+
+    It must produce a non-empty body for every version in CHANGELOG.md, must not
+    repeat the `## [x.y.z]` heading (gh sets the title), and must refuse an
+    unknown version loudly - an empty release body would publish happily and be
+    noticed by users rather than by us.
+
+    The encoding case is not hypothetical. `release.yml` runs on windows-latest,
+    where stdout still defaults to the ANSI code page, and `[0.3.0]` contains
+    U+25CF: writing it as str raised UnicodeEncodeError and would have failed the
+    publish step. The tool writes UTF-8 bytes, and this test reads them back as
+    bytes so a regression cannot hide behind the test's own decoding.
+    """
+    sys.path.insert(0, os.path.join(ROOT, "tools"))
+    try:
+        import release_notes
+    finally:
+        sys.path.pop(0)
+
+    with open(os.path.join(ROOT, "CHANGELOG.md"), encoding="utf-8") as f:
+        text = f.read()
+    versions = re.findall(r"^## \[(\d+\.\d+\.\d+)\]", text, re.M)
+    check("CHANGELOG.md declares released versions to extract", bool(versions),
+          f"({versions})")
+
+    for version in versions:
+        body = release_notes.section(version, text)
+        check(f"release notes for {version} are not empty", bool(body and body.strip()))
+        check(f"release notes for {version} drop the version heading",
+              not (body or "").lstrip().startswith("## ["))
+        check(f"release notes for {version} stop before the next version",
+              "## [" not in (body or ""))
+        check(f"release notes for {version} survive a round trip through UTF-8",
+              body.encode("utf-8").decode("utf-8") == body)
+
+    check("an unknown version yields nothing rather than an empty-looking body",
+          release_notes.section("99.99.99", text) is None)
+
+    # Run the real process for EVERY version, not just VERSION.txt's.
+    #
+    # This is the half that matters and the half that was missing. The first
+    # version of this test ran the subprocess once, for VERSION.txt - which is
+    # 0.4.0, and 0.4.0 is pure ASCII. Reverting the UTF-8 byte write therefore
+    # left the test GREEN: it never fed the process the character that breaks it.
+    # Caught by mutation, and only after re-running the mutants from a clean
+    # baseline, because release_notes.py was untracked and `git checkout` had been
+    # silently restoring nothing.
+    script = os.path.join(ROOT, "tools", "release_notes.py")
+    non_ascii_seen = False
+    for version in versions:
+        out = subprocess.run([sys.executable, script, version], capture_output=True)
+        check(f"release_notes.py exits 0 for {version}", out.returncode == 0,
+              f"({out.returncode}, {out.stderr[-200:]!r})")
+        check(f"release_notes.py writes decodable UTF-8 for {version}",
+              bool(out.stdout) and out.stdout.decode("utf-8").strip(),
+              f"({out.stdout[:80]!r})")
+        if any(b > 127 for b in out.stdout):
+            non_ascii_seen = True
+
+    # Without this the encoding guard above can quietly stop guarding anything:
+    # an all-ASCII changelog would pass it on every version while the console
+    # encoding path goes untested. [0.3.0] carries U+25CF and is frozen history,
+    # so this holds today - and says so out loud if it ever stops.
+    check("at least one released section carries non-ASCII, so the encoding path is "
+          "actually exercised", non_ascii_seen,
+          "(every section is ASCII - this test no longer proves the Windows "
+          "console-encoding fix)")
+
+    missing = subprocess.run([sys.executable,
+                              os.path.join(ROOT, "tools", "release_notes.py"), "99.99.99"],
+                             capture_output=True)
+    check("release_notes.py fails loudly on an unknown version",
+          missing.returncode != 0 and not missing.stdout.strip(),
+          f"(rc={missing.returncode}, stdout={missing.stdout[:80]!r})")
 
 
 def test_ci_and_release_freeze_the_same_python():

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Print one version's section of CHANGELOG.md, ready to publish or paste.
+
+`release.yml` feeds this to `gh release create --notes-file`, so the GitHub
+release page shows the curated notes instead of a list of merged pull request
+titles. The same output is what you paste into a blog post or a forum thread.
+
+The point is that there is no second copy to drift: CHANGELOG.md is the source,
+and the release page, the blog post and the file all say the same words. That
+matters more here than it looks - nobody proof-reads a release page against a
+changelog, so a second copy would be wrong within one release and stay wrong.
+
+Usage:
+    python tools/release_notes.py            # the version in VERSION.txt
+    python tools/release_notes.py 0.3.0      # any released version
+
+Stdlib only, on purpose: the release job installs the runtime requirements and
+PyInstaller, not the dev extras, so anything else would fail at publish time -
+the one moment nobody wants a surprise.
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CHANGELOG = os.path.join(ROOT, "CHANGELOG.md")
+VERSION_FILE = os.path.join(ROOT, "VERSION.txt")
+
+
+def section(version, text):
+    """The body of `## [version] ...`, without the heading. None when absent."""
+    lines = text.splitlines()
+    starts = [i for i, ln in enumerate(lines) if ln.startswith("## [")]
+    for n, start in enumerate(starts):
+        if re.match(r"^## \[%s\]" % re.escape(version), lines[start]):
+            end = starts[n + 1] if n + 1 < len(starts) else len(lines)
+            body = lines[start + 1:end]
+            while body and not body[0].strip():
+                body.pop(0)
+            while body and not body[-1].strip():
+                body.pop()
+            return "\n".join(body)
+    return None
+
+
+def main(argv):
+    if len(argv) > 1:
+        version = argv[1]
+    else:
+        with open(VERSION_FILE, encoding="utf-8") as fh:
+            version = fh.read().strip()
+
+    with open(CHANGELOG, encoding="utf-8") as fh:
+        found = section(version, fh.read())
+
+    if found is None:
+        # Loud, not empty. An empty release body would publish happily and be
+        # noticed by users rather than by us.
+        sys.stderr.write(
+            "release_notes: no '## [%s]' section in CHANGELOG.md\n" % version)
+        return 1
+
+    # Write UTF-8 bytes rather than str. `release.yml` runs on windows-latest,
+    # where stdout still defaults to the ANSI code page on this Python, so a
+    # single non-ASCII character in the notes crashes the publish step with a
+    # UnicodeEncodeError. Found the real way: [0.3.0] contains U+25CF, and
+    # printing it raised while 0.4.0 (all ASCII) looked fine.
+    out = getattr(sys.stdout, "buffer", None)
+    if out is None:                       # a stream without one (a test harness)
+        sys.stdout.write(found + "\n")
+    else:
+        out.write((found + "\n").encode("utf-8"))
+        out.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes the changelogs for 0.4.0 and puts guards on the act of releasing, which
until now had none.

## Why this was needed before tagging

`v0.4.0-rc.1` was cut on 2026-07-30. **43 commits landed after it**, all
collecting under `[Unreleased]`, three of them BREAKING. Tagging `v0.4.0` in
that state would have published a release whose changelog dates 0.4.0 weeks
earlier, omits those three contract breaks from the released section, and files
them under a heading saying they are not released yet.

`release.yml` would not have caught it: it only compared the tag's base to
`VERSION.txt`, and `0.4.0` matches either way.

## What is in here

**Changelogs closed.** `[Unreleased]` folded into `## [0.4.0] - 2026-08-01` in
both files. `CHANGELOG.md` now has one section per type in a canonical order -
the two blocks together held three `### Added`, three `### Fixed` and two
`### BREAKING`. Entry counts preserved: 89 in, 89 out, and 496 in, 496 out.
`CHANGELOG-INTERNAL.md` keeps its section order and wording, because its
headings carry information a type vocabulary cannot hold.

**0.4.0's user-facing notes rewritten at a third of the length.** Measured
first: 817 lines, 92 entries, 11338 words, median 115 per entry, longest 342.
Now 346 lines, 67 entries, 4023 words, median 65, longest 93. Nothing was lost -
`CHANGELOG-INTERNAL.md` holds 50729 words for the same version, and eight topics
from the longest entries were checked there before cutting. Six entries carrying
`**BREAKING:**` were sitting inside `### Changed` and are now in `### BREAKING`.
Past versions are untouched: they are release notes people have already read.

**The release page will show the changelog.** `release.yml` used
`--generate-notes`, which lists merged pull request titles - for this release
that would have been 43 of them. New `tools/release_notes.py` extracts the
version's section from `CHANGELOG.md` and the workflow passes it as
`--notes-file`, so the release page, a blog post and the changelog are one text.

**Guards, because every rule about releasing was prose and three had already
been broken.**

| rule | guard |
|---|---|
| `VERSION.txt` names a dated section in both changelogs | `test_version_txt_has_a_dated_section_in_both_changelogs` |
| mutable `CHANGELOG.md` sections have no duplicate headings | `test_the_mutable_changelog_sections_have_no_duplicate_headings` |
| no user-facing entry over 100 words | `test_no_user_facing_entry_grows_into_an_essay` |
| the extractor handles every released version | `test_release_notes_extract_every_released_version` |
| `ci.yml`'s build job and `release.yml` freeze the same Python | `test_ci_and_release_freeze_the_same_python` |
| `[Unreleased]` is empty at tag time | a step in `release.yml` |

The last one is a workflow step rather than a test on purpose: during ordinary
development `[Unreleased]` is supposed to have entries, so it cannot be
always-on. An empty `[Unreleased]` heading passes, since that is the normal
shape between releases.

**README accuracy**, in both languages: an "Enable" checkbox that no longer
exists, `psutil` described as what makes process targeting work (it is the
off-Windows fallback - measured with the import blocked: 310 ports mapped, 37 of
37 names resolved), a Tests section listing about half of what CI runs, and no
mention anywhere of how a release is produced.

## Verification

Guards verified by mutation, twelve mutants. Two of those runs had to be redone:
`tools/release_notes.py` was untracked, so `git checkout --` restored nothing
and the mutants accumulated. Re-run from an explicit known-good copy, **one
survived** - because the test ran the subprocess only for `VERSION.txt`, which
is pure ASCII, and the bug needs a non-ASCII character. The test now runs the
real process for every released version.

That bug was real and release-blocking: `release.yml` runs on `windows-latest`,
where stdout defaults to the ANSI code page, and `[0.3.0]` carries U+25CF.
Writing the notes as `str` raised `UnicodeEncodeError` and would have failed the
publish step.

Full suite green (903 tests, exit 0), GUI smoke green, and the `release.yml`
gate exercised against four trees before landing: current (pass), an
`[Unreleased]` reopened with one entry (fail), an undated heading (fail), and an
empty `[Unreleased]` (pass).
