### PR TITLE
fix: a block that matches everything is not a bounded block, and pin the ratchet ceilings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Blocking everything now warns you, like every other way of affecting everything.** A block
+  normally limits its own damage, because it names an address or a port - so it never raised the
+  "this affects every connection" warning. But `*` names everything: it cut the whole machine and
+  said nothing, while a 50% loss, which only slows things down, warned. Any blocking expression
+  that matches everything now counts as affecting everything. A real block - `172.*`, one subnet,
+  one port - is unchanged and still silent, and so is a block with a target or a time limit.
+
 - **The labels on the Control page are punctuated the same way now.** Ten of them were missing
   the colon the others had, so "Loss", "Corruption" and "Duplication" sat directly beside
   "Latency:" and "Jitter:", and the link-drop section contradicted itself in two adjacent

--- a/beantester/fields.py
+++ b/beantester/fields.py
@@ -350,6 +350,10 @@ NON_PROFILE_FIELDS = tuple((f.key, f.label) for f in FIELD_DEFS if not f.in_prof
 # them, so a new impairment is declared once instead of remembered twice.
 IMPAIRING_KEYS = tuple(f.key for f in FIELD_DEFS if f.impairs)
 GLOBALLY_IMPAIRING_KEYS = tuple(f.key for f in FIELD_DEFS if f.impairs == IMPAIRS_ALL)
+# Damages only what it NAMES - which stops being a limit the moment the expression
+# names everything. `settings.armed_global_impairments` promotes one of these to a
+# global impairment when its expression covers the whole space; see it for why.
+MATCHED_IMPAIRING_KEYS = tuple(f.key for f in FIELD_DEFS if f.impairs == IMPAIRS_MATCHED)
 NARROWING_KEYS = tuple(f.key for f in FIELD_DEFS if f.narrows)
 
 

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -80,14 +80,51 @@ def build_matchers(s):
     return out
 
 
+def _expression_covers_everything(key, value):
+    """Does this filter expression accept the WHOLE space it is written against?
+
+    Total by design: an expression that does not compile is answered ``False``
+    rather than raised on. This runs on the path to a start-time WARNING, and a
+    warning that could abort a start would be worse than the mode it warns about
+    (same reasoning as ``unbounded_impairment``). The form and the CLI both
+    validate expressions up front, so a broken one has already been reported.
+    """
+    field = FIELDS[key]
+    text = setting_expression(key, value)
+    if not text:
+        return False
+    try:
+        matcher = parse_matcher(text, field.expr_kind, field.label, field.bounds)
+    except ValueError:
+        return False
+    return bool(matcher.covers_everything)
+
+
 def armed_global_impairments(s):
     """Keys of impairments that are ON and damage every captured packet.
 
     Registry-derived (``fields.GLOBALLY_IMPAIRING_KEYS``), so an impairment added
     later is covered by declaring it once, in the table where it is defined.
+
+    🔴 Plus the case the registry cannot state statically. A field marked
+    ``IMPAIRS_MATCHED`` damages only what its expression names - which is a limit
+    right up until the expression names EVERYTHING, and then it is a machine-wide
+    impairment wearing a narrow-looking label. MEASURED before this existed:
+    ``--block-ip '*'`` dropped every packet to every address and raised NO
+    warning, while ``--loss 50``, which merely degrades the link, raised one. The
+    blocking expression that cut the network looked safer than the one that
+    slowed it down.
+
+    This is the same hole as ``--target *`` (fixed 2026-08-06) seen from the other
+    side, and it is answered by the same property: ``Matcher.covers_everything``.
+    A narrow block - ``10.*``, ``172.16.0.0/12``, one port - is untouched and
+    still bounds its own damage, which is what makes it not a narrowing.
     """
-    return tuple(key for key in F.GLOBALLY_IMPAIRING_KEYS
-                 if F.is_active(FIELDS[key], s.get(key, DEFAULT_SETTINGS[key])))
+    armed = [key for key in F.GLOBALLY_IMPAIRING_KEYS
+             if F.is_active(FIELDS[key], s.get(key, DEFAULT_SETTINGS[key]))]
+    armed += [key for key in F.MATCHED_IMPAIRING_KEYS
+              if _expression_covers_everything(key, s.get(key, DEFAULT_SETTINGS[key]))]
+    return tuple(armed)
 
 
 def targeting_is_set(s):

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -1075,6 +1075,44 @@ def test_blocking_bounds_only_its_own_damage(monkeypatch):
     check("warning: a block does not bound the loss beside it", _warned(err))
 
 
+def test_a_block_that_matches_everything_is_not_a_bounded_block(monkeypatch):
+    """The other side of the test above, and the one that was missing.
+
+    A block bounds its own damage BECAUSE it names something. `--block-ip '*'`
+    names everything, so it cuts every connection on this machine - and this is
+    the machine Claude Code runs on. MEASURED before the fix: it dropped 5 of 5
+    addresses and raised no warning at all, while `--loss 50`, which only
+    degrades the link, raised one. The expression that severed the network looked
+    safer than the one that slowed it down.
+
+    Same hole as `--target *` (fixed 2026-08-06) seen from the other side, and
+    answered by the same `Matcher.covers_everything`.
+
+    The narrow cases below are the half that matters most: they are what makes
+    this a fix rather than a new false alarm. `172.*` is included because that is
+    how people actually write a prefix.
+    """
+    for argv, why in (
+            (["--block-ip", "*"], "an IP wildcard covering everything"),
+            (["--block-port", "*"], "a port wildcard covering everything"),
+            (["--block-ip", "re:.*"], "a regular expression matching all"),
+            (["--block-ip", "0.0.0.0/0"], "the whole address space as a CIDR"),
+    ):
+        _, _, err, _ = _real_run(monkeypatch, argv)
+        check(f"warning: a block by {why} is machine-wide", _warned(err), f"({argv})")
+
+    for argv, why in (
+            (["--block-ip", "172.*"], "a one-octet prefix, the way people write it"),
+            (["--block-ip", "10.0.0.1"], "a single address"),
+            (["--block-ip", "172.16.0.0/12"], "a real subnet"),
+            (["--block-port", "443"], "a single port"),
+            (["--block-ip", "*", "--duration", "5"], "everything, but with a deadline"),
+            (["--block-ip", "*", "--target", "probe.exe"], "everything, but one process"),
+    ):
+        _, _, err, _ = _real_run(monkeypatch, argv)
+        check(f"warning: silent for {why}", not _warned(err), f"({argv})")
+
+
 def test_an_exclusion_only_target_is_not_a_bound(monkeypatch):
     """``!chrome.exe`` is non-empty and narrows nothing.
 

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -45,8 +45,16 @@ from fakes import ROOT, check
 # split by style family. The ceiling had been pinned to it exactly, so ANY change to
 # the theme reddened the suite - and the ratchet's own answer to that is to move code
 # out, not to raise the number. Down is routine: this took the routine door.
+#
+# 🔴 BOTH ARE PINNED TO TODAY'S MEASUREMENT, and a test below enforces that. A
+# ceiling standing ABOVE the truth is a knob that has quietly loosened: it grants
+# headroom nobody decided to grant, and the next arrival slips in under it in
+# silence. This one had drifted - `FILE_CEILING` stayed at 1299 after `gui/crash.py`
+# was carved out of `app.py` and left it at 1287, so twelve lines of allowance sat
+# there for a week and were found only because somebody printed the numbers. That is
+# the same defect the crowd counts below exist to catch, one level up.
 FUNCTION_CEILING = 133          # beantester/cli.py::_run_session
-FILE_CEILING = 1299             # beantester/gui/app.py
+FILE_CEILING = 1287             # beantester/gui/app.py
 
 # 🔴 THE SECOND KNOB. A ceiling on the worst single item sees one thing growing
 # to a record and is blind to everything creeping upward together: five files at
@@ -224,3 +232,33 @@ def test_the_crowd_counts_are_not_set_so_loosely_that_they_never_fire():
     check("the function count is today's measurement, not a looser number",
           actual_functions == FUNCTIONS_NEAR_CEILING,
           f"(measured {actual_functions}, frozen at {FUNCTIONS_NEAR_CEILING} - lower it)")
+
+
+def test_the_ceilings_are_not_set_so_loosely_that_they_never_fire():
+    """The same rule as above, applied one level up: to the CEILINGS themselves.
+
+    "Down is routine, up is a decision" only holds if down actually happens. A
+    ceiling left above the truth grants headroom nobody decided to grant, and the
+    next arrival slips in under it silently - so the number has to BE the
+    measurement, not merely be above it.
+
+    Measured, not hypothetical: `FILE_CEILING` stayed at 1299 after `gui/crash.py`
+    was carved out of `app.py` and left it at 1287. Twelve lines of allowance sat
+    there for a week, and nothing was watching that gap - the crowd counts guard
+    the population of the top band, not the height of the band. This test is the
+    missing half.
+
+    Shrinking something therefore comes with a two-line chore: bring the ceiling
+    down with it. That is the routine door, and it is meant to be routine.
+    """
+    files, functions, _ = _sizes()
+    biggest_file = max(files)
+    biggest_function = max(functions)
+    check("the file ceiling IS the largest module, not a number above it",
+          biggest_file[0] == FILE_CEILING,
+          f"({biggest_file[1]} is {biggest_file[0]}, ceiling is {FILE_CEILING} - "
+          f"move the ceiling to {biggest_file[0]})")
+    check("the function ceiling IS the largest function, not a number above it",
+          biggest_function[0] == FUNCTION_CEILING,
+          f"({biggest_function[1]} is {biggest_function[0]}, ceiling is "
+          f"{FUNCTION_CEILING} - move the ceiling to {biggest_function[0]})")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -985,6 +985,41 @@ def test_block_ip_and_port_combine_with_or():
     check("block OR: neither passes", neither.drop is False)
 
 
+def test_block_by_wildcard_drops_the_prefix_and_nothing_else():
+    """A wildcard in a BLOCK expression, which nothing covered until 2026-08-10.
+
+    Wildcards were tested in `test_matchers.py` and blocking was tested with
+    literals and CIDRs, and the two were never tested together - at any layer,
+    including the real-driver rig. That is a gap between two green areas, which
+    is where they hide.
+
+    `172.*` is deliberately the short form. People write a one-octet prefix and
+    expect it to mean the whole /8; the parser has to agree, and `172.16.0.1`
+    matching while `173.16.0.1` does not is the whole claim.
+    """
+    core = BeanCore()
+    core.set_block(True, ip="172.*")
+    rng = random.Random(1)
+    inside = core.decide(100, True, 5000, 0.0, rng, remote_ip="172.16.0.1", remote_port=80)
+    edge = core.decide(100, True, 5000, 0.0, rng, remote_ip="172.255.255.254", remote_port=80)
+    outside = core.decide(100, True, 5000, 0.0, rng, remote_ip="173.16.0.1", remote_port=80)
+    check("block 172.*: an address in the prefix is dropped",
+          inside.drop is True and inside.reason == "block")
+    check("block 172.*: the far end of the same prefix is dropped too", edge.drop is True)
+    check("block 172.*: the next prefix passes", outside.drop is False)
+
+    core = BeanCore()
+    core.set_block(True, port="44*")
+    rng = random.Random(1)
+    kw = dict(remote_ip="8.8.8.8")
+    p443 = core.decide(100, True, 5000, 0.0, rng, remote_port=443, **kw)
+    p4400 = core.decide(100, True, 5000, 0.0, rng, remote_port=4400, **kw)
+    p80 = core.decide(100, True, 5000, 0.0, rng, remote_port=80, **kw)
+    check("block 44*: 443 dropped", p443.drop is True and p443.reason == "block")
+    check("block 44*: 4400 dropped", p4400.drop is True)
+    check("block 44*: 80 passes", p80.drop is False)
+
+
 def test_block_respects_process_targeting():
     """Block sits after the targeting gate: a process target scopes it, so a flow
     that is not the target passes even when its destination is on the block list."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -254,6 +254,27 @@ def test_block_integration():
           s["drop_block"] == 2, f"(drop_block={s['drop_block']}, seen={s['seen']})")
 
 
