### PR TITLE
chore: skip the admin-only checks instead of failing, and review new dependencies

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+# Blocks a pull request that introduces a dependency with a known vulnerability.
+#
+# Why a separate workflow and not a step in ci.yml: this action compares the
+# dependency manifests of the BASE and the HEAD of a pull request, so it is
+# meaningful on `pull_request` only - a push has nothing to diff against. Wiring
+# it into the main matrix would make it run (and be skipped) three more times per
+# push for no benefit.
+name: dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: review new dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
+        with:
+          # A tool that loads a kernel driver has no business gaining a
+          # vulnerable dependency quietly. Anything at or above "moderate"
+          # fails the pull request rather than warning in a log nobody reads.
+          fail-on-severity: moderate
+          comment-summary-in-pr: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,17 +8,16 @@ testable on any OS.
 
 ```bash
 pip install -r requirements-dev.txt
-python -m pytest tests            # full suite - the engine needs no Windows and no driver
+python -m pytest tests            # full suite - no Windows, no driver, no admin rights
 python smoke_gui.py               # GUI smoke with a fake tkinter
 python bean_network_tester.py --simulate --loss 10 --duration 3   # CLI demo
 python bean_network_tester.py --doctor                            # environment report
 ```
 
-**One exception, on Windows only:** two tests in `tests/test_cli_runtime.py` check what
-the CLI does once it is allowed to open the driver. In a shell without administrator
-rights the permission check answers first, so those two - and only those two - fail.
-Run the suite from an elevated prompt, or read a run with exactly those two failures as
-green. Everywhere else the suite passes with no special rights.
+Two checks in `tests/test_cli_runtime.py` assert what the CLI does once it is allowed to
+open the driver. On Windows without administrator rights they **skip themselves and say
+so** - green still means green. Run the suite from an elevated prompt if you want them
+executed; nothing else in it needs special rights.
 
 The shipped build is ONE executable (`BeanNetworkTester.exe`, built from
 `BeanNetworkTester.spec`) that serves both the GUI and the CLI: console subsystem,

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -14,7 +14,7 @@ import os
 import time
 
 from beantester import cli as cli_module
-from beantester import exitcodes
+from beantester import exitcodes, winenv
 from beantester.cli import (_Terminated, _print_conns, build_arg_parser,
                             config_from_args, run_cli)
 from fakes import check
@@ -329,6 +329,27 @@ def test_fail_on_no_traffic_is_shorthand_for_min_packets_one():
           config_from_args(args)["min_packets"] == 1)
 
 
+def _needs_permission_to_answer(what):
+    """Skip, with a reason, when the CLI would refuse before reaching the point.
+
+    Two tests here assert what the CLI does once it is ALLOWED to open the driver.
+    On Windows without an elevated shell the permission check answers first, so
+    they used to fail - a permanent pair of red lines that this project
+    re-diagnosed every few sessions and that a contributor met with no
+    explanation. They are skipped instead, so "green means green" holds
+    everywhere.
+
+    A skip is not silence: pytest names it and prints the reason. That matters,
+    because the alternative - deleting the assertion - would leave the elevated
+    run proving less than it does today.
+    """
+    import pytest
+
+    if os.name == "nt" and not winenv.is_admin():
+        pytest.skip("%s needs an elevated shell on Windows: the CLI answers "
+                    "PERMISSION(7) before it gets this far" % what)
+
+
 def test_exit_code_runtime_without_pydivert():
     """A capture that cannot start is RUNTIME, not 0.
 
@@ -337,7 +358,14 @@ def test_exit_code_runtime_without_pydivert():
     and admin rights), where a real capture started, saw no traffic and exited 0.
     So the failure is forced deterministically instead: an injected engine whose
     ``start`` raises, exactly as a missing/unopenable driver would.
+
+    The injected engine is still not enough on its own: ``run_cli`` refuses on
+    PERMISSION before it ever reaches the engine, so an unelevated Windows shell
+    never gets here. Measured, not assumed - forcing ``is_admin()`` False still
+    produced ``code=7``.
     """
+    _needs_permission_to_answer("a capture that cannot start")
+
     class _CannotStartEngine:
         fault = False
 
@@ -849,8 +877,12 @@ def test_print_config_dumps_the_effective_settings():
 
 def test_doctor_reports_the_environment():
     code, out, _ = cli(["--doctor"])
+    # The two lines it prints are true on any machine, elevated or not.
     check("--doctor: reports python", "python" in out)
     check("--doctor: reports the platform", "platform" in out)
+    # The VERDICT is not: without admin rights `driver.doctor()` reports a box
+    # that cannot capture, and exit 1 is the right answer there, not a defect.
+    _needs_permission_to_answer("--doctor's healthy-box verdict")
     check("--doctor: exits OK on a healthy (simulate-capable) box",
           code == exitcodes.OK, f"({code})")
 


### PR DESCRIPTION
Two loose ends, each its own commit. Both were open questions rather than bugs, and both
turned out to have a clearly better answer than the status quo.

## The two "known admin failures" now skip themselves

An unelevated Windows run of `pytest tests` ended with exactly two red lines in
`tests/test_cli_runtime.py`. Both assert what the CLI does once it is **allowed** to open the
driver, and `run_cli` answers `PERMISSION(7)` before either assertion is reached - so the
failure said nothing at all about the change under test.

The cost of leaving them red was not theoretical: this project re-diagnosed the pair every few
sessions, and a contributor met two failures with nothing to read. The contributor guide had
grown a paragraph explaining them, which is a documentation fix for a test problem.

They now call `_needs_permission_to_answer()`, which skips with the reason printed.

**A skip is not silence** - pytest names it and says why. That distinction is the whole design:
deleting the assertion would have been silence, so the assertion stays and still runs on an
elevated shell. Verified in both directions rather than reasoned about:

- elevated: `2 passed, 0 skipped`;
- with `IsUserAnAdmin` patched to return 0 through a throwaway pytest plugin: `2 skipped`, both
  reasons printed, zero failures.

`CONTRIBUTING.md` loses its exception paragraph. Red means red now, everywhere.

## dependency-review on every pull request

The last item on the post-public checklist. Private vulnerability reporting, CodeQL, secret
scanning and the branch ruleset were already in place.

`fail-on-severity: moderate`, because a tool that loads a kernel-mode driver has no business
gaining a vulnerable dependency quietly, and a warning in a log nobody reads is not a guard.

It gets its own workflow rather than a step in `ci.yml`: the action diffs the **base** of a pull
request against its **head**, so it is meaningful on `pull_request` only and would otherwise run
and skip three more times per push for nothing.

The action versions were checked against the actions' own release API rather than written from
memory - the first draft said `checkout@v5` and `dependency-review-action@v4`, while this repo is
on `checkout@v7` and the action's current release is `v5.0.0`. That check is now a written rule
here, and this was its first outing.

## Verification

- `python -m pytest tests` - **1032 passed**, run bare (a second `-q` on top of the one in
  `addopts` suppresses the summary line) and as the last action after the prose edits.
- `python smoke_gui.py` - green.
- `python tools/check_public_text.py --commits origin/master..HEAD` - 2 blocks, clean.
- The skip guard exercised both ways, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
