### PR TITLE
fix: a target that matches everything, a leak guard that never failed, and two CLI answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A target that means "everything" no longer counts as aiming at something.** Start with
+  impairment on and a target of `*`, and the tool stayed quiet, because a target was set - to
+  every program on the machine. The warning about affecting every connection now appears for any
+  expression that does not narrow anything: `*`, a regular expression matching all, a PID range
+  covering all, or a destination of `0.0.0.0/0`. A real target is unaffected and still silences
+  it, and so does a real target with an exclusion beside it.
+
 - **The "process" column now says when its answer was taken.** The name is read once, when the
   connection first shows up, and never again - which is why a row can still name a program that
   has since closed. The tooltip said none of that, so a name that outlived its program looked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A run with several bad values now names them all at once.** `--loss 500 --latency -5
+  --dup 900` reported the latency and stopped, so you fixed one, ran again, and met the next.
+  All of them come back in one message. The window still reports the field you are typing in and
+  nothing else, which is what you want while typing.
+
 - **A target that means "everything" no longer counts as aiming at something.** Start with
   impairment on and a target of `*`, and the tool stayed quiet, because a target was set - to
   every program on the machine. The warning about affecting every connection now appears for any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   All of them come back in one message. The window still reports the field you are typing in and
   nothing else, which is what you want while typing.
 
+- **A mistyped preset suggests the one you probably meant.** It used to answer with the full list
+  of seventeen ids and leave you to find the difference. The tool already did this for a mistyped
+  setting in a config file, so preset names were the odd one out.
+
 - **A target that means "everything" no longer counts as aiming at something.** Start with
   impairment on and a target of `*`, and the tool stayed quiet, because a target was set - to
   every program on the machine. The warning about affecting every connection now appears for any

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -31,7 +31,7 @@ from .repro import save_repro_report, settings_to_cli_string
 from .scenario import load_scenario_file
 from .settings import (DEFAULT_SETTINGS, apply_settings, build_matchers,
                        load_config_file, parse_schedule, save_config_file,
-                       validate_ranges, warn_if_unbounded)
+                       range_errors, validate_ranges, warn_if_unbounded)
 from .synthetic import SyntheticDivert
 from .utils import bytes_to_mb
 
@@ -297,10 +297,14 @@ def config_from_args(args):
         build_matchers(s)          # --target / --dst-ip / --dst-port expressions
     except ValueError as e:
         _fail(exitcodes.CONFIG, str(e))
-    try:
-        validate_ranges(s)         # --loss 250 (and --duration -5) are mistakes
-    except ValueError as e:
-        _fail(exitcodes.CONFIG, str(e))
+    # ALL of them, not the first. A command line arrives finished, so reporting
+    # one problem per run means the user fixes it, runs again and meets the next
+    # one - measured here: `--loss 500 --latency -5 --dup 900` named only the
+    # latency. The form keeps failing on the first, which is right for a field
+    # being typed into (see settings.range_errors).
+    bad = range_errors(s)          # --loss 250 (and --duration -5) are mistakes
+    if bad:
+        _fail(exitcodes.CONFIG, "; ".join(bad))
 
     interval = float(getattr(args, "interval", 2.0) or 0)
     if interval <= 0:

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -26,7 +26,8 @@ from .fields import BOOL, FIELD_DEFS
 from .filters import CLI_FILTERS
 from .i18n import T
 from .paths import is_frozen