+def test_block_integration_with_a_wildcard():
+    """The same path as above, but the expression is a wildcard prefix.
+
+    `test_block_integration` uses a CIDR and a literal port, so the wildcard
+    branch of the matcher had never reached `drop_block` through a running
+    engine - the counter the GUI and the CSV both read. `172.*` is the short form
+    people actually type.
+    """
+    pkts = [FakePacket(size=150, is_outbound=True, port=80, dst_addr="172.16.0.9"),
+            FakePacket(size=150, is_outbound=True, port=80, dst_addr="172.31.255.1"),
+            FakePacket(size=150, is_outbound=True, port=80, dst_addr="173.16.0.9")]
+    sh = BeanEngine()
+    sh.set_block(True, "172.*", "")
+    sh.start("test", divert=FakeDivert(pkts))
+    wait_until(lambda: sh.stats_snapshot()["drop_block"] == 2)
+    s = sh.stats_snapshot()
+    sh.stop()
+    check("block wildcard: both addresses in the prefix are counted, the third is not",
+          s["drop_block"] == 2, f"(drop_block={s['drop_block']}, seen={s['seen']})")
+
+
 def test_connection_records_scope_and_dropped():
     """Per-flow bookkeeping behind the "impaired?" and "dropped" columns: with
     process targeting on one port and 100% loss, only the targeted flow is in

--- a/tools/ci_blocking_smoke.py
+++ b/tools/ci_blocking_smoke.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""A real-driver check that blocking BLOCKS - including by wildcard.
+
+Why this exists
+---------------
+Blocking is step 2c of ``BeanCore.decide`` and it never reaches the driver
+filter: ``filters.narrowed_filter`` deliberately refuses to narrow on anything it
+cannot prove, so a block is decided entirely in this process. That makes it easy
+to test with fakes and easy to leave untested for real - which is what had
+happened. Until 2026-08-10 the coverage was:
+
+* wildcards were tested in ``test_matchers.py``, in isolation, never as a block;
+* blocking was tested in ``test_core.py`` and ``test_engine.py`` with literal
+  addresses, a CIDR and a literal port - never a wildcard;
+* the only real-driver blocking check, ``internal_tools/probe_blocking_truth.py``,
+  is outside git, needs a LAN peer, and also used literals.
+
+So no packet had ever been blocked by a wildcard anywhere, at any layer. This
+closes that with a real WinDivert session and real sockets.
+
+What it proves, and how the halves differ
+-----------------------------------------
+Each phase measures BOTH endpoints, because "blocked" and "the peer went away"
+look identical from one side. A phase passes only when the named endpoint goes
+silent AND the bystander keeps answering in the same run - one signal is a
+result, two are a claim about the expression.
+
+``127.5.*`` is the shape people actually type: a prefix and a star, not a CIDR.
+The last phase uses the one-octet form ``127.*`` on its own, because that is how
+the question was asked - and there the bystander check is reported as NOT
+APPLICABLE rather than quietly skipped: a one-octet loopback prefix covers every
+address a loopback bystander could have, so nothing on this machine can play that
+role. Saying so is the point; pretending otherwise would be the false pass.
+
+What bounds the damage (convention 6)
+-------------------------------------
+The expression under test is the SUBJECT, never the bound. The bound is the
+driver filter, pinned to two UDP ports on the loopback interface, so even the
+``127.*`` phase can only ever touch this script's own two sockets - nothing else
+on the machine is handed to the tool at all. There is no impairment beyond the
+block itself: no loss, no latency, no rate limit. Runtime is a few seconds.
+
+Not Windows, not elevated, or no pydivert -> it prints SKIP and exits 0. A check
+that cannot run must say so out loud rather than pass quietly.
+"""
+import os
+import socket
+import sys
+import threading
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+# Two loopback addresses, so an IP expression can name one and miss the other.
+# Windows binds any 127.x on the loopback adapter (verified before this was
+# written - the whole shape of the check depends on it).
+BLOCKED_ADDR, BLOCKED_PORT = "127.5.5.5", 9091
+BYSTANDER_ADDR, BYSTANDER_PORT = "127.9.9.9", 9200
+
+ROUNDS = 20                 # datagrams per endpoint per phase
+SILENT_AT_MOST = 0          # a blocked endpoint must answer nothing at all
+ALIVE_AT_LEAST = 18         # a bystander must stay essentially untouched
+
+FILTER = ("udp and (udp.SrcPort == %d or udp.DstPort == %d or "
+          "udp.SrcPort == %d or udp.DstPort == %d)"
+          % (BLOCKED_PORT, BLOCKED_PORT, BYSTANDER_PORT, BYSTANDER_PORT))
+
+
+def echo(addr, port, stop):
+    """A UDP echo server. UDP so the count is exact - no retransmission to hide
+    a partial block, and no connect timeout to wait through."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((addr, port))
+    sock.settimeout(0.2)
+    while not stop.is_set():
+        try:
+            data, peer = sock.recvfrom(2048)
+            sock.sendto(data, peer)
+        except socket.timeout:
+            continue
+        except OSError:
+            break
+    sock.close()
+
+
+def answered(addr, port, rounds=ROUNDS):
+    """How many of `rounds` datagrams came back."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(0.25)
+    got = 0
+    try:
+        for index in range(rounds):
+            try:
+                sock.sendto(b"block-probe-%03d" % index, (addr, port))
+                sock.recv(2048)
+                got += 1
+            except socket.timeout:
+                continue
+            except OSError:
+                continue
+    finally:
+        sock.close()
+    return got
+
+
+def skip(reason):
+    print("SKIP: %s" % reason)
+    return 0
+
+
+def main():
+    from beantester import winenv
+    if not winenv.is_windows():
+        return skip("not Windows - there is no WinDivert here")
+    if not winenv.is_admin():
+        return skip("not elevated - a capture session cannot start")
+    try:
+        import pydivert                                  # noqa: F401
+    except Exception as exc:
+        return skip("pydivert is not importable (%s)" % exc)
+
+    from beantester.engine import BeanEngine
+
+    stop = threading.Event()
+    for addr, port in ((BLOCKED_ADDR, BLOCKED_PORT), (BYSTANDER_ADDR, BYSTANDER_PORT)):
+        threading.Thread(target=echo, args=(addr, port, stop), daemon=True).start()
+    time.sleep(0.4)
+
+    # (label, block ip, block port, bystander is meaningful here)
+    phases = [
+        ("control - nothing blocked", "", "", True),
+        ("block ip by prefix wildcard '127.5.*'", "127.5.*", "", True),
+        ("block port by wildcard '909*'", "", "909*", True),
+        ("block ip by ONE-OCTET wildcard '127.*'", "127.*", "", False),
+    ]
+
+    engine = BeanEngine()
+    engine.start(FILTER)
+    results = []
+    try:
+        for label, ip, port, bystander_counts in phases:
+            engine.set_block(bool(ip or port), ip, port)
+            time.sleep(0.2)
+            named = answered(BLOCKED_ADDR, BLOCKED_PORT)
+            other = answered(BYSTANDER_ADDR, BYSTANDER_PORT)
+            results.append((label, ip, port, named, other, bystander_counts))
+    finally:
+        engine.stop()
+        stop.set()
+        from beantester import driver
+        driver.mark_driver_used()
+        driver.release_on_exit()
+
+    problems = []
+    for label, ip, port, named, other, bystander_counts in results:
+        blocking = bool(ip or port)
+        if not blocking:
+            if named < ALIVE_AT_LEAST or other < ALIVE_AT_LEAST:
+                problems.append("%s: the control phase did not pass traffic "
+                                "(%d/%d and %d/%d) - every later verdict would be "
+                                "meaningless" % (label, named, ROUNDS, other, ROUNDS))
+            continue
+        if named > SILENT_AT_MOST:
+            problems.append("%s: the NAMED endpoint still answered %d of %d"
+                            % (label, named, ROUNDS))
+        if bystander_counts and other < ALIVE_AT_LEAST:
+            problems.append("%s: the bystander was hit too (%d of %d) - the block "
+                            "took more than it named" % (label, other, ROUNDS))
+
+    print("phase                                     named  bystander")
+    for label, ip, port, named, other, bystander_counts in results:
+        note = "" if bystander_counts else "   (bystander N/A: a one-octet " \
+                                           "loopback prefix covers every 127.x)"
+        print("  %-38s %2d/%-2d  %2d/%-2d%s"
+              % (label, named, ROUNDS, other, ROUNDS, note))
+
+    for line in problems:
+        print("FAIL: %s" % line)
+    if problems:
+        return 1
+    print("ok: every blocking expression cut exactly what it named, wildcards "
+          "included, and the bystander survived each one that could have a bystander")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two commits. The second started as "do we have a real test that a wildcard block blocks?" - the
answer was no, and looking for the test found a safety hole instead.

