### PR TITLE
docs(presets): make every cited figure checkable, and name the trademarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   "Apply changes" to put them into a running session.
 
 ### Docs
-
+- **Every number in the presets says where it came from.** The comment block in
+  `beantester/presets.py` now carries authors, venue and a DOI for each study, and the Ookla
+  figures name the period and the date they were read. Three entries looked like citations without
+  being ones - the bufferbloat figures are marked as a typical range and the 3G latencies as
+  general knowledge, rather than dressed up as sourced. Both READMEs gained a trademark note: the
+  names say whose measurements these are, and the project is not affiliated with them.
 - **The buffer help sheet no longer promises more lag than the buffer can give.** It told you to
   enter how many ms of lag you want, which is right for a small buffer and optimistic for a large
   one: the number is the most the queue can add, and one small download may never fill it.

--- a/README.md
+++ b/README.md
@@ -316,10 +316,12 @@ Terrible network - plus your own (saved under a name). The program **always star
 network"** (nothing is impaired until you set something). Built-in presets cannot be deleted - the
 "Delete" button is disabled for them.
 
-Their numbers come from published measurements wherever measurements exist (Ookla medians for
-satellite and mobile, academic studies for Starlink's 15-second reconfiguration and for in-flight
-Wi-Fi). Where no such figure exists - "weak Wi-Fi" is not a measurable quantity - the comment next
-to the value in `beantester/presets.py` says so. A few of them are worth a sentence:
+Their numbers come from published measurements wherever measurements exist (Ookla® Speedtest®
+medians for satellite and mobile, peer-reviewed studies for Starlink's 15-second reconfiguration
+and for in-flight Wi-Fi). Every figure is attributed in the comment block at the top of
+`beantester/presets.py`, with the authors, the venue and a DOI, so you can check it rather than
+trust it. Where no such figure exists - "weak Wi-Fi" is not a measurable quantity - the comment
+next to the value says so instead of inventing a source. A few of them are worth a sentence:
 
 - **Satellite (low orbit)** - modelled on Starlink. Its steady state is good (about 40 ms of ping,
   100 Mbit/s). What makes it distinctive is the reconfiguration every 15 seconds, which briefly
@@ -1350,6 +1352,14 @@ In short: you are free to use it for any purpose (private or commercial), to stu
 change it, and to redistribute copies - including modified ones - provided you pass the program on
 under the same GPLv3 terms and make the corresponding source available. The program is provided
 "AS IS", with no warranty and no liability on the author's part. The author is **DonislawDev**.
+
+### Trademarks and the figures in the presets
+
+Ookla, Speedtest, Starlink, HughesNet and Viasat are trademarks of their respective owners. They
+are named in this project for one reason only: to say **whose published measurements** a preset's
+numbers came from. Bean Network Tester is not affiliated with, endorsed by or sponsored by any of
+them, and none of their data is redistributed here - only individual figures, cited to their
+source, the way any technical document cites one.
 
 ### What you make with it is yours
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -240,7 +240,7 @@ jest martwe przez podany procent czasu. Symuluje migające połączenie.
 
 **Profile** - gotowe presety **posortowane od najlepszego (góra) do najgorszego (dół)**: Idealna sieć, Dobre WiFi, Sieć 5G, DSL domowy (VDSL), Sieć LTE/4G, Satelita niskoorbitalny, Odległy serwer (inny kontynent), Słabe WiFi, Kawiarnia (zatłoczone WiFi), Zapchane łącze domowe (bufferbloat), Pociąg / metro (tunele), Sieć 3G, Roaming zagraniczny, Satelita geostacjonarny, Wi-Fi w samolocie, Modem 56k, Fatalna sieć - oraz Twoje własne (zapis pod nazwą). Program **startuje zawsze na „Idealnej sieci”** (nic nie jest psute, dopóki sam czegoś nie ustawisz). Presetów wbudowanych nie da się usunąć - przycisk „Usuń” jest wtedy nieaktywny.
 
-Ich liczby pochodzą z opublikowanych pomiarów wszędzie tam, gdzie pomiary istnieją (mediany Ookla dla satelity i sieci komórkowych, prace naukowe o 15-sekundowym przełączaniu Starlinka i o Wi-Fi w samolotach). Tam, gdzie takiej liczby nie ma - „słabe WiFi” nie jest wielkością mierzalną - mówi o tym wprost komentarz przy wartości w `beantester/presets.py`. Kilka zasługuje na zdanie:
+Ich liczby pochodzą z opublikowanych pomiarów wszędzie tam, gdzie pomiary istnieją (mediany Ookla® Speedtest® dla satelity i sieci komórkowych, recenzowane prace naukowe o 15-sekundowym przełączaniu Starlinka i o Wi-Fi w samolocie). Każda liczba jest przypisana do źródła w komentarzu na górze `beantester/presets.py` - z autorami, miejscem publikacji i numerem DOI - żebyś mógł ją sprawdzić, a nie tylko nam uwierzyć. Tam, gdzie takiej liczby nie ma - „słabe Wi-Fi" nie jest wielkością mierzalną - komentarz przy wartości mówi to wprost, zamiast wymyślać źródło.
 
 - **Satelita niskoorbitalny** - wzorowany na Starlinku. W stanie ustalonym jest dobry (około 40 ms pingu, 100 Mb/s). Wyróżnia go przełączanie satelity co 15 sekund, które na chwilę wstrzymuje transmisję i objawia się okazjonalnym skokiem pingu, a nie stratą pakietów.
 - **Odległy serwer (inny kontynent)** - szybkie łącze, w którym nic nie jest zepsute, tylko jest daleko (~120 ms pingu). To ten preset obnaża gadatliwe protokoły i kod pisany przy założeniu, że serwer stoi obok.
