### PR TITLE
docs: say in the contributor guide that the repository is public

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,12 @@ onedir, `asInvoker`. Do not reintroduce `--noconsole` / `--onefile` / `--uac-adm
 ## Conventions (enforced by tests)
 
 - Everything is named **BeanNetworkTester**; no references to legacy names.
-- Code, comments and docstrings are in **English**.
+- Code, comments and docstrings are in **English**, and so are commit messages and pull
+  request descriptions. This repository is public and its history is permanent: a comment or
+  a message cannot be unpublished, because the commit carrying it stays. Keep local paths,
+  machine names, addresses and credentials out of all of them. Quote the program - interface
+  text, command output, code - and not a person: a sentence from a chat or an issue is
+  somebody else's words. CI checks the mechanical half of this on every pull request.
 - UI texts appear in code **only as i18n keys** (`lang/<code>.json` holds the
   texts; English is the fallback). Adding a language = adding a JSON file.
 - The CLI is always English and logs with the `[bean]` prefix.

--- a/beantester/gui/tooltip.py
+++ b/beantester/gui/tooltip.py
@@ -177,8 +177,10 @@ def add_tooltip(widget, key, shortcut=None):
     """Attach a tooltip with the translated text for the i18n ``key``.
 
     ``shortcut`` (e.g. ``"F5"``, ``"Ctrl+Enter"``) is appended so a control that
-    has a keyboard shortcut advertises it in its own tooltip (convention 51). The
-    Tooltip is stored on the widget (``_bnt_tooltip``) so tests can read it back.
+    has a keyboard shortcut advertises it in its own tooltip. A shortcut nobody
+    can discover is a shortcut nobody uses, and the tooltip is the only place a
+    control can say so about itself. The Tooltip is stored on the widget
+    (``_bnt_tooltip``) so tests can read it back.
     """
     if not key:
         return widget


### PR DESCRIPTION
Two documents were quietly incomplete.

`CONTRIBUTING.md` told contributors that code, comments and docstrings are English.
It said nothing about commit messages or pull request descriptions, and nothing
about the part that makes the rule matter: this repository is public and its
history is permanent, so none of those can be unpublished afterwards. It now also
draws the line the CI check enforces - quote the program, not a person.

`gui/tooltip.py` cited "convention 51" for the rule that a control advertises its
shortcut in its own tooltip. No such convention exists; the rule is convention 40.
Found by listing every convention referenced across the code and the notes against
every convention actually defined. The docstring now carries the reason itself,
which is what a public comment is supposed to do and what stops the number from
drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)