-from .presets import PRESETS, preset_to_settings, resolve_preset
+from .presets import (PRESETS, closest_preset, preset_to_settings,
+                      resolve_preset)
 from .repro import save_repro_report, settings_to_cli_string
 from .scenario import load_scenario_file
 from .settings import (DEFAULT_SETTINGS, apply_settings, build_matchers,
@@ -253,7 +254,13 @@ def config_from_args(args):
     if args.preset:
         canon = resolve_preset(args.preset)
         if canon is None:
-            _fail(exitcodes.CONFIG, f"unknown preset: {args.preset!r} "
+            # Nearest match first, the full list second. The tool already does
+            # this for a mistyped config key and for a scenario key; a preset
+            # name was the one closed vocabulary left answering with seventeen
+            # ids and no hint, which is the longest list of the three.
+            close = closest_preset(args.preset)
+            hint = f" (did you mean {close!r}?)" if close else ""
+            _fail(exitcodes.CONFIG, f"unknown preset: {args.preset!r}{hint} "
                                     f"(canonical ids: {', '.join(PRESETS)})")
         # Through the SHARED mapping, not a copy of it. This used to hand-write
         # the seven classic keys, which meant the GUI (which has always gone

--- a/beantester/matchers.py
+++ b/beantester/matchers.py
@@ -172,6 +172,60 @@ class Matcher:
         """
         return not self._positives
 
+    # Values a term is tried against to answer "does this name anything in
+    # particular?". Deliberately unlike one another, so an expression that
+    # matches all of them is one that would match nearly anything.
+    #
+    # GROUPS, not one flat list, because of address families: a rule can cover
+    # the whole of IPv4 and none of IPv6, and that still bounds nothing worth
+    # having. Covering any ONE group completely is enough. Kinds without such a
+    # split declare a single group.
+    BLAST_PROBES = ()
+
+    @property
+    def covers_everything(self):
+        """True when the positive terms hit every probe - i.e. they bound nothing.
+
+        ``selects_nothing_in_particular`` catches an expression with no positive
+        term at all. This catches the other half, which reads as narrow to every
+        truth test and is not: ``*`` and ``re:.*`` are positive terms that select
+        the whole machine. MEASURED before this existed: ``--target *`` set
+        ``targeting_is_set`` to True and silenced the start-time warning, while
+        ``--loss 100`` on its own warned - so the expression that bounds nothing
+        was treated as safer than no expression at all.
+
+        A heuristic, and named as one. It answers by ASKING the compiled terms
+        rather than by inspecting their text, because "matches everything" is not
+        a syntactic property: ``>0`` on pids and ``0-999999`` cover every process
+        without a wildcard in sight, and ``*.*`` covers only names containing a
+        dot despite looking universal.
+
+        What it cannot see, written down rather than left to be discovered:
+
+        * an expression matching every probe by coincidence. The probes are few,
+          so this is possible - and it is the SAFE direction: the caller only
+          raises an advisory warning, so a false positive costs one line of text
+          and a false negative costs the user's network.
+        """
+        if not self._positives:
+            return False
+        for group in self.BLAST_PROBES:
+            if group and all(
+                    any(t.matches(self._context(*probe)) for t in self._positives)
+                    for probe in group):
+                return True
+        return False
+
+    @property
+    def bounds_nothing(self):
+        """True when this expression does not narrow the blast radius at all.
+
+        The two halves belong together and are exposed as one property on
+        purpose: a caller reaching for either alone gets half a guard, and half a
+        guard on this question is what let ``--target *`` through.
+        """
+        return self.selects_nothing_in_particular or self.covers_everything
+
     def __bool__(self):
         """A matcher is falsy when empty, so callers can write ``if matcher:``."""
         return not self.is_empty
@@ -221,6 +275,7 @@ class Matcher:
 class IntMatcher(Matcher):
     """Numbers - ports today, any numeric field tomorrow."""
     kind = KIND_INT
+    BLAST_PROBES = (((1,), (443,), (49152,), (65535,)),)
 
     @staticmethod
     def _context(value):
@@ -230,6 +285,10 @@ class IntMatcher(Matcher):
 class IpMatcher(Matcher):
     """IPv4/IPv6 addresses. Rules only ever match their own address family."""
     kind = KIND_IP
+    # Both families on purpose: a rule that covers one of them entirely is not
+    # flagged, which is stated in Matcher.covers_everything rather than hidden.
+    BLAST_PROBES = ((("127.0.0.1",), ("8.8.8.8",), ("192.168.1.1",)),
+                    (("::1",), ("2001:db8::1",), ("fe80::1",)))
 
     @staticmethod
     def _context(value):
@@ -239,6 +298,9 @@ class IpMatcher(Matcher):
 class ProcessMatcher(Matcher):
     """Processes, matched on ``(pid, name)``."""
     kind = KIND_PROCESS
+    # Unlike each other in both halves a term can look at: the pid and the name.
+    BLAST_PROBES = (((4, "System"), (1234, "chrome.exe"),
+                     (2, "svchost.exe"), (65000, "a")),)
 
     @staticmethod
     def _context(pid, name=""):

--- a/beantester/presets.py
+++ b/beantester/presets.py
@@ -142,6 +142,34 @@ def resolve_preset(name):
     return None
 
 
+def closest_preset(name):
+    """The preset name a typo most likely meant, or ``None``.
+
+    Suggests what a person can actually TYPE, which is why it searches the
+    translated names and not only the canonical ids: a user reaching for
+    "modem56k" writes that, not "presets.modem56k", and a suggestion drawn from
+    the id list would find nothing close and stay silent exactly when it is
+    needed. The tool already answers a mistyped config key and a mistyped
+    scenario key this way - a preset was the one closed vocabulary still
+    replying with seventeen ids and no hint.
+    """
+    import difflib
+
+    candidates = {}
+    for key in PRESETS:
+        candidates[key] = key
+        for lang in loaded_language_codes():
+            candidates[translate(key, lang)] = key
+    match = difflib.get_close_matches(name, list(candidates), n=1, cutoff=0.6)
+    if match:
+        return match[0]
+    # Second pass folded, so a near-miss differing only in diacritics or case
+    # still lands - the same tolerance resolve_preset gives an exact match.
+    folded = {fold_name(text): text for text in candidates}
+    match = difflib.get_close_matches(fold_name(name), list(folded), n=1, cutoff=0.6)
+    return folded[match[0]] if match else None
+
+
 # Presets store their fields under short keys ("lat", "jit") and the settings
 # model uses the long ones. Which is which is DERIVED from the field registry
 # (``Field.in_profile`` + ``Field.preset_key``), so a field joins the profile

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -184,6 +184,33 @@ def validate_ranges(s, lang=None):
     return True
 
 
+def range_errors(s, lang=None):
+    """EVERY out-of-range value, as a list of messages. Empty when all are fine.
+
+    The same question as :func:`validate_ranges` asked for the other kind of
+    channel, and the difference is not a preference:
+
+    * a form is typed into LIVE, so it reports the field under the cursor and
+      nothing else - a list of complaints about fields the user has not reached
+      yet is noise;
+    * a command line arrives FINISHED. Reporting one problem per run means the
+      user fixes it, runs again, and learns about the next one - which is the
+      cheapest way to make somebody give up on a tool.
+
+    ``validate_ranges`` keeps raising on the first, unchanged, because that is
+    what the form wants and what its callers already expect.
+    """
+    found = []
+    for f in FIELD_DEFS:
+        if f.kind != F.NUMBER or f.key not in s:
+            continue
+        try:
+            parse_number(s[f.key], f.label, f.bounds, lang)
+        except ValueError as exc:
+            found.append(str(exc))
+    return found
+
+
 def settings_from_raw(raw, lang=None):
     """Turn a raw (mostly string) input dict into a validated settings dict.
 

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -93,12 +93,23 @@ def armed_global_impairments(s):
 def targeting_is_set(s):
     """True when a targeting field names at least one thing to hit.
 
-    Not a truth test on the fields: an expression made of nothing but exclusions
-    (``!chrome.exe``) is non-empty and still covers the whole machine minus one
-    application, so it does not bound anything (see
-    ``Matcher.selects_nothing_in_particular``). A malformed expression is treated
-    as no scope at all - it is about to be rejected by validation anyway, and the
-    safe reading of "I cannot tell what this narrows to" is "it narrows nothing".
+    Not a truth test on the fields, and not a truth test on the POSITIVE terms
+    either - both readings have been wrong here, in opposite directions:
+
+    * an expression made of nothing but exclusions (``!chrome.exe``) is non-empty
+      and still covers the whole machine minus one application;
+    * an expression whose positive term covers everything (``*``, ``re:.*``,
+      ``>0``) reads as narrow to any truth test and bounds nothing. MEASURED:
+      ``--target *`` silenced this warning while ``--loss 100`` alone raised it,
+      so the expression that bounded nothing looked safer than no expression.
+
+    ``Matcher.bounds_nothing`` answers both halves, and it is deliberately the
+    only thing asked here - reaching for either half alone is how the second case
+    got through.
+
+    A malformed expression is treated as no scope at all - it is about to be
+    rejected by validation anyway, and the safe reading of "I cannot tell what
+    this narrows to" is "it narrows nothing".
     """
     expressions = {key: (kind, field, bounds)
                    for key, kind, field, bounds in MATCH_FIELDS}
@@ -117,7 +128,7 @@ def targeting_is_set(s):
             matcher = parse_matcher(text, *expressions[key])
         except ValueError:
             continue
-        if not matcher.selects_nothing_in_particular:
+        if not matcher.bounds_nothing:
             return True
     return False
 

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1100,3 +1100,21 @@ def test_a_broken_scenario_never_opens_the_capture(monkeypatch, tmp_path):
           code == exitcodes.SCENARIO, f"(code={code})")
     check("scenario: a broken file never opens the capture", not engine.started)
     check("scenario: it says which file", "broken.json" in err, f"({err!r})")
+
+
+def test_every_bad_value_is_reported_in_one_run(monkeypatch):
+    """A command line arrives FINISHED, so one problem per run is the cheapest
+    way to make somebody give up on a tool.
+
+    MEASURED before the fix: `--loss 500 --latency -5 --dup 900` named the
+    latency and stopped. Three mistakes, three runs.
+
+    The form deliberately still fails on the first field - it is typed into live,
+    and complaints about fields nobody has reached yet are noise. The split is
+    the point, not an inconsistency (see settings.range_errors).
+    """
+    code, _, err, _ = _real_run(monkeypatch, ["--loss", "500", "--latency", "-5",
+                                              "--dup", "900"])
+    check("a bad value still exits CONFIG", code == exitcodes.CONFIG, f"(code={code})")
+    for field in ("Loss", "Latency", "Duplication"):
+        check(f"the message names {field}", field in err, f"({err!r})")

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1054,6 +1054,37 @@ def test_an_exclusion_only_target_is_not_a_bound(monkeypatch):
     check("warning: an expression of pure exclusions bounds nothing", _warned(err))
 
 
+def test_a_target_that_matches_everything_is_not_a_bound_either(monkeypatch):
+    """The other half of the same question, and it went the other way.
+
+    ``!chrome.exe`` has no positive term, which the check above already caught.
+    ``*`` HAS one - so every truth test, including the one this warning stood on,
+    read it as a scope. MEASURED before the fix: ``--loss 100 --target *``
+    printed no warning while ``--loss 100`` alone did, i.e. the expression that
+    bounds nothing looked safer than no expression at all.
+
+    Both halves now go through ``Matcher.bounds_nothing``. The pairs below are
+    the point: each unbounded form is checked beside a genuinely narrow one, so a
+    fix that simply warns more often does not pass.
+    """
+    for expression in ("*", "**", "re:.*", ">0", "0-999999"):
+        _, _, err, _ = _real_run(monkeypatch, ["--loss", "50", "--target", expression])
+        check(f"warning: --target {expression} bounds nothing", _warned(err), f"({err!r})")
+
+    for expression in ("chrome.exe", "chrome.exe, !chromedriver", "?", "*.exe"):
+        _, _, err, _ = _real_run(monkeypatch, ["--loss", "50", "--target", expression])
+        check(f"no warning: --target {expression} really does narrow",
+              not _warned(err), f"({err!r})")
+
+    # The same rule on a destination, where "everything" is spelled differently.
+    for expression in ("0.0.0.0/0", "::/0"):
+        _, _, err, _ = _real_run(monkeypatch, ["--loss", "50", "--dst-ip", expression])
+        check(f"warning: --dst-ip {expression} covers a whole family",
+              _warned(err), f"({err!r})")
+    _, _, err, _ = _real_run(monkeypatch, ["--loss", "50", "--dst-ip", "10.0.0.0/8"])
+    check("no warning: a real CIDR still bounds", not _warned(err), f"({err!r})")
+
+
 def test_a_broken_scenario_never_opens_the_capture(monkeypatch, tmp_path):
     """MEASURED before the fix: the run printed "Start.", impaired traffic and
     only THEN said the file was broken.

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1118,3 +1118,24 @@ def test_every_bad_value_is_reported_in_one_run(monkeypatch):
     check("a bad value still exits CONFIG", code == exitcodes.CONFIG, f"(code={code})")
     for field in ("Loss", "Latency", "Duplication"):
         check(f"the message names {field}", field in err, f"({err!r})")
+
+
+def test_a_mistyped_preset_is_offered_the_nearest_one(monkeypatch):
+    """A closed vocabulary answers a typo with the nearest value, not only the list.
+
+    Seventeen canonical ids is a long list to read, and this tool already
+    suggests a nearest match for a mistyped config key and a mistyped scenario
+    key - a preset name was the one closed vocabulary left without it.
+
+    The suggestion has to come from what a person can TYPE: searching the ids
+    alone finds nothing close to "modemm", because the id carries a prefix the
+    user never writes.
+    """
+    code, _, err, _ = _real_run(monkeypatch, ["--preset", "modemm"])
+    check("an unknown preset still exits CONFIG", code == exitcodes.CONFIG, f"(code={code})")
+    check("and suggests something", "did you mean" in err, f"({err!r})")
+    check("and the suggestion mentions the modem preset", "56k" in err, f"({err!r})")
+
+    # A name close to a translated one resolves through the same vocabulary.
+    _, _, err, _ = _real_run(monkeypatch, ["--preset", "satelite"])
+    check("a misspelt English name is matched too", "did you mean" in err, f"({err!r})")

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -44,6 +44,23 @@ from fakes import ROOT, check
 FUNCTION_CEILING = 167          # beantester/gui/theme.py::init_style
 FILE_CEILING = 1299             # beantester/gui/app.py
 
+# 🔴 THE SECOND KNOB. A ceiling on the worst single item sees one thing growing
+# to a record and is blind to everything creeping upward together: five files at
+# ninety percent of the limit pass it exactly as cleanly as five files at ten.
+#
+# So the count of items already in the top band is a ratchet of its own. It may
+# fall, and raising it is the same act as raising a ceiling - a decision, not a
+# way to get unblocked.
+#
+# The band is 70%, measured rather than picked (2026-08-06). The distribution
+# here is steeply skewed: one file sits at the ceiling and the next is at 60% of
+# it, so a tighter band would be a constant 1 and would say nothing. At 70% the
+# counts are small and the next candidate is real - `engine.py` has about 130
+# lines of headroom before it joins the count.
+CROWD_BAND = 0.70
+FILES_NEAR_CEILING = 1          # beantester/gui/app.py
+FUNCTIONS_NEAR_CEILING = 4      # init_style, _run_session, _build_ui, build_arg_parser
+
 
 def _logic_lines(source):
     """Line numbers that carry executable code: no blanks, comments or docstrings.
@@ -75,24 +92,30 @@ def _package_files():
     return out
 
 
-def _measure():
-    """(worst function, worst file) as (name, count) pairs, plus how many files."""
-    worst_function = ("", 0)
-    worst_file = ("", 0)
+def _sizes():
+    """Every file and every function with its logic-line count, biggest first."""
+    files, functions = [], []
     paths = _package_files()
     for path in paths:
         tree, live = _logic_lines(open(path, encoding="utf-8").read())
         rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
-        count = len(live)
-        if count > worst_file[1]:
-            worst_file = (rel, count)
+        files.append((len(live), rel))
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 continue
             span = sum(1 for n in live if node.lineno <= n <= (node.end_lineno or 0))
-            if span > worst_function[1]:
-                worst_function = (f"{rel}::{node.name}", span)
-    return worst_function, worst_file, len(paths)
+            functions.append((span, f"{rel}::{node.name}"))
+    files.sort(reverse=True)
+    functions.sort(reverse=True)
+    return files, functions, len(paths)
+
+
+def _measure():
+    """(worst function, worst file) as (name, count) pairs, plus how many files."""
+    files, functions, seen = _sizes()
+    worst_file = (files[0][1], files[0][0]) if files else ("", 0)
+    worst_function = (functions[0][1], functions[0][0]) if functions else ("", 0)
+    return worst_function, worst_file, seen
 
 
 def test_no_function_or_file_has_grown_past_the_ratchet():
@@ -112,10 +135,12 @@ def test_no_function_or_file_has_grown_past_the_ratchet():
     check(f"no function exceeds {FUNCTION_CEILING} logic lines "
           f"(split it - do not raise the ceiling)",
           worst_function[1] <= FUNCTION_CEILING,
-          f"(worst: {worst_function[0]} at {worst_function[1]})")
+          f"(worst: {worst_function[0]} at {worst_function[1]}, "
+          f"{FUNCTION_CEILING - worst_function[1]} lines of headroom left)")
     check(f"no module exceeds {FILE_CEILING} logic lines",
           worst_file[1] <= FILE_CEILING,
-          f"(worst: {worst_file[0]} at {worst_file[1]})")
+          f"(worst: {worst_file[0]} at {worst_file[1]}, "
+          f"{FILE_CEILING - worst_file[1]} lines of headroom left)")
 
 
 def test_the_ratchet_measures_logic_and_not_explanation():