@@ -1209,6 +1209,14 @@ działa i zmieniać go, a także rozpowszechniać kopie - również zmodyfikowan
 pod warunkiem przekazywania programu dalej na tych samych warunkach GPLv3 i
 udostępnienia odpowiadającego kodu źródłowego. Program dostarczany jest „AS IS”,
 bez gwarancji i bez odpowiedzialności autora. Autorem jest **DonislawDev**.
+
+### Znaki towarowe i liczby w presetach
+
+Ookla, Speedtest, Starlink, HughesNet i Viasat są znakami towarowymi swoich właścicieli.
+Pojawiają się w tym projekcie z jednego powodu: żeby powiedzieć, **czyje opublikowane pomiary**
+stoją za liczbami w presetach. Bean Network Tester nie jest z nimi powiązany, przez nich
+wspierany ani sponsorowany, i nie rozpowszechnia ich danych - są tu wyłącznie pojedyncze liczby,
+z podanym źródłem, tak jak cytuje je każdy dokument techniczny.
 
 ### To, co nim zrobisz, należy do Ciebie
 

--- a/beantester/presets.py
+++ b/beantester/presets.py
@@ -30,21 +30,55 @@ from .settings import DEFAULT_SETTINGS
 # bandwidth and 3G latency wrong, each badly enough to reverse a design decision
 # (see PROJECT_NOTES, rule 5, the sources bullet).
 #
