### PR TITLE
fix(licence): match the LGPL instructions to what is really shipped

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,10 @@
       English throughout, no local file paths or machine names, no personal data
       of any kind, no credentials, and every comment explains itself rather than
       pointing at a document only the maintainers can open.
+- [ ] **Quotes the program, not a person.** Interface text, command output and
+      code are evidence and belong here. A sentence from a chat, an email or an
+      issue thread is somebody else's words: say what was found, not who said
+      it. Translating it first does not change that.
 - [ ] Any new dependency, DLL, font or bundled asset has a licence compatible
       with the GPLv3, an entry in `THIRD-PARTY-NOTICES.md`, its full licence text
       in `licenses/` and a row in `beantester/legal.py`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,12 @@
 - [ ] User-facing changes noted in `CHANGELOG.md`, under `[Unreleased]`.
 - [ ] Commits follow Conventional Commits (`type(scope): summary`).
 - [ ] No version bump - the owner closes a version via `VERSION.txt`.
+- [ ] **Written for a public audience.** This repository is public, and so is
+      everything in it: code comments, commit messages and this description are
+      readable by anyone, forever, including in the history after an edit. So:
+      English throughout, no local file paths or machine names, no personal data
+      of any kind, no credentials, and every comment explains itself rather than
+      pointing at a document only the maintainers can open.
+- [ ] Any new dependency, DLL, font or bundled asset has a licence compatible
+      with the GPLv3, an entry in `THIRD-PARTY-NOTICES.md`, its full licence text
+      in `licenses/` and a row in `beantester/legal.py`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The suite scans FILES. A commit message and a pull-request description are just
+  # as public and just as permanent - a message cannot be edited away, because the
+  # commit that carried it stays - and nothing in tests/ can see either of them. So
+  # the conventions that govern them (English only, plain hyphens, nothing private
+  # to a machine) were held up by remembering, every time. This is the guard.
+  public-text:
+    name: commit messages and PR description
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the whole range being merged, not just its tip
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: check the commit messages
+        run: |
+          python tools/check_public_text.py \
+            --commits origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }}
+      - name: check the pull-request description
+        # Passed through the environment rather than interpolated into the shell:
+        # a description is untrusted text and must never become part of a command.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > pr-body.txt
+          python tools/check_public_text.py --text-file pr-body.txt
+
   tests:
     name: tests (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The licence notices now point at the files that are actually there.** The instructions for
+  replacing WinDivert with your own build named `WinDivert.dll` in `_internal\pydivert\`; the
+  program ships `WinDivert64.dll` in `_internal\pydivert\windivert_dll\`. Replacing the library
+  is a right the LGPL gives you, and directions you cannot follow are not much of one.
+- **The PyDivert replacement instructions were wrong, and quietly so.** They said you could drop a
+  modified `pydivert` package into `_internal\`. Measured against a real build: the copy inside
+  the executable wins, and the replaced module even reports the path you used, so it looks like it
+  worked. The notices now give the two routes that do work - rebuild the application against your
+  version, or run it from source - and the written offer of source now lasts the three years the
+  licence asks of an offer.
+- **"About" now carries the no-warranty notice.** The GPL defines a legal notice as four things
+  together: copyright, no warranty, your right to pass the program on, and where to read the
+  licence. The window had three of them.
 - **Error messages say what to do instead of who is at fault.** A config file with an unusable
   number answered "Invalid value for 'loss'". It now says the setting needs a number between 0
   and 100, and quotes back what it got. A misspelled setting in a scenario file gets the same

--- a/README.md
+++ b/README.md
@@ -1372,10 +1372,15 @@ bootloader. The full list, versions and source addresses are in
 [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), and the full license texts are in the `licenses/`
 directory. From within the program: `--license` (CLI) or the **About** button in the interface.
 
-The LGPL libraries (WinDivert, PyDivert) can be replaced with your own interface-compatible versions -
-which is why the program is built as **onedir**, with the driver and libraries sitting next to the
-.exe file. GPLv3 is compatible with these components' licenses, and nothing in the project's license
-restricts the rights arising from them.
+The LGPL libraries can be replaced with your own interface-compatible versions, and the two are
+replaced differently. **WinDivert** is a DLL and a driver loaded from disk at run time, so you swap
+the files in `_internal\pydivert\windivert_dll\` - which is why the program is built as **onedir**
+rather than as a single file. **PyDivert** is pure Python and is compiled into the .exe, so it is
+replaced by rebuilding the program against your version, or by running it from source. Dropping a
+modified copy next to the .exe does not work, and
+[THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) says so rather than leaving you to find out. GPLv3
+is compatible with these components' licenses, and nothing in the project's license restricts the
+rights arising from them.
 
 ## Privacy: no telemetry
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -1232,11 +1232,16 @@ adresy źródeł są w [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md), a pełn
 teksty licencji w katalogu `licenses/`. Z poziomu programu: `--license` (CLI)
 albo przycisk **O programie** w interfejsie.
 
-Biblioteki LGPL (WinDivert, PyDivert) można podmienić na własne, zgodne
-interfejsowo wersje - dlatego program jest budowany jako **onedir**, ze
-sterownikiem i bibliotekami leżącymi obok pliku .exe. GPLv3 jest zgodna z
-licencjami tych komponentów, a licencja projektu nie ogranicza praw z nich
-wynikających.
+Biblioteki LGPL można podmienić na własne, zgodne interfejsowo wersje, a każdą
+z dwóch podmienia się inaczej. **WinDivert** to DLL i sterownik wczytywane z
+dysku w trakcie działania, więc wymienia się pliki w
+`_internal\pydivert\windivert_dll\` - i właśnie dlatego program jest budowany
+jako **onedir**, a nie jako jeden plik. **PyDivert** jest czystym Pythonem
+i jest wkompilowany w .exe, więc podmienia się go, przebudowując program wobec
+swojej wersji albo uruchamiając go ze źródeł. Podłożenie zmodyfikowanej kopii
+obok .exe nie zadziała, a [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) mówi
+to wprost, zamiast zostawiać to do odkrycia. GPLv3 jest zgodna z licencjami tych
+komponentów, a licencja projektu nie ogranicza praw z nich wynikających.
 
 ## Prywatność: brak telemetrii
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -16,7 +16,7 @@ To see the exact versions bundled in the copy you are holding, run:
 
 ---
 
-## WinDivert (`WinDivert.dll`, `WinDivert64.sys`)
+## WinDivert (`WinDivert64.dll`, `WinDivert64.sys`)
 
 * Copyright (c) basil (basil@reqrypt.org)
 * Used under: **GNU Lesser General Public License, version 3 (LGPLv3)**
@@ -25,15 +25,21 @@ To see the exact versions bundled in the copy you are holding, run:
 * Licence text: `licenses/WinDivert-LICENSE.txt` (contains LGPLv3, GPLv3 and GPLv2)
 * Homepage: https://reqrypt.org/windivert.html
 * Source code: https://github.com/basil00/WinDivert
-* Shipped as: a stand-alone DLL and a stand-alone kernel driver, inside
-  `_internal\pydivert\`. They are **not** compiled into `BeanNetworkTester.exe`.
+* Shipped as: a stand-alone DLL and a stand-alone kernel driver, in
+  `_internal\pydivert\windivert_dll\`. They are **not** compiled into
+  `BeanNetworkTester.exe`.
 
 **Your LGPL rights, in practice.** You may modify WinDivert and use your modified
 version with this program: build (or download) an interface-compatible
-`WinDivert.dll` / `WinDivert64.sys` and replace the files shipped in
-`_internal\pydivert\`. The program loads them from that path at run time and will
-use whatever it finds there. You may reverse engineer Bean Network Tester to the
-extent necessary to debug such modifications.
+`WinDivert64.dll` / `WinDivert64.sys` and replace the two files in
+`_internal\pydivert\windivert_dll\`. The program loads them from that folder at
+run time and will use whatever it finds there. You may reverse engineer Bean
+Network Tester to the extent necessary to debug such modifications.
+
+**Where the folder is.** `_internal` sits next to `BeanNetworkTester.exe`. That the
+libraries are separate files you can swap, rather than code melted into the
+executable, is the reason this program is built as a folder and not as a single
+file: it is what makes the paragraph above something you can actually do.
 
 **Driver signing.** The `WinDivert64.sys` driver shipped here is the official,
 digitally signed build from the WinDivert project. If you replace it with a driver
@@ -57,14 +63,29 @@ machine is in test-signing mode). That is a Windows requirement, not ours.
   `BeanNetworkTester.exe --license`)
 * PyDivert is used **unmodified**.
 
-**Your LGPL rights, in practice.** PyDivert is a pure-Python library. It is bundled
-inside this application, and you may replace it with your own modified,
-interface-compatible version: put your modified `pydivert` package in
-`_internal\pydivert\` (Python packages there take precedence over the bundled
-copy), or rebuild the application against your version. **Written offer:** for as
-long as this release is distributed, the Author will supply, on request and at no
-charge beyond the cost of delivery, the complete corresponding source of the
-PyDivert version used in this build. Contact: https://donislawdev.com/
+**Your LGPL rights, in practice.** PyDivert is a pure-Python library, and its code
+is compiled into `BeanNetworkTester.exe` rather than left on disk beside it. That
+matters for how you replace it, so here is the accurate answer rather than the
+convenient one: **dropping a modified `pydivert` package into `_internal\` does
+not work.** The copy inside the executable wins, and it wins quietly - the
+replaced module even reports the path you put your files at, so it looks like it
+was picked up when it was not. (Measured against a frozen build, 2026-08-04.)
+
+What does work, and what the licence entitles you to:
+
+* **Rebuild this application against your version.** The complete source of Bean
+  Network Tester is public at https://github.com/donislawdev/BeanNetworkTester
+  under the GPLv3, and the build is one command (`pyinstaller
+  BeanNetworkTester.spec`). Install your modified PyDivert into the build
+  environment and the result uses it.
+* **Or run it from source**, where PyDivert is an ordinary installed package and
+  replacing it needs nothing but `pip install`.
+
+**Written offer:** for at least three years from the date of this release, the
+Author will supply, on request and at no charge beyond the cost of delivery, the
+complete corresponding source of the PyDivert version used in this build. You do
+not need to take up that offer to get it - the released source of the exact
+version is linked above. Contact: https://donislawdev.com/
 
 ---
 

--- a/beantester/gui/panels/about.py
+++ b/beantester/gui/panels/about.py
@@ -79,6 +79,13 @@ class AboutWindow(PanelWindow):
         line(text=T("about.license", license=LICENSE_NAME), style="TLabel").pack(
             side="top", fill="x", anchor="w", padx=pad)
         line(text=T("about.license_terms"), style="Muted.TLabel").pack(
+            side="top", fill="x", anchor="w", padx=pad)
+        # The GPL defines "Appropriate Legal Notices" as four things: the
+        # copyright, the absence of a warranty, that the work may be conveyed
+        # under this licence, and how to read it. This window carried three of
+        # them - the disclaimer was only in the README, where a user of the
+        # binary has no reason to look.
+        line(text=T("about.no_warranty"), style="Muted.TLabel").pack(
             side="top", fill="x", anchor="w", padx=pad, pady=(0, scaled(8)))
 
         # The privacy line is the one people came here to read.

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,6 +8,7 @@
   "about.license_terms": "Free and open source under the GNU GPL v3. Use, change and share it under the same licence.",
   "about.licenses_dir": "Full licence texts: {path}",
   "about.no_telemetry": "This program sends no data anywhere. No telemetry, no update checks, no external services.",
+  "about.no_warranty": "There is no warranty of any kind, to the extent the law allows.",
   "about.third_party": "Built on (each under its own licence, see THIRD-PARTY-NOTICES.md):",
   "about.version": "version {version}",
   "app.author": "Author: {author}",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -8,6 +8,7 @@
   "about.license_terms": "Wolne i otwarte oprogramowanie na licencji GNU GPL v3. Wolno używać, zmieniać i udostępniać dalej na tej samej licencji.",
   "about.licenses_dir": "Pełne teksty licencji: {path}",
   "about.no_telemetry": "Ten program nie wysyła nigdzie żadnych danych. Zero telemetrii, brak sprawdzania aktualizacji, brak usług zewnętrznych.",
+  "about.no_warranty": "Program nie ma żadnej gwarancji, w zakresie dozwolonym przez prawo.",
   "about.third_party": "Zbudowany na (każdy składnik na własnej licencji, patrz THIRD-PARTY-NOTICES.md):",
   "about.version": "wersja {version}",
   "app.author": "Autor: {author}",

--- a/tests/test_license_surface.py
+++ b/tests/test_license_surface.py
@@ -106,3 +106,86 @@ def test_license_as_json_is_one_parsable_record_with_every_component():
         check(f"{component['name']} carries source + licence in JSON",
               component.get("source", "").startswith("http")
               and bool(component.get("license")), f"({component})")
+
+
+# -- the replacement instructions have to point at the real files ------------ #
+
+
+def _windivert_binaries():
+    """Where the WinDivert files sit inside the installed pydivert package.
+
+    Returns ``(relative directory, {filenames})`` using forward slashes, or
+    ``None`` when pydivert is absent (it is a Windows-only dependency, so the
+    Linux runner has nothing to check).
+
+    Read from the INSTALLED package rather than from a path typed here, because
+    the whole failure this guards is the package moving its files while our
+    instructions stay where they were.
+    """
+    import os
+    try:
+        import pydivert
+    except ImportError:
+        return None
+    root = os.path.dirname(os.path.dirname(os.path.abspath(pydivert.__file__)))
+    found = {}
+    for dirpath, _dirnames, filenames in os.walk(os.path.dirname(pydivert.__file__)):
+        for name in filenames:
+            if name.lower().startswith("windivert") and name.lower().endswith((".dll", ".sys")):
+                rel = os.path.relpath(dirpath, root).replace(os.sep, "/")
+                found.setdefault(rel, set()).add(name)
+    return next(iter(found.items())) if len(found) == 1 else (None, found)
+
+
+def test_the_notices_name_the_windivert_files_that_are_really_shipped():
+    r"""An LGPL right you cannot follow the directions to is not much of a right.
+
+    Convention 35 exists because these libraries have to be REPLACEABLE by the
+    holder of the binary, and the notices are the instructions for doing it.
+    Measured 2026-08-04: they named ``WinDivert.dll`` in ``_internal\pydivert\``
+    while the build ships ``WinDivert64.dll`` in
+    ``_internal\pydivert\windivert_dll\`` - wrong filename, wrong folder. Nobody
+    noticed because nothing compared the document with the package.
+
+    PyInstaller lays a collected package out exactly as it is installed, so the
+    installed tree is the authority here and no PyInstaller import is needed.
+    """
+    import os
+    result = _windivert_binaries()
+    if result is None:
+        return                      # pydivert is Windows-only; nothing shipped here
+    rel_dir, names = result
+    check("pydivert keeps its WinDivert files in one place", bool(rel_dir),
+          f"(found in several: {names})")
+
+    notices = legal.notices_text()
+    check("notices: the text is readable at all", len(notices) > 500,
+          f"({len(notices)} chars)")
+
+    windows_dir = "_internal\\" + rel_dir.replace("/", "\\")
+    check(f"notices: name the folder the files are really in ({windows_dir})",
+          windows_dir in notices, "(the replacement instructions point elsewhere)")
+    for name in sorted(names):
+        check(f"notices: name the file that is really shipped ({name})",
+              name in notices, "(a user would look for a file that is not there)")
+    # ...and do not still name a file that no longer exists
+    stale = [n for n in ("WinDivert.dll", "WinDivert32.dll")
+             if n not in names and n in notices]
+    check("notices: no longer name a WinDivert file this build does not ship",
+          not stale, f"({stale})")
+
+
+def test_the_written_offer_lasts_as_long_as_the_licence_demands():
+    """GPLv3 section 6(b), which LGPLv3 incorporates: an offer of source must be
+    "valid for at least three years".
+
+    Ours said "for as long as this release is distributed", which is shorter than
+    the licence allows an offer to be. The offer is belt and braces - section 6(d)
+    is already satisfied by naming the exact version and where its source lives -
+    but a promise printed in a public document is one somebody may rely on, so it
+    has to be at least what the licence requires.
+    """
+    notices = legal.notices_text()
+    check("notices: the written offer names the three-year floor",
+          "three years" in notices,
+          "(an offer weaker than GPLv3 section 6(b) allows)")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -225,6 +225,36 @@ MUTATIONS = [
         "test": "test_the_table_is_reachable_and_readable_without_a_mouse",
     },
     {
+        "label": "public: the privacy scan reads an empty file list",
+        "file": "tests/test_repo_conventions.py",
+        "old": "    files = repo_text_files((\".py\", \".md\", \".json\", \".txt\", \".toml\", \".spec\", \".yml\"))\n"
+               "    check(\"the privacy scan actually read the repository\"",
+        "new": "    files = []\n"
+               "    check(\"the privacy scan actually read the repository\"",
+        "test": "test_nothing_private_to_this_machine_reaches_the_public_repository",
+    },
+    {
+        "label": "licence: the notices name a WinDivert file that is not shipped",
+        "file": "THIRD-PARTY-NOTICES.md",
+        "old": "## WinDivert (`WinDivert64.dll`, `WinDivert64.sys`)",
+        "new": "## WinDivert (`WinDivert.dll`, `WinDivert64.sys`)",
+        "test": "test_the_notices_name_the_windivert_files_that_are_really_shipped",
+    },
+    {
+        "label": "licence: the written offer drops below the three-year floor",
+        "file": "THIRD-PARTY-NOTICES.md",
+        "old": "**Written offer:** for at least three years from the date of this release, the",
+        "new": "**Written offer:** for as long as this release is distributed, the",
+        "test": "test_the_written_offer_lasts_as_long_as_the_licence_demands",
+    },
+    {
+        "label": "licence: the About window drops the no-warranty notice",
+        "file": "beantester/gui/panels/about.py",
+        "old": "        line(text=T(\"about.no_warranty\"), style=\"Muted.TLabel\").pack(",
+        "new": "        line(text=\"\", style=\"Muted.TLabel\").pack(",
+        "test": "test_the_about_window_is_a_complete_legal_notice",
+    },
+    {
         "label": "keyboard: the search box stops advertising its shortcut",
         "file": "beantester/gui/pages/conns.py",
         "old": "        add_tooltip(entry, \"tips.conn_search\", shortcut=\"Ctrl+F\")",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -404,6 +404,14 @@ CANARY = {
 # machine can repeat it. This is weaker than MUTATIONS and stronger than nothing -
 # and it is the honest state of most "verified by mutation" lines in the notes.
 PROVEN_BY_HAND = {
+    # No re-runnable patch is possible here: in a healthy tree EVERY workflow
+    # script is tracked, so disabling the check has nothing left to fail on - the
+    # mutant survives for the same reason the guard is quiet, which is not a fault
+    # in either. Proven the only way it can be: by committing the mistake. Moving
+    # tools/check_public_text.py into internal_tools/ (2026-08-04) turned the test
+    # red at once, and moving it back turned it green.
+    "test_every_script_the_workflows_run_is_actually_in_the_repository":
+        "2026-08-04, moved a workflow script into internal_tools/ and back",
     # test_shortcut_buttons_advertise_their_key moved to MUTATIONS on 2026-08-03,
     # when Ctrl+F gave it a patch worth writing down. This list is meant to shrink.
     "test_an_overridden_field_is_visibly_disabled": "2026-07-21, removing the disabled style maps",

--- a/tests/test_repo_conventions.py
+++ b/tests/test_repo_conventions.py
@@ -301,3 +301,72 @@ def test_the_repository_scanners_stay_out_of_what_is_not_in_the_repository():
         leaked = sorted(p for p in scanned if p.startswith(prefix))
         check(f"nothing under {prefix} is scanned (git-ignored, absent in CI)",
               not leaked, f"({leaked[:4]})")
+
+
+# Things that must never reach a public repository. Only the mechanical half of
+# the rule lives here - see the note next to the test about the other half.
+PRIVATE_PATTERNS = (
+    (r"[A-Za-z]:[\/]{1,2}Users[\/]", "a Windows user-profile path"),
+    (r"/home/[a-z][\w.-]*/", "a Linux home path"),
+    (r"/Users/[A-Za-z][\w.-]*/", "a macOS home path"),
+    (r"\bgh[pousr]_[A-Za-z0-9]{16,}", "a GitHub token"),
+    (r"\bAKIA[0-9A-Z]{12,}", "an AWS access key id"),
+    (r"-----BEGIN [A-Z ]*PRIVATE KEY-----", "a private key"),
+)
+
+# The WinDivert copyright line has to carry its author's address: it is part of
+# the notice we are obliged to reproduce. Nothing else may hold an address.
+EMAIL_ALLOWED_IN = {"THIRD-PARTY-NOTICES.md"}
+
+
+def test_nothing_private_to_this_machine_reaches_the_public_repository():
+    """This repository is public, and so is its history.
+
+    A path, a machine name or a token committed once stays readable after it is
+    deleted, because the commit that added it does not go away. That makes this
+    cheaper to enforce than to clean up, which is the whole argument for a test.
+
+    What this canNOT check is the other half of the rule (convention 45): that a
+    comment explains ITSELF rather than pointing at a document only the
+    maintainers can open. Four comments doing exactly that were found by reading,
+    2026-08-03, and reading is the only thing that finds them. Said out loud so
+    the presence of this test is not mistaken for full coverage.
+    """
+    import re
+    files = repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml"))
+    check("the privacy scan actually read the repository", len(files) >= 30,
+          f"({len(files)} files)")
+    for pattern, what in PRIVATE_PATTERNS:
+        rx = re.compile(pattern)
+        offenders = []
+        for path in files:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                for number, line in enumerate(handle, 1):
+                    if rx.search(line):
+                        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+                        offenders.append(f"{rel}:{number}")
+        check(f"nothing in the repository looks like {what}", not offenders,
+              f"({offenders[:4]})")
+
+
+def test_no_stray_email_addresses_in_the_public_tree():
+    """An address in a public repository is an address that gets scraped.
+
+    The one exception is deliberate and required: the WinDivert notice reproduces
+    its author's copyright line, address included, because that is the notice we
+    are obliged to pass on.
+    """
+    import re
+    rx = re.compile(r"[\w.+-]+@[\w-]+\.[A-Za-z]{2,}")
+    offenders = []
+    for path in repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml")):
+        name = os.path.basename(path)
+        if name in EMAIL_ALLOWED_IN:
+            continue
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for number, line in enumerate(handle, 1):
+                for hit in rx.findall(line):
+                    rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+                    offenders.append(f"{rel}:{number} {hit}")
+    check("no email addresses outside the notices that must carry one",
+          not offenders, f"({offenders[:4]})")

--- a/tests/test_repo_conventions.py
+++ b/tests/test_repo_conventions.py
@@ -370,3 +370,40 @@ def test_no_stray_email_addresses_in_the_public_tree():
                     offenders.append(f"{rel}:{number} {hit}")
     check("no email addresses outside the notices that must carry one",
           not offenders, f"({offenders[:4]})")
+
+
+def test_every_script_the_workflows_run_is_actually_in_the_repository():
+    """A CI dependency that git does not carry works here and nowhere else.
+
+    ``internal_tools/`` is deliberately outside git: measurement rigs and probes
+    that never ship and that the owner backs up separately. ``tools/`` is the
+    opposite - it IS carried, because the workflows run it. Put a workflow
+    dependency in the wrong one and nothing fails locally, where the file exists;
+    it fails on a fresh clone, which is to say on somebody else's machine, and
+    the error is a missing file rather than the reason for it.
+
+    So the rule "when a script becomes a CI dependency it moves to ``tools/``"
+    gets a guard instead of a memory: every ``python <path>`` a workflow runs has
+    to exist AND be tracked.
+    """
+    import re
+    import subprocess
+    workflows = glob.glob(os.path.join(ROOT, ".github", "workflows", "*.yml"))
+    check("there are workflows to read", bool(workflows), f"({workflows})")
+
+    referenced = set()
+    for path in workflows:
+        with open(path, encoding="utf-8") as handle:
+            for match in re.finditer(r"python\s+([\w./-]+\.py)", handle.read()):
+                referenced.add(match.group(1))
+    check("the workflow scan found the scripts it runs", len(referenced) >= 3,
+          f"({sorted(referenced)})")
+
+    for script in sorted(referenced):
+        full = os.path.join(ROOT, script)
+        check(f"{script} exists", os.path.exists(full))
+        tracked = subprocess.run(["git", "ls-files", "--error-unmatch", script],
+                                 cwd=ROOT, capture_output=True, text=True)
+        check(f"{script} is tracked by git (a fresh clone must have it)",
+              tracked.returncode == 0,
+              "(it is ignored or untracked - internal_tools/ cannot hold a CI dependency)")

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -420,3 +420,46 @@ def test_every_prose_label_in_the_about_window_can_wrap():
         for key in ("about.license_terms", "about.no_telemetry", "about.third_party"):
             assert bnt.T(key) in texts, (key, texts)
     """)