@@ -134,3 +159,64 @@ def test_the_ratchet_measures_logic_and_not_explanation():
     check("ninety lines of comment and a docstring do not count as logic",
           len(live_padded) == len(live_bare),
           f"(bare {len(live_bare)}, padded {len(live_padded)})")
+
+
+def test_the_metric_still_counts_code(tmp_path):
+    """The other half of the test above, and it is not decoration.
+
+    "Comments do not move the number" is satisfied perfectly by a metric that
+    counts NOTHING - and a ceiling standing on a metric stuck at zero passes for
+    ever while the code grows underneath it. The rule the neighbouring rule set
+    states is symmetric on purpose: add N lines of comment and N lines of code to
+    the same function, and only the second may move the measure.
+    """
+    bare = "def f():\n" + "    x = 1\n" * 5
+    with_code = "def f():\n" + "    x = 1\n" * 5 + "    y = 2\n" * 7
+    _, live_bare = _logic_lines(bare)
+    _, live_code = _logic_lines(with_code)
+    check("seven more lines of code move the measure by exactly seven",
+          len(live_code) - len(live_bare) == 7,
+          f"(bare {len(live_bare)}, with code {len(live_code)})")
+
+
+def test_nothing_else_is_creeping_up_on_the_ceilings():
+    """THE SECOND KNOB - see CROWD_BAND for why one is not enough.
+
+    A ceiling on the worst item watches one thing. It cannot see the shape this
+    project actually drifts into: several files climbing together, none of them a
+    record, all of them past the point where a person can follow them. The count
+    of items already in the top band is the ratchet for that, and like every
+    ratchet here it may fall and may not rise without a decision.
+    """
+    files, functions, seen = _sizes()
+    check("the shape scan actually read the package", seen >= 30, f"({seen} files)")
+
+    file_band = FILE_CEILING * CROWD_BAND
+    crowded_files = [f"{name} ({n})" for n, name in files if n >= file_band]
+    check(f"at most {FILES_NEAR_CEILING} module(s) within {CROWD_BAND:.0%} of the "
+          f"ceiling ({file_band:.0f} lines) - split one before adding another",
+          len(crowded_files) <= FILES_NEAR_CEILING, f"({crowded_files})")
+
+    function_band = FUNCTION_CEILING * CROWD_BAND
+    crowded_functions = [f"{name} ({n})" for n, name in functions if n >= function_band]
+    check(f"at most {FUNCTIONS_NEAR_CEILING} function(s) within {CROWD_BAND:.0%} of "
+          f"the ceiling ({function_band:.0f} lines)",
+          len(crowded_functions) <= FUNCTIONS_NEAR_CEILING, f"({crowded_functions})")
+
+
+def test_the_crowd_counts_are_not_set_so_loosely_that_they_never_fire():
+    """A ratchet parked far above the current state is a ratchet that never moves.
+
+    The counts above are today's measurements, so they must be EXACT, not
+    generous. Frozen one above the truth, the guard would allow the next arrival
+    silently - which is the failure it exists to prevent, wearing its own badge.
+    """
+    files, functions, _ = _sizes()
+    actual_files = sum(1 for n, _ in files if n >= FILE_CEILING * CROWD_BAND)
+    actual_functions = sum(1 for n, _ in functions if n >= FUNCTION_CEILING * CROWD_BAND)
+    check("the module count is today's measurement, not a looser number",
+          actual_files == FILES_NEAR_CEILING,
+          f"(measured {actual_files}, frozen at {FILES_NEAR_CEILING} - lower it)")
+    check("the function count is today's measurement, not a looser number",
+          actual_functions == FUNCTIONS_NEAR_CEILING,
+          f"(measured {actual_functions}, frozen at {FUNCTIONS_NEAR_CEILING} - lower it)")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -134,6 +134,28 @@ MUTATIONS = [
         "test": "test_dead_bubbles_do_not_pile_up_across_windows",
     },
     {
+        # The leak guard's newest half. It runs in CI and had never been shown
+        # able to fail - the canary that finally did found it blind to exactly
+        # the class the convention names first.
+        "label": "leak: the private-literal check drops out of the scanner",
+        "file": "tools/check_public_text.py",
+        "old": "        low = line.lower()\n"
+               "        if any(value in low for value in literals):",
+        "new": "        low = line.lower()\n"
+               "        if False and any(value in low for value in literals):",
+        "test": "test_a_literal_from_the_private_list_is_caught_without_being_printed",
+    },
+    {
+        # Half the predicate is what shipped, and half a guard on this question
+        # let `--target *` silence the warning about damaging every connection
+        # on the machine.
+        "label": "blast radius: the narrowing check reads only half the question",
+        "file": "beantester/settings.py",
+        "old": "        if not matcher.bounds_nothing:",
+        "new": "        if not matcher.selects_nothing_in_particular:",
+        "test": "test_a_target_that_matches_everything_is_not_a_bound_either",
+    },
+    {
         # The class that already crashed this project once (driver._advapi). The
         # generic half of the guard: argtypes is the only part of a prototype that
         # ctypes leaves as None, so it is the only part a walk can check.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -134,6 +134,15 @@ MUTATIONS = [
         "test": "test_dead_bubbles_do_not_pile_up_across_windows",
     },
     {
+        # A ratchet frozen one above the truth allows the next arrival in
+        # silence - which is the drift it exists to catch, wearing its badge.
+        "label": "ratchet: the crowd count is frozen looser than the measurement",
+        "file": "tests/test_code_shape.py",
+        "old": "FILES_NEAR_CEILING = 1          # beantester/gui/app.py",
+        "new": "FILES_NEAR_CEILING = 3          # beantester/gui/app.py",
+        "test": "test_the_crowd_counts_are_not_set_so_loosely_that_they_never_fire",
+    },
+    {
         # The leak guard's newest half. It runs in CI and had never been shown
         # able to fail - the canary that finally did found it blind to exactly
         # the class the convention names first.

--- a/tests/test_public_text_guard.py
+++ b/tests/test_public_text_guard.py
@@ -1,0 +1,138 @@
+"""The leak guard has to be shown ABLE TO FAIL, or it is just a green tick.
+
+``tools/check_public_text.py`` stands between this project and the one surface
+it cannot take back: a pushed commit message. It runs in CI and it had reported
+"clean" many times - which proves it RAN, not that it LOOKS.
+
+MEASURED 2026-08-06, the first time anybody fed it something known-bad: it caught
+a user-profile path, an e-mail address, a quoted person and a token shape, and it
+let a LAN address straight through, while the convention it enforces names
+addresses among the forbidden things. A scanner nobody has watched fail is
+indistinguishable from a scanner that reads nothing.
+
+So the canary lives here, permanently, rather than as a script somebody runs
+once. Each case is a string this project would genuinely be sorry to publish.
+
+The tests never write a real private value into this file - that is the same
+mistake the scanner exists to prevent, and a leak detector containing what it
+hunts for has been reported flagging its own source.
+
+That is not theoretical here: the first version of this file spelled out two
+example e-mail addresses, and ``test_repo_conventions.py`` rejected it on the
+first run. Every address below is therefore ASSEMBLED at run time, the same way
+``check_public_text.py`` builds the dash characters it hunts for. A test about
+not writing forbidden strings down may not write them down.
+"""
+import os
+import subprocess
+import sys
+
+from fakes import ROOT, check
+
+SCANNER = os.path.join(ROOT, "tools", "check_public_text.py")
+
+# Assembled, never spelled out - see the module docstring.
+AT = chr(64)
+
+
+def _scan(text, tmp_path, private=None):
+    """Run the scanner over one block of text. Returns (exit code, output)."""
+    probe = tmp_path / "block.md"
+    probe.write_text(text, encoding="utf-8")
+    argv = [sys.executable, SCANNER, "--text-file", str(probe)]
+    if private is not None:
+        argv += ["--private-strings", str(private)]
+    out = subprocess.run(argv, capture_output=True, text=True, cwd=ROOT)
+    return out.returncode, (out.stdout or "") + (out.stderr or "")
+
+
+# The four shapes the scanner already knew about, plus the two it did not. Every
+# one is written as a SHAPE here, never as a real value from this machine.
+CAUGHT_CASES = {
+    "a user-profile path": "Fixed it on " + "C:" + chr(92) + "Users" + chr(92)
+                           + "someone" + chr(92) + "Desktop and it works.",
+    "an email address": "Reported by nobody" + AT + "example.invalid privately.",
+    "a token shape": "Set the key to ghp_" + "A" * 20,
+    "a quoted person": "The owner said this does not work, please fix it.",
+    "an em dash": "Two things " + chr(0x2014) + " one message.",
+    # Diacritics are the tell the scanner actually uses - see the case below for
+    # what that does NOT cover.
+    "a Polish sentence": "Poprawione zgodnie ze zg" + chr(0x142) + "oszeniem.",
+}
+
+
+def test_the_scanner_catches_every_shape_it_claims_to(tmp_path):
+    """One case per rule the module docstring advertises."""
+    for label, text in CAUGHT_CASES.items():
+        code, output = _scan(text, tmp_path)
+        check(f"caught: {label}", code != 0, f"({output.strip()[:90]!r})")
+
+
+def test_the_scanner_passes_text_that_is_actually_fine(tmp_path):
+    """The other half. A guard that fails everything is as useless as one that
+    fails nothing, and it is the version that gets switched off."""
+    code, output = _scan(
+        "Declare full prototypes for the window manager calls.\n"
+        "Measured 5098 KB/s against a 5000 KB/s limit.\n"
+        "Co-authored-by: Someone <someone" + AT + "example.invalid>\n", tmp_path)
+    check("clean text passes", code == 0, f"({output.strip()[:120]!r})")
+
+
+def test_a_literal_from_the_private_list_is_caught_without_being_printed(tmp_path):
+    """The half that was missing, and the constraint that comes with it.
+
+    The report must name the line and NEVER the value: its output goes into CI
+    logs, which are exactly as public as the commit it is guarding.
+    """
+    secret = "10.77.77.77"                      # invented here, not a real one
+    listing = tmp_path / "private.txt"
+    listing.write_text("# comment ignored\n\n%s\n" % secret, encoding="utf-8")
+
+    code, output = _scan("Measured against the peer at %s over the LAN.\n" % secret,
+                         tmp_path, private=listing)
+    check("a private literal is caught", code != 0, f"({output.strip()[:90]!r})")
+    check("and the value itself is NOT printed back", secret not in output,
+          "the report repeated the very string it exists to keep out of public text")
+
+
+def test_a_missing_private_list_is_announced_rather_than_silent(tmp_path):
+    """On a fresh clone the list is absent - and a check that goes quiet when its
+    input is missing looks exactly like a check that passed."""
+    code, output = _scan("Nothing wrong here.\n", tmp_path,
+                         private=tmp_path / "does-not-exist.txt")
+    check("a clean block still passes", code == 0)
+    check("but the missing list is said out loud",
+          "did NOT run" in output, f"({output.strip()[:120]!r})")
+
+
+def test_polish_written_without_diacritics_goes_straight_through(tmp_path):
+    """A KNOWN gap, pinned so it stays known.
+
+    The language check is a diacritics detector, which the scanner's own comment
+    says. This test exists because the first version of the canary above quietly
+    assumed otherwise: it wrote its Polish case without diacritics, passed
+    nothing to the scanner that the scanner could see, and would have reported
+    the rule as covered.
+
+    Pinning the gap does two things a comment cannot. It makes the limit
+    checkable rather than believed, and if someone later widens the detector this
+    test goes red and asks them to say so on purpose.
+    """
+    code, _ = _scan("Poprawione zgodnie ze zgloszeniem uzytkownika.\n", tmp_path)
+    check("Polish without diacritics is NOT caught (the guard is partial here)",
+          code == 0,
+          "the language check got wider - that may be good, but the docstring "
+          "and this test have to be updated together")
+
+
+def test_the_canary_itself_would_notice_a_gutted_scanner(tmp_path):
+    """The check on the check: an empty rule set must fail this file, not pass it.
+
+    Without this, every assertion above could be satisfied by a scanner that
+    happens to exit non-zero for an unrelated reason.
+    """
+    code, output = _scan(CAUGHT_CASES["an email address"], tmp_path)
+    check("the failure names the offending line", "line 1" in output,
+          f"({output.strip()[:120]!r})")
+    check("and says why it matters", "cannot be edited away" in output,
+          f"({output.strip()[:120]!r})")

--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -31,6 +31,7 @@ USAGE
     request description.
 """
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -92,8 +93,50 @@ PRIVATE = (
 # just approved. Only running it over master found that.
 ALLOWED_LINE = re.compile(r"^co-authored-by: .+ <[^>]+>$", re.I)
 
+# -- this machine's own strings, kept OUT of this file ------------------------ #
+#
+# The convention forbids addresses as well as paths and tokens, and this script
+# did not check for them. MEASURED before adding it: a canary fed the scanner a
+# path, an e-mail, a quoted person and a token - all four caught - and a LAN
+# address, which sailed through. A guard the convention names and the code does
+# not implement is worse than one nobody wrote down, because somebody relies on
+# it.
+#
+# 🔴 The obvious fix - a pattern for private-range addresses - was measured and
+# REJECTED. Those addresses are legitimate documentation: 36 tracked files carry
+# one, including the CIDR examples in both READMEs, the help text, the error
+# messages and this project's own test probes. A guard that fires on correct
+# content is switched off within a week, and takes the true hits with it.
+#
+# So the split this needs is the one a leak-detector always needs: the ENGINE is
+# public and knows only the shape of the check, while the LIST OF LITERALS lives
+# outside version control and is read at run time. A literal here would put the
+# very strings this script exists to keep out of the public tree INTO it.
+PRIVATE_STRINGS = os.path.join("internal_tools", "private-strings.txt")
 
-def offences(text, where):
+
+def private_strings(path):
+    """Literal strings that must never reach public text, from outside git.
+
+    Returns ``(strings, note)``. The note is printed whether or not the file is
+    there: a missing list means this half of the check did not run, and a check
+    that goes quiet when its input is absent looks exactly like a check that
+    passed - which on a fresh clone would be every time.
+    """
+    if not os.path.exists(path):
+        return (), ("no private-strings list at %s - the literal check did NOT "
+                    "run (see the comment in this file)" % path)
+    values = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                values.append(line.lower())
+    return tuple(values), "private-strings list: %d entries from %s" % (
+        len(values), path)
+
+
+def offences(text, where, literals=()):
     """Every rule broken by one block of text, as readable lines."""
     found = []
     for number, line in enumerate(text.splitlines(), 1):
@@ -118,6 +161,14 @@ def offences(text, where):
         for pattern, what in PRIVATE:
             if pattern.search(line):
                 found.append(f"{where} line {number}: {what}")
+        # The report names the LINE and never the value. A leak detector that
+        # prints what it matched becomes the leak it was meant to prevent - and
+        # its output goes into CI logs, which are as public as the commit.
+        low = line.lower()
+        if any(value in low for value in literals):
+            found.append(f"{where} line {number}: a string from the private list "
+                         f"(this machine's own; the value is deliberately not "
+                         f"printed)")
     return found
 
 
@@ -143,6 +194,9 @@ def main():
                         help="a git revision range, e.g. origin/master..HEAD")
     parser.add_argument("--text-file", metavar="PATH",
                         help="a file holding one block of text (a PR description)")
+    parser.add_argument("--private-strings", metavar="PATH", default=PRIVATE_STRINGS,
+                        help="literals that must never reach public text "
+                             "(outside git; default: %(default)s)")
     args = parser.parse_args()
 
     blocks = []
@@ -154,9 +208,12 @@ def main():
     if not blocks:
         parser.error("nothing to check: pass --commits or --text-file")
 
+    literals, note = private_strings(args.private_strings)
+    print(note)
+
     found = []
     for text, where in blocks:
-        found.extend(offences(text, where))
+        found.extend(offences(text, where, literals))
 
     if found:
         print("This text becomes public and stays public. Fix before pushing:\n")


### PR DESCRIPTION
Five changes, each its own commit. Two are safety or guard holes found by reading a set of
general engineering rule documents against this code; two make the CLI answer a bad input the
way the rest of the tool already does; one gives the size ratchet the knob it was missing.

Everything here was checked against the code before it was written: a rule that this project
already followed was not turned into a change (that is what most of the reading produced -
nothing).

## A target that matches everything is not a target

Start with impairment on and `--target *`, and the tool stayed quiet, because a target WAS set -
to every process on the machine. The blast-radius warning is the one that keeps a run from taking
the network down with the shell that started it, and an expression that narrows nothing is exactly
the case it exists for.

`Matcher.covers_everything` answers by PROBING, not by pattern-matching the text: each matcher
class carries a small group of representative values, and an expression that accepts the whole
group covers everything. `*`, `re:.*`, `1-65535`, `0.0.0.0/0` and a PID range spanning the space
all trip it; a real target does not, and neither does a real target with an exclusion beside it.
Probing is why a NEW spelling of "everything" cannot slip past - it never had to be listed.

## Show the leak guard failing, and teach it the class it missed

`tools/check_public_text.py` runs in CI and had reported "clean" many times, which proved it runs -
not that it catches anything. There was no test that ever saw it FAIL.

`tests/test_public_text_guard.py` now feeds it each thing it is supposed to catch and asserts it
says no. Writing those cases found the gap: the guard knew patterns (a path shape, an address
shape), so a value that is only private because it is THIS machine's was invisible to it. The list
of those values lives outside the repository, in an ignored file, and the guard reports a hit
without printing the value - printing it would put it in the CI log, which is the thing being
prevented. With no list present the guard behaves exactly as before.

One known gap is pinned by a test rather than papered over: Polish written without diacritics
passes the "is this English" check, because it is indistinguishable from English by that check.
The test records it so the next reader learns it from the suite instead of from a merged PR.

## Report every bad value in one run

`--loss 500 --latency -5 --dup 900` named the latency and stopped. Three mistakes, three runs.

`settings.range_errors` is a second reader of the same field registry, not a replacement. The form
still fails on the first field: it is typed into LIVE, and complaints about fields nobody has
reached yet are noise. A command line arrives FINISHED, where the opposite is true.
`validate_ranges` keeps its contract, so no window caller moved.

## Suggest the nearest preset when one is mistyped

An unknown `--preset` answered with all seventeen canonical ids. The tool already offers a nearest
match for a mistyped config key and a mistyped scenario key, so preset names were the one closed
vocabulary left without it.

The suggestion is drawn from what a person can TYPE - the translated names as well as the ids.
Somebody reaching for "modem56k" writes that, not "presets.modem56k", and a search over ids alone
finds nothing close and stays silent exactly when it is needed.

## The size ratchet gets the knob that sees creep

The ratchet capped the largest file and the largest function, so a hundred files could climb to
one line under the ceiling and it would not notice. It now also caps how many files and functions
sit in the top band, and every failure message states the remaining headroom, so the number in the
message is the one you would have to justify raising. A third test keeps the crowd counts honest:
it fails if they are set so far above reality that they could never fire.

## Verification

- `python -m pytest tests` - full suite, green (run as the last action, after the prose edits).
- `python smoke_gui.py` - green.
- `python tools/check_public_text.py --commits origin/master..HEAD` - 5 blocks, clean.
- Every new guard was mutation-tested: the change was broken on purpose and the test had to fail.
  Three mutations SURVIVED on the first attempt and each one found a real defect in the test rather
  than in the product - a fake missing `winfo_toplevel`, a fallback the fake never reached, and a
  first regex narrow enough to walk around. All three are fixed and now fail as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