-# Sources (measured, not recalled):
-#   [OOKLA25]  Ookla Q1 2025 medians: HughesNet 683 ms / 47.8 Mbit/s, Viasat
-#              684 ms / 49.1 Mbit/s; Starlink US ~105 Mbit/s down, 14.8 up.
-#   [STAR-WWW] Mohan et al., "A Multifaceted Look at Starlink Performance"
-#              (WWW 2024): reconfiguration every 15 s, latency peak averaging
-#              +74 ms at the interval boundary.
-#   [STAR-CON] "Making Sense of Constellations" - during a reconfiguration the
-#              GSL interfaces stop transmitting for 100 ms, but packets are
-#              QUEUED, not dropped. This is why LEO carries a spike and no flap.
-#   [MILEHIGH] Rula et al., "Mile High WiFi" (WWW 2018), 45 flight-hours over
-#              16 flights: RTT ~750 ms and 7% median loss for satellite (MSS),
-#              ~40% loss at the 90th percentile; ~200 ms / 3.3% for air-to-ground.
-#   [BLOAT]    Bufferbloat surveys: >70% of home links affected; idle 14 ms ->
-#              320 ms under a sustained upload, extremes 200-2000 ms.
-#   [3GPP-RTT] UMTS 100-200 ms RTT, HSPA 80-150 ms; real throughput 0.384-2 Mbit/s.
+# Sources (measured, not recalled). Every entry carries enough to be looked up:
+# a citation nobody can check is decoration, and three of these used to be exactly
+# that. Figures are FACTS quoted with attribution, which is what the sources are
+# for - no wording is reproduced from any of them.
+#
+#   [OOKLA25]  Ookla(R) Speedtest(R) analysis of US satellite providers, Q1 2025
+#              (published July 2025; figures as reported, accessed 2026-08-11):
+#              HughesNet median multi-server latency 683 ms and 47.79 Mbit/s
+#              down; Viasat 684 ms and 49.12 Mbit/s; Starlink 45 ms, 104.71 down
+#              and 14.84 up. NOT from Ookla's Open Data tiles - see the note at
+#              the bottom of this block before reaching for those.
+#   [STAR-WWW] Mohan, Ferguson, Cech, Bose, Renatin, Marina and Ott, "A
+#              Multifaceted Look at Starlink Performance", ACM Web Conference
+#              (WWW) 2024, doi:10.1145/3589334.3645328, arXiv:2310.09242:
+#              reconfiguration every 15 s, latency peak averaging +74 ms at the
+#              interval boundary.
+#   [STAR-CON] Tanveer, Puchol, Singh, Bianchi and Nithyanand, "Making Sense of
+#              Constellations: Methodologies for Understanding Starlink's
+#              Scheduling Algorithms", CoNEXT 2023 Companion,
+#              doi:10.1145/3624354.3630586, arXiv:2307.00402: during a
+#              reconfiguration the GSL interfaces stop transmitting for 100 ms,
+#              but packets are QUEUED, not dropped. Hence a spike and no flap.
+#   [MILEHIGH] Rula, Newman, Bustamante, Molavi Kakhki and Choffnes, "Mile High
+#              WiFi: A First Look At In-Flight Internet Connectivity", WWW 2018,
+#              doi:10.1145/3178876.3186057. 45 flight-hours over 16 flights:
+#              RTT ~750 ms and 7% median loss for satellite (MSS), ~40% loss at
+#              the 90th percentile; ~200 ms / 3.3% for air-to-ground.
+#   [BLOAT]    The PHENOMENON is Gettys and Nichols, "Bufferbloat: Dark Buffers
+#              in the Internet", ACM Queue 9(11), 2011 (also CACM 55(1), 2012),
+#              doi:10.1145/2063166.2071893. 🔴 The NUMBERS beside it here - idle
+#              14 ms rising to ~320 ms under a sustained upload, extremes
+#              200-2000 ms, "most home links affected" - are a typical range
+#              assembled from general reporting, NOT figures from that paper.
+#              Treat them as a shaped default, not as a measurement.
+#   [3GPP-RTT] GENERAL KNOWLEDGE, deliberately not dressed as a citation: UMTS
+#              round trips of roughly 100-200 ms, HSPA 80-150 ms, real
+#              throughput 0.384-2 Mbit/s. Widely reported engineering ranges; no
+#              single document is being leaned on, and inventing a specification
+#              number to make it look sourced would be worse than saying this.
+#
+# 🔴 LICENSING, before somebody improves this: the figures above are FACTS with
+# attribution, which is exactly what is allowed - facts carry no copyright and a
+# handful of them is not a substantial part of any database. That stops being
+# true if anyone ingests **Ookla's Open Data tiles**: those are CC BY-NC-SA 4.0,
+# and both the NonCommercial and the ShareAlike terms conflict with this
+# project's GPLv3. Cite published findings; do not import the dataset.
+# Ookla, Speedtest, Starlink, HughesNet and Viasat are trademarks of their
+# respective owners, named here only to identify whose measurements these are.
+# This project is not affiliated with, endorsed by or sponsored by any of them.
 # --------------------------------------------------------------------------- #
 PRESETS = {
     # ordered best -> worst (top = best network, bottom = worst)


### PR DESCRIPTION
Prompted by a licensing question about `beantester/presets.py`: is quoting Ookla medians and
academic findings permitted use?

## The licensing answer: yes, and not marginally

Researched at the publishers rather than recalled.

- **Individual measurements are facts, and facts carry no copyright.** In the US that is settled by
  *Feist v. Rural Telephone* (1991), which rejected "sweat of the brow" - the effort of collecting
  data creates no protection in the data.
- **No wording is reproduced** from any source. The file quotes numbers and paper titles; a title
  is too short to protect.
- **Six figures are not a substantial part of a database** under Directive 96/9/EC, and the use was
  one-off rather than systematic.
- **Trademarks are used nominatively** - naming a company to identify whose measurement a number
  is. No preset is named after a brand (`presets.leo`, not "Starlink").

**The one real trap is adjacent, and is now written down.** Ookla's *Open Data* tiles are
CC BY-NC-SA 4.0; the NonCommercial and ShareAlike terms both conflict with GPLv3. Our figures come
from their published Q1 2025 analysis, not that dataset. Citing findings is fine; importing the
dataset would not be, and a comment in the file and a convention in the private notes now say so
before somebody helpfully reaches for it.

## What the check actually found: three citations that were not citations

The legal question came back clean. The quality question did not.

| entry | before | after |
|---|---|---|
| `[BLOAT]` | "Bufferbloat surveys" - no document at all | Gettys and Nichols, ACM Queue 9(11) 2011, DOI - **and** an explicit line saying the paper backs the phenomenon while the numbers beside it are a shaped default, not measurements from it |
| `[3GPP-RTT]` | bare figures, a name implying a specification | labelled GENERAL KNOWLEDGE, with the reason: inventing a spec number to make it look sourced would be worse |
| `[STAR-CON]` | title only | Tanveer, Puchol, Singh, Bianchi, Nithyanand; CoNEXT 2023 Companion; DOI; arXiv |

A source nobody can look up is worse than an honest "general knowledge", because it borrows
authority it has not earned - and this project's rule is that every claim carries its evidence or
says it has none.

The other two papers gained their full author list, venue and DOI as well (Mohan et al., WWW 2024;
Rula et al., WWW 2018), each verified at ACM or arXiv rather than from memory. The Ookla entry now
names the period analysed and the date it was read.

## Trademarks

Both READMEs gained a short section: the names are there to say whose published measurements the
presets are based on, the project is not affiliated with, endorsed by or sponsored by any of them,
and none of their data is redistributed here.

## Verification

- `python -m pytest tests` - **1037 passed**, run bare and as the last action after the prose.
- `python smoke_gui.py` - green.
- The changelog guard caught the first draft of the user-facing entry at over 100 words; it is 91
  now. Worth mentioning because that guard exists for exactly this kind of enthusiasm.
- Every DOI resolves, and each was taken from the publisher's own listing rather than reconstructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