+
+
+def test_the_about_window_is_a_complete_legal_notice():
+    """The GPL's own definition, applied to the window that claims to be it.
+
+    "Appropriate Legal Notices" (GPLv3 section 0) means four things together: a
+    copyright notice, a notice that there is NO WARRANTY, that licensees may
+    convey the work under this licence, and how to view a copy of it. This window
+    carried three - the disclaimer lived only in the README, which the holder of
+    an .exe has no reason to open.
+
+    Asserted through the rendered widget texts rather than the language file, so
+    a key that exists and is never shown does not pass.
+    """
+    run_gui("""
+        import beantester as bnt
+        panel = app.open_window("about")
+        assert panel is not None, "the About window did not open"
+
+        def texts(widget, out):
+            out.append(str(widget.kw.get("text", "")))
+            # the component list and the path to the licence texts go into a Text
+            # widget, so a walk over `text=` options alone would miss half of what
+            # this window actually shows
+            # `getattr(..., default)` is no use here: the fake widget answers ANY
+            # unknown attribute with a callable, so the default never arrives
+            lines = getattr(widget, "lines", None)
+            if isinstance(lines, list):
+                out.extend(str(l) for l in lines)
+            for child in getattr(widget, "children", []):
+                texts(child, out)
+            return out
+
+        shown = " | ".join(texts(panel.win, []))
+
+        for what, needle in (
+                ("a copyright notice", bnt.appinfo.COPYRIGHT),
+                ("the no-warranty notice", bnt.T("about.no_warranty")),
+                ("the right to convey it", bnt.T("about.license_terms")),
+                ("where to read the licence", "licenses")):
+            assert needle.split("{")[0][:30] in shown or needle in shown, \
+                "the About window does not show %s: %r" % (what, shown[:400])
+    """)

