### PR TITLE
chore(repo): ignore CLAUDE.md alongside the other private dev notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ BeanNetworkTester-*.zip
 
 # Claude config and dev notes - kept in the private BeanNetworkTester-Doc repo
 .claude/
+CLAUDE.md
 PROJECT_NOTES.md
 HISTORY_NOTES.md
 


### PR DESCRIPTION
One line in `.gitignore`.

`CLAUDE.md` is the short entry point a Claude Code session loads on its own. It points at `PROJECT_NOTES.md` (the source) and repeats only the rules whose breach is expensive or irreversible, so a session that never opens the notes still gets them.

Like `PROJECT_NOTES.md`, `HISTORY_NOTES.md` and `.claude/`, it is a maintainer file kept in the private BeanNetworkTester-Doc repo, so it must not land in the public tree. The existing comment block in `.gitignore` already explains that group.

No code, no behaviour, nothing shipped changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)