## A block that matches everything is not a bounded block

A block normally limits its own damage **because it names something**, so it was deliberately
excluded from the "this affects every connection" warning - warning about `--block-ip 10.0.0.1`
would be the false alarm that teaches people to ignore the real one.

`*` names everything. Measured before the fix:

| setting | dropped | warned |
|---|---|---|
| `--loss 50` (only degrades the link) | - | **yes** |
| `--block-ip '*'` (severs the machine) | 5 of 5 addresses | **no** |

The expression that cut the network read as safer than the one that slowed it down. This is
`--target *` (fixed in #109) seen from the other side, and it takes the same answer:
`Matcher.covers_everything`.

Registry-driven rather than special-cased. `fields.MATCHED_IMPAIRING_KEYS` names the fields
declared `IMPAIRS_MATCHED` - exactly the two blocking fields today - and
`armed_global_impairments` promotes one when its expression covers the whole space. The lookup is
total: a malformed expression answers False rather than raising, because this runs on the way to a
start-time warning and a warning that can abort a start is worse than the mode it warns about.

**Narrow blocks are untouched, and that half is what makes this a fix rather than a new false
alarm.** `172.*`, `172.16.0.0/12`, `10.0.0.1` and `443` stay silent, and so does `*` once a target
or a duration bounds it. Re-verified after the fix through the real CLI (`--dry-run`) and through
`warn_if_unbounded`, so both interfaces were seen answering rather than just the function.

## The coverage gap underneath it

No wildcard had ever reached the blocking path **at any layer**: wildcards were tested in
`test_matchers.py` in isolation, blocking was tested with literals and CIDRs in `test_core.py`,
`test_engine.py` and even in the LAN rig. Two green areas with a gap between them.

`tools/ci_blocking_smoke.py` closes it against a **real WinDivert session**. Blocking never
reaches the driver filter - `narrowed_filter` refuses what it cannot prove - so only a real
session can answer the question. Two UDP echo servers on two loopback addresses, and every phase
measures BOTH endpoints, because "blocked" and "the peer went away" look identical from one side:

```
phase                                     named  bystander
  control - nothing blocked              20/20  20/20
  block ip by prefix wildcard '127.5.*'   0/20  20/20
  block port by wildcard '909*'           0/20  20/20
  block ip by ONE-OCTET wildcard '127.*'  0/20   0/20   (bystander N/A: a one-octet
                                                         loopback prefix covers every 127.x)
```

That last phase reports its bystander as **not applicable, with the reason printed**, rather than
skipping it quietly - on loopback a one-octet prefix covers every address a bystander could have.
Convention 6 is honoured by the FILTER, pinned to two UDP ports, never by the expression under
test. Mutation-checked in both directions: a block that never drops, and a block that drops
everything, each turn it red.

The one-octet form was then proven where it can have a real bystander - the LAN rig, peer on the
network and bystander on loopback:

```
block_ip by one-octet wildcard '192.*'   peer        100.0%  want cut off entirely   ok
block_ip by one-octet wildcard '192.*'   bystander     0.0%  want untouched          ok
```

Unit and engine pins use `172.*` and `44*`, the short form people actually type.

## Pin the ratchet ceilings to the measurement

"Down is routine, up is a decision" only holds if down actually happens. `FILE_CEILING` stayed at
1299 after `gui/crash.py` was carved out of `app.py` and left it at 1287 - twelve lines of
headroom nobody granted, sitting there for a week, found only because the numbers happened to get
printed. The crowd counts guard the population of the top band; the height of the band had no
guard at all.

Each ceiling must now BE the largest item, not merely be above it. Mutation-checked three ways.
The cost, named rather than hidden: with zero slack the next change to `app.py` or `_run_session`
begins with a split, and shrinking anything carries a two-line chore to bring its ceiling down.

## Verification

- `python -m pytest tests` - **1037 passed**, run bare and as the last action after the prose.
- `python smoke_gui.py` - green.
- `python tools/ci_blocking_smoke.py` - green on a real driver, output above.
- The LAN rig green end to end against a real peer, including the one-octet wildcard.
- `python tools/check_public_text.py --commits origin/master..HEAD` - 2 blocks, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
