### PR TITLE
fix: stop the leak guard failing on an empty range, and split the 167-line style function

### DIFF
--- a/beantester/gui/theme.py
+++ b/beantester/gui/theme.py
@@ -88,15 +88,8 @@ DONATE_C = "#ff8fb1"      # the support button (not a session control - own colo
 SCROLL_BG = "#3a4150"     # scrollbar thumb
 SCROLL_TROUGH = "#20232b"
 
-def init_style(root=None):
-    """Configure the shared ttk styles for the dark theme."""
-    s = ttk.Style()
-    try:
-        s.theme_use("clam")
-    except Exception as _exc:
-        crashlog.note(_exc, "gui.theme")
-
-    # -- surfaces ---------------------------------------------------------- #
+def _style_surfaces(s):
+    """Frames, labels and label-frames: the flat colours everything else sits on."""
     s.configure("TFrame", background=BG)
     s.configure("Card.TFrame", background=BG2)
     s.configure("Line.TFrame", background=LINE_C)
@@ -129,7 +122,14 @@ def init_style(root=None):
                 bordercolor=LINE_C, lightcolor=LINE_C, darkcolor=LINE_C)
     s.configure("TLabelframe.Label", background=BG, foreground=ACC, font=(FONT, 9, "bold"))
 
-    # -- buttons ------------------------------------------------------------ #
+
+def _style_buttons(s):
+    """Every button variant, and the checkbutton indicator built from images.
+
+    The longest of these by far, and the one with the most paid-for reasoning in
+    its comments - which is why the split put it in its own function rather than
+    spreading it.
+    """
     # FOCUS AND HOVER MUST NOT LOOK THE SAME (see the module docstring). Hover is
     # the fill; focus is the ring clam's ``Button.focus`` element draws INSIDE the
     # button - every clam button layout has it, and at thickness 1 it costs no
@@ -207,7 +207,9 @@ def init_style(root=None):
           lightcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)],
           darkcolor=[("active", BTN_BG), ("pressed", BTN_HOVER)])
 
-    # -- checkbuttons ------------------------------------------------------- #
+
+def _style_checkbuttons(s):
+    """The tick itself is drawn, not a font glyph - see `_check_image`."""
     # clam's built-in indicator is a flat, tiny, badly aligned square that no
     # amount of option juggling fixes. Draw the box ourselves instead.
     s.configure("TCheckbutton", background=BG2, foreground=FG, font=(FONT, 9),
@@ -217,7 +219,9 @@ def init_style(root=None):
           foreground=[("disabled", DIS_FG)])
     _install_check_indicator(s)
 
-    # -- entries ------------------------------------------------------------ #
+
+def _style_entries(s):
+    """Text fields, including the read-only and invalid states."""
     s.configure("TEntry", fieldbackground=FIELD, foreground=FG, insertcolor=FG,
                 borderwidth=1, bordercolor=BORDER, lightcolor=BORDER,
                 darkcolor=BORDER, padding=scaled(2))
@@ -234,7 +238,9 @@ def init_style(root=None):
           fieldbackground=[("disabled", DIS_BG)],
           foreground=[("disabled", DIS_FG)])
 
-    # -- comboboxes --------------------------------------------------------- #
+
+def _style_comboboxes(s):
+    """The closed combobox. Its POPDOWN is a classic Tk listbox - see below."""
     s.configure("TCombobox", fieldbackground=FIELD, background=BG2, foreground=FG,
                 arrowcolor=MUT, borderwidth=1, bordercolor=BORDER,
                 lightcolor=BORDER, darkcolor=BORDER, padding=scaled(2))
@@ -254,7 +260,9 @@ def init_style(root=None):
     # frame, its width and the highlight on the current entry are outside Tk's
     # reach. Two dropdowns on the same page must be the same widget.
 
-    # -- scrollbars --------------------------------------------------------- #
+
+def _style_scrollbars(s):
+    """Scrollbars, which clam draws with three separate colours."""
     for orient in ("Vertical.TScrollbar", "Horizontal.TScrollbar"):
         s.configure(orient, background=SCROLL_BG, troughcolor=SCROLL_TROUGH,
                     bordercolor=SCROLL_TROUGH, arrowcolor=MUT,
@@ -265,7 +273,9 @@ def init_style(root=None):
               background=[("disabled", DIS_BG), ("active", "#4b5468")],
               arrowcolor=[("disabled", DIS_BG)])
 
