### PR TITLE
fix(ci): match the co-author trailer the way git and GitHub write it

### DIFF
--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -85,7 +85,12 @@ PRIVATE = (
 # Co-author trailers carry an address by design. Matched by SHAPE rather than by
 # spelling the address out: a literal here would be an address in the public tree,
 # which is the thing this script exists to keep out of it.
-ALLOWED_LINE = re.compile(r"^Co-Authored-By: .+ <[^>]+>$")
+#
+# Case-insensitive because git trailers are, and because GitHub proves it: a
+# squash merge rewrites "Co-Authored-By" as "Co-authored-by", so the first version
+# of this line passed on every branch and then flagged the merge commit it had
+# just approved. Only running it over master found that.
+ALLOWED_LINE = re.compile(r"^co-authored-by: .+ <[^>]+>$", re.I)
 
 
 def offences(text, where):


### PR DESCRIPTION
The allowance for a co-author trailer, which carries an address by design, was
case-sensitive. Git trailers are not, and GitHub proves it: a squash merge
rewrites the header as `Co-authored-by`, so the check passed on every branch and
then flagged the merge commit it had just approved.

Found by running the tool over `master` rather than over a branch. The rewritten
form only exists there, so no branch could have surfaced it - which is worth
recording, because the guard had been green on two pull requests by then.

An address on an ordinary line is still caught: verified against a block holding
one of each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)