--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -52,6 +52,26 @@ POLISH = re.compile("[" + "".join(chr(c) for c in (
     0x105, 0x107, 0x119, 0x142, 0x144, 0xF3, 0x15B, 0x17C, 0x17A,
     0x104, 0x106, 0x118, 0x141, 0x143, 0xD3, 0x15A, 0x17B, 0x179)) + "]")
 
+# Quoting the conversation the work came out of. The rule is simple and the reason
+# is not obvious until it is said out loud: a commit or a pull request may quote
+# the PROGRAM - its interface text, its output, its code - and may not quote a
+# PERSON. A maintainer describing a fault in a chat has not published anything;
+# pasting their sentence into a pull request does it for them, in public, for
+# good. It happened here (pull request #95, two sentences in the reporter's own
+# words) and the language rule alone would not have stopped an English one.
+#
+# These are the TELLS, not a detector. A translated report with no attributive
+# phrase reads like ordinary prose and no pattern will find it - which is why the
+# rule sits in the convention as well, for the half a machine cannot do.
+QUOTED_PERSON = (
+    r"(?i)\bthe (owner|maintainer|reporter|user) (said|asked|wrote|reported|put it"
+    r"|noticed|complained|pointed out)\b",
+    r"(?i)\byou (asked me|said|reported|told me|complained|pointed out)\b",
+    r"(?i)\bas (you|he|she|they) (said|put it|wrote|described it)\b",
+    r"(?i)\b(his|her|their) (exact )?words\b",
+    r"(?i)\b(quoting|quote from) (the )?(chat|conversation|discussion|report)\b",
+)
+
 PRIVATE = (
     (re.compile(r"[A-Za-z]:[\\/]{1,2}Users[\\/]"), "a Windows user-profile path"),
     (re.compile(r"/home/[a-z][\w.-]*/"), "a Linux home path"),
@@ -78,6 +98,18 @@ def offences(text, where):
             found.append(f"{where} line {number}: em or en dash - use '-'")
         if POLISH.search(line):
             found.append(f"{where} line {number}: not English")
+        # Code spans are stripped for this check only. Naming a pattern is not
+        # using it: a message explaining this very rule has to be able to write
+        # `the owner said` down, and it was the first thing to trip the guard.
+        # Deliberately NOT done for the language check - a quoted line of Polish
+        # program output is still Polish in a public description, and putting it
+        # in backticks is how that would be smuggled past.
+        prose = re.sub(r"`[^`]*`", "", line)
+        for pattern in QUOTED_PERSON:
+            if re.search(pattern, prose):
+                found.append(f"{where} line {number}: quotes a person, not the "
+                             f"program - say what was found, not who said it")
+                break
         for pattern, what in PRIVATE:
             if pattern.search(line):
                 found.append(f"{where} line {number}: {what}")

--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -1,0 +1,136 @@
+"""Check text that becomes public the moment it is pushed: commits and the PR body.
+
+WHY THIS IS NOT A TEST IN ``tests/``
+    The suite scans FILES. A commit message and a pull-request description are
+    just as public, are read by just as many people, and live in the repository
+    history forever - a message cannot be edited away, because the commit that
+    carried it stays. Nothing in ``tests/`` can see either of them, so the two
+    conventions that govern them (English only, plain hyphens) had no guard at
+    all: they were held up by remembering, every time, which is the definition of
+    a rule this project does not trust.
+
+WHAT IT CHECKS
+    The same three things the repository files are already held to:
+
+    * plain hyphens only, never an em dash or an en dash (convention 33)
+    * English only - Polish diacritics are the reliable tell (convention 43)
+    * nothing private to a machine: user paths, addresses, credential shapes
+      (convention 45)
+
+WHAT IT DELIBERATELY DOES NOT CHECK
+    Whether the message is any good. Nothing mechanical can tell a description
+    that explains a change from one that restates its diff, and pretending
+    otherwise would put a green tick on the half that matters least.
+
+USAGE
+    python tools/check_public_text.py --commits <base>..<head>
+    python tools/check_public_text.py --text-file body.txt
+
+    Exits 0 when clean, 1 with the offending lines named. Both forms are used by
+    the CI workflow: the commit range for the branch, the text file for the pull
+    request description.
+"""
+import argparse
+import re
+import subprocess
+import sys
+
+# An em dash or an en dash. Convention 33: this project uses the plain hyphen
+# everywhere, and the reason it is worth enforcing is that the two are almost
+# indistinguishable in a diff.
+# Built from code points rather than written out: this file is repository text and
+# is scanned by the very rule it enforces (convention 33), so spelling the two
+# characters here would make the guard illegal under its own guard. That is
+# exactly how it was first written, and the suite caught it.
+DASHES = re.compile("[" + chr(0x2013) + chr(0x2014) + "]")
+
+# Polish diacritics. Not a language detector and not meant to be: the commits and
+# the pull requests of this project are written in English while the conversation
+# behind them is in Polish, and the way that rule breaks is a sentence quoted
+# straight from the conversation.
+POLISH = re.compile("[" + "".join(chr(c) for c in (
+    0x105, 0x107, 0x119, 0x142, 0x144, 0xF3, 0x15B, 0x17C, 0x17A,
+    0x104, 0x106, 0x118, 0x141, 0x143, 0xD3, 0x15A, 0x17B, 0x179)) + "]")
+
+PRIVATE = (
+    (re.compile(r"[A-Za-z]:[\\/]{1,2}Users[\\/]"), "a Windows user-profile path"),
+    (re.compile(r"/home/[a-z][\w.-]*/"), "a Linux home path"),
+    (re.compile(r"/Users/[A-Za-z][\w.-]*/"), "a macOS home path"),
+    (re.compile(r"[\w.+-]+@[\w-]+\.[A-Za-z]{2,}"), "an email address"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{16,}"), "a GitHub token"),
+    (re.compile(r"\bAKIA[0-9A-Z]{12,}"), "an AWS access key id"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "a private key"),
+)
+
+# Co-author trailers carry an address by design. Matched by SHAPE rather than by
+# spelling the address out: a literal here would be an address in the public tree,
+# which is the thing this script exists to keep out of it.
+ALLOWED_LINE = re.compile(r"^Co-Authored-By: .+ <[^>]+>$")
+
+
+def offences(text, where):
+    """Every rule broken by one block of text, as readable lines."""
+    found = []
+    for number, line in enumerate(text.splitlines(), 1):
+        if ALLOWED_LINE.match(line.strip()):
+            continue
+        if DASHES.search(line):
+            found.append(f"{where} line {number}: em or en dash - use '-'")
+        if POLISH.search(line):
+            found.append(f"{where} line {number}: not English")
+        for pattern, what in PRIVATE:
+            if pattern.search(line):
+                found.append(f"{where} line {number}: {what}")
+    return found
+
+
+def commit_messages(revision_range):
+    """``(subject+body, label)`` for each commit in the range."""
+    out = subprocess.run(
+        ["git", "log", "--format=%H%x00%B%x1e", revision_range],
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
+    if out.returncode != 0:
+        print(f"cannot read {revision_range}: {out.stderr.strip()}", file=sys.stderr)
+        raise SystemExit(1)
+    for record in out.stdout.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        sha, _, body = record.partition("\x00")
+        yield body, f"commit {sha[:8]}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--commits", metavar="RANGE",
+                        help="a git revision range, e.g. origin/master..HEAD")
+    parser.add_argument("--text-file", metavar="PATH",
+                        help="a file holding one block of text (a PR description)")
+    args = parser.parse_args()
+
+    blocks = []
+    if args.commits:
+        blocks.extend(commit_messages(args.commits))
+    if args.text_file:
+        with open(args.text_file, encoding="utf-8", errors="replace") as handle:
+            blocks.append((handle.read(), "description"))
+    if not blocks:
+        parser.error("nothing to check: pass --commits or --text-file")
+
+    found = []
+    for text, where in blocks:
+        found.extend(offences(text, where))
+
+    if found:
+        print("This text becomes public and stays public. Fix before pushing:\n")
+        for line in found:
+            print(f"  {line}")
+        print("\nA pushed commit message cannot be edited away: the commit that "
+              "carried it stays in the history.")
+        return 1
+    print(f"public text: {len(blocks)} block(s) checked, clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
A licence audit, measured against the installed packages and against a real
frozen build rather than against our own prose, plus the guards for a public
repository that came out of the same pass.

## What was wrong

The instructions for replacing the LGPL libraries were wrong twice, and that
matters more than a typo in a document would: those instructions **are** the
obligation. The LGPL gives whoever holds the binary the right to swap these
libraries for their own build, and it is the reason this program ships as a
folder rather than a single file. Directions you cannot follow are not much of a
right.

* **WinDivert** was named as `WinDivert.dll` in `_internal\pydivert\`. The build
  ships `WinDivert64.dll` and `WinDivert64.sys` in
  `_internal\pydivert\windivert_dll\`. Wrong filename, wrong folder.
* **PyDivert** was worse, because it was wrong quietly. The notices said you
  could drop a modified `pydivert` package into `_internal\`. Measured against a
  minimal frozen build: the copy inside the executable wins, and the module even
  reports the path you put your files at, so it looks like it was picked up when
  it was not. Someone exercising their licence right would have walked away
  believing it worked.

The difference between the two is measured, not assumed: the native DLL really
is replaceable, because PyDivert builds its DLL path from `__file__` and hands it
to `ctypes.WinDLL`, so the file on disk is what loads. Pure Python is compiled
into the executable; a native library is not. The notices now give the routes
that work - rebuild the application against your version, or run it from source -
and say plainly that the drop-in does not.

Two smaller things from the same reading:

* The **written offer of source** promised "for as long as this release is
  distributed". GPLv3 section 6(b), which LGPLv3 incorporates and which ships in
  our own `licenses/GPL-3.0.txt`, requires an offer "valid for at least three
  years". We do not depend on that offer - section 6(d) is already satisfied by
  naming the exact version and where its source lives - but a promise printed in
  a public document is one somebody may rely on.
* The **About window** carried three of the four things the GPL calls Appropriate
  Legal Notices: the copyright, the right to pass the program on, and where to
  read the licence. The no-warranty line existed only in the README, which
  nobody holding an `.exe` has a reason to open.

## What was already right

Worth stating, because an audit that only lists faults misrepresents the thing it
audited. Every component's licence matches what its own package metadata
declares. All of them are GPLv3-compatible. No third-party code is vendored, no
fonts or icon sets are bundled, and `--license` prints the full licence text
alongside live versions and source URLs for everything shipped.

## Public repository

This repository is public and so is its history: a path, a machine name or a
token committed once stays readable after it is deleted, because the commit that
added it does not. That is cheaper to enforce than to clean up, so it is a test
rather than an intention. Two of them cover user-profile and home paths, GitHub
and AWS credential shapes, private keys, and stray email addresses - one file may
carry an address, the WinDivert notice, because it is part of the copyright line
we are obliged to reproduce. Both carry the empty-scan canary. Zero offenders
when written.

The other half of the rule has no guard and says so in the test: a comment must
explain itself rather than point at a document only the maintainers can open.
Reading is the only thing that finds those.

## Guards

The notices are now compared against the **installed package layout**, so the
next time a dependency moves its files the document goes red the same day rather
than at the next audit. **45 mutations caught, 0 survived**, canary BROKEN. Full
suite green, GUI smoke green, real-Tk render check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