-    # -- notebook / tables --------------------------------------------------- #
+
+def _style_notebook_and_tables(s):
+    """Page tabs and every Treeview: the two surfaces that carry data."""
     # clam paints a tab from several elements (Notebook.tab -> Notebook.padding ->
     # Notebook.focus -> Notebook.label) and marks the selected one by GROWING it
     # (an `expand` map). Recolouring the style alone only tinted the inner element,
@@ -305,7 +315,13 @@ def init_style(root=None):
     s.map("Treeview.Heading", background=[("active", BG2)])
     s.map("Treeview", background=[("selected", "#33455f")], foreground=[("selected", FG)])
 
-    # -- the combobox popdown is a classic Tk listbox: style it via options --- #
+
+def _style_popdown(root):
+    """The combobox popdown is a classic Tk listbox, so ttk styles do NOT reach it.
+
+    It is configured through the option database instead, which needs a root -
+    hence the odd signature: this is the one block that styles nothing on `s`.
+    """
     if root is not None:
         try:
             root.option_add("*TCombobox*Listbox.background", FIELD)
@@ -317,6 +333,34 @@ def init_style(root=None):
             root.option_add("*TCombobox*Listbox.font", (FONT, 9))
         except Exception as _exc:
             crashlog.note(_exc, "gui.theme")
+
+
+def init_style(root=None):
+    """Configure the shared ttk styles for the dark theme.
+
+    A list of calls, in the order the blocks were written in. Split out of one
+    167-line function on 2026-08-10: the size ratchet had pinned its ceiling to
+    exactly this function, so any styling change reddened the suite, and the
+    ratchet's documented answer is to move code out rather than raise the number.
+
+    Proved to be a pure move: every ttk style's `configure`, `map` and `layout`
+    plus the popdown's option entries were dumped before and after - 173 styles,
+    byte-identical.
+    """
+    s = ttk.Style()
+    try:
+        s.theme_use("clam")
+    except Exception as _exc:
+        crashlog.note(_exc, "gui.theme")
+
+    _style_surfaces(s)
+    _style_buttons(s)
+    _style_checkbuttons(s)
+    _style_entries(s)
+    _style_comboboxes(s)
+    _style_scrollbars(s)
+    _style_notebook_and_tables(s)
+    _style_popdown(root)
     return s
 
 

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -41,7 +41,11 @@ import os
 from fakes import ROOT, check
 
 # Today's maxima, measured 2026-08-02. Ratchet: down is routine, up is a decision.
-FUNCTION_CEILING = 167          # beantester/gui/theme.py::init_style
+# Lowered 2026-08-10 from 167 (`gui/theme.py::init_style`) after that function was
+# split by style family. The ceiling had been pinned to it exactly, so ANY change to
+# the theme reddened the suite - and the ratchet's own answer to that is to move code
+# out, not to raise the number. Down is routine: this took the routine door.
+FUNCTION_CEILING = 133          # beantester/cli.py::_run_session
 FILE_CEILING = 1299             # beantester/gui/app.py
 
 # 🔴 THE SECOND KNOB. A ceiling on the worst single item sees one thing growing
@@ -59,7 +63,7 @@ FILE_CEILING = 1299             # beantester/gui/app.py
 # lines of headroom before it joins the count.
 CROWD_BAND = 0.70
 FILES_NEAR_CEILING = 1          # beantester/gui/app.py
-FUNCTIONS_NEAR_CEILING = 4      # init_style, _run_session, _build_ui, build_arg_parser
+FUNCTIONS_NEAR_CEILING = 3      # _run_session, _build_ui, build_arg_parser
 
 
 def _logic_lines(source):

--- a/tests/test_public_text_guard.py
+++ b/tests/test_public_text_guard.py
@@ -105,6 +105,32 @@ def test_a_missing_private_list_is_announced_rather_than_silent(tmp_path):
           "did NOT run" in output, f"({output.strip()[:120]!r})")
 
 
+def test_an_empty_commit_range_is_a_clean_result_not_a_usage_error(tmp_path):
+    """Two different empties, and conflating them made the guard cry wolf.
+
+    `preflight.py` runs `--commits origin/master..HEAD`. On a branch with no
+    commits of its own that range is empty, and the scanner used to answer
+    "nothing to check: pass --commits or --text-file" with exit 2 - a usage error
+    naming a flag that HAD been passed. Preflight reported FAIL on a clean tree,
+    and a guard that fails for no reason is a guard people learn to skip.
+
+    Being asked for nothing is still a usage error. Being asked about a range
+    that holds nothing is a clean answer.
+    """
+    empty = subprocess.run(
+        [sys.executable, SCANNER, "--commits", "HEAD..HEAD"],
+        capture_output=True, text=True, cwd=ROOT)
+    check("an empty range exits clean", empty.returncode == 0,
+          f"(code={empty.returncode}, {(empty.stdout + empty.stderr).strip()[:120]!r})")
+    check("and says why it had nothing to do",
+          "0 block(s)" in empty.stdout, f"({empty.stdout.strip()[:120]!r})")
+
+    asked_for_nothing = subprocess.run(
+        [sys.executable, SCANNER], capture_output=True, text=True, cwd=ROOT)
+    check("but passing no source at all is still a usage error",
+          asked_for_nothing.returncode == 2, f"(code={asked_for_nothing.returncode})")
+
+
 def test_polish_written_without_diacritics_goes_straight_through(tmp_path):
     """A KNOWN gap, pinned so it stays known.
 

--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -205,8 +205,18 @@ def main():
     if args.text_file:
         with open(args.text_file, encoding="utf-8", errors="replace") as handle:
             blocks.append((handle.read(), "description"))
+    # Two different empties, and conflating them made this guard cry wolf. Being
+    # ASKED for nothing is a usage error; being asked about a range that HOLDS
+    # nothing is a clean result - a branch with no commits of its own carries no
+    # public text, which is exactly what we wanted to hear. `preflight.py` ran
+    # this on a fresh branch and reported FAIL, and a guard that fails for no
+    # reason teaches people to skip it.
     if not blocks:
-        parser.error("nothing to check: pass --commits or --text-file")
+        if not (args.commits or args.text_file):
+            parser.error("nothing to check: pass --commits or --text-file")
+        print(f"public text: 0 block(s) in {args.commits or args.text_file!r} "
+              f"- nothing to check, which is not a failure")
+        return 0
 
     literals, note = private_strings(args.private_strings)
     print(note)


### PR DESCRIPTION
Two cleanups, each its own commit. Both were found by running the project's own tooling rather
than by reading it.

## An empty commit range is a clean result, not a usage error

`preflight.py` runs the leak guard as `--commits origin/master..HEAD`. On a branch with no
commits of its own that range is empty, `blocks` stayed empty, and the script fell through to:

```
check_public_text.py: error: nothing to check: pass --commits or --text-file
```

exit 2 - a usage error naming a flag that had in fact been passed. So preflight reported `FAIL
public text (commits)` on a clean tree.

The exit code is the smaller half. **A guard that fails for no reason is one people learn to
skip**, and this particular guard is the last thing standing between a machine path and a public
commit message.

Two empties now read differently: being asked for nothing is still a usage error; being asked
about a range that holds nothing prints `0 block(s)` and exits 0. Both halves are in the test,
and restoring the old unconditional `parser.error` reddens it.

## init_style split by widget family, and the ratchet lowered

`gui/theme.py::init_style` was 167 logic lines and `FUNCTION_CEILING` was pinned to **exactly**
that number, so any change to the theme reddened the suite. The ratchet's own documented answer
is to move code out rather than raise the number, and doing it with no feature waiting on it is
when it costs least.

Eight functions, one per style family - surfaces, buttons, checkbuttons, entries, comboboxes,
scrollbars, notebook/tables, popdown - called in the original order. `init_style` is now the list
of calls.

**Proved to be a pure move rather than reviewed as one.** A screenshot compares what a person
notices; this compares what Tk holds. Every ttk style's `configure`, `map` and `layout`, plus the
popdown's option-database entries, dumped before and after:

- **173 styles, byte-identical** (sha256 `257161e1...` both sides);
- `smoke_gui.py` green;
- `tools/ci_gui_render.py` green on real Tk at 1366x768 in **both** shipped languages - the check
  that sees clipping the fake Tk cannot, and the one that matters most for a theme change.

Ratchet lowered to match: `FUNCTION_CEILING` 167 -> 133 (`cli.py::_run_session`),
`FUNCTIONS_NEAR_CEILING` 4 -> 3. Down is routine, up is a decision.

Worth noting which guard caught the stale number: the crowd-count test added on 2026-08-06 exists
precisely to fail when a frozen count is looser than the measurement. This was its first real
outing and it fired - `(measured 3, frozen at 4 - lower it)`.

## Verification

- `python -m pytest tests` - **1033 passed**, run bare and as the last action after the prose.
- `python smoke_gui.py` - green.
- `python tools/ci_gui_render.py --lang en` and `--lang pl` - both OK.
- `python tools/check_public_text.py --commits origin/master..HEAD` - 2 blocks, clean.
- The style dump described above, and a mutation on the empty-range fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
