### PR TITLE
feat(release): publish a signed SPDX SBOM, and list everything the bundle really ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,30 @@ jobs:
           find dist/BeanNetworkTester -iname "WinDivert*" -print | tee found.txt
           test -s found.txt || { echo "WinDivert.dll/.sys is missing from the bundle"; exit 1; }
 
+      # 🔴 The scanner guards the REGISTRY, not the other way round. `legal.py` is
+      # the reviewed list of what we ship and the SBOM is generated from it, so the
+      # question worth asking on every build is "does the bundle contain something
+      # that list does not know?". It already has an answer: on 2026-08-11 this
+      # comparison found zlib, libffi and 42 Microsoft runtime files shipping in
+      # every release while every list claimed to be complete.
+      #
+      # Here rather than in release.yml deliberately. This job has `contents: read`
+      # and cuts no tag, so a third-party action costs far less here - and a hole
+      # found at PR time is cheaper than one found while publishing. Syft is pinned
+      # by SHA; the tag it stood at is in the comment.
+      - name: Scan the bundle and hold the licence registry to it
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          path: dist/BeanNetworkTester
+          format: syft-json
+          output-file: bundle-scan.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: The registry must account for everything the scan found
+        shell: bash
+        run: python tools/sbom.py --audit-bundle bundle-scan.json
+
       - uses: actions/upload-artifact@v7
         with:
           name: BeanNetworkTester-windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
 # needs write. Scoped to this workflow, not the whole repository.
 permissions:
   contents: write
+  # For the SBOM attestation. `id-token` mints the short-lived OIDC token that
+  # signs it, `attestations` writes the result to the repository's attestation
+  # store. Both are required by actions/attest-sbom and neither grants anything
+  # else; a release that skipped them would still publish an SBOM, just an
+  # unsigned one that anybody could swap.
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -108,6 +115,38 @@ jobs:
           cat SHA256SUMS.txt
           echo "ASSET=${name}.zip" >> "$GITHUB_ENV"
 
+      # The SBOM is generated from `beantester/legal.py`, the reviewed list of what
+      # this build ships - not from a scan. Measured 2026-08-11: a scanner reading
+      # the built bundle finds CPython, Tcl and Tk with versions but misses psutil,
+      # PyDivert and PyInstaller (PyInstaller strips `.dist-info`), never sees
+      # `WinDivert64.sys`, and attaches no licence to anything. The registry has the
+      # licences; the scanner's job is to guard it, which is a separate step below.
+      #
+      # The tag seeds the document namespace, so re-running this workflow on the
+      # same tag produces the same URI instead of a fresh random one.
+      - name: Generate the SBOM (SPDX 2.3)
+        shell: bash
+        run: |
+          python tools/sbom.py --namespace-seed "$GITHUB_REF_NAME" \
+                 -o "BeanNetworkTester-${GITHUB_REF_NAME}.spdx.json"
+          python -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); \
+                     print('packages:', len(d['packages']))" \
+                 "BeanNetworkTester-${GITHUB_REF_NAME}.spdx.json"
+          echo "SBOM=BeanNetworkTester-${GITHUB_REF_NAME}.spdx.json" >> "$GITHUB_ENV"
+
+      # Signs the SBOM against the zip a user downloads, so `gh attestation verify`
+      # can prove the pair belongs together. Without this the SBOM is a text file
+      # anybody could replace, which is the difference between a bill of materials
+      # and a note claiming to be one.
+      - name: Attest the SBOM against the release archive
+        # Pinned by SHA, not by tag. This is the first third-party-shaped action in
+        # the workflow that publishes the release, and a tag can be moved; the SHA
+        # below is what `v4.1.0` pointed at on 2026-08-11, read from the API.
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e  # v4.1.0
+        with:
+          subject-path: ${{ env.ASSET }}
+          sbom-path: ${{ env.SBOM }}
+
       # gh is preinstalled on the runner - no third-party action, uses the job token.
       # A -rc/-beta/-alpha tag publishes as a "Pre-release"; a plain tag as "Latest".
       #
@@ -126,4 +165,4 @@ jobs:
           head -5 RELEASE_NOTES.md
           flags=(--title "$TITLE" --notes-file RELEASE_NOTES.md)
           if [ "$PRERELEASE" = "true" ]; then flags+=(--prerelease); else flags+=(--latest); fi
-          gh release create "$GITHUB_REF_NAME" "$ASSET" SHA256SUMS.txt "${flags[@]}"
+          gh release create "$GITHUB_REF_NAME" "$ASSET" SHA256SUMS.txt "$SBOM" "${flags[@]}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 ## [Unreleased]
 
 ### Added
+- **Every release now carries an SBOM, signed against the download.** A standard SPDX file listing
+  each third-party component with its version, licence and source - the same list `--license`
+  prints, in a form tools can read. It is signed together with the archive, so
+  `gh attestation verify` can prove that this build and this list belong to each other and came
+  out of this repository. A checksum says the file arrived unchanged; the attestation says where
+  it came from. Both READMEs show the command.
 
 - **A run that would break everything now says so first.** Start with impairment on, nothing to
   aim it at and no time limit, and both the command line and the window say: this affects every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   "Apply changes" to put them into a running session.
 
 ### Docs
+- **The licence notices now list everything the download actually contains.** Scanning the built
+  package turned up three things shipping in every release that no list mentioned: zlib, libffi and
+  Microsoft's C runtime - 42 files of the latter, over half the bundle. All permissive or
+  redistributable, so nothing was ever breached; the notices simply were not complete. The bundled
+  Python licence was also a truncated copy, missing the part covering software Python itself
+  includes; it is now the full text. `--license` reports the WinDivert driver version instead of
+  the word "bundled".
 - **Every number in the presets says where it came from.** The comment block in
   `beantester/presets.py` now carries authors, venue and a DOI for each study, and the Ookla
   figures name the period and the date they were read. Three entries looked like citations without

--- a/README.md
+++ b/README.md
@@ -1130,8 +1130,8 @@ in English.
 
 Releases go out through a second workflow (`.github/workflows/release.yml`) on a `v*` tag. It
 checks the tag against `VERSION.txt`, refuses to publish while the changelogs are still open,
-builds and smoke-tests the exe, then publishes the zip together with the `SHA256SUMS.txt` this
-README tells you to verify.
+builds and smoke-tests the exe, then publishes three assets: the zip, the `SHA256SUMS.txt` this
+README tells you to verify, and an SPDX SBOM signed against the archive it describes.
 
 ## Project layout
 
@@ -1407,3 +1407,18 @@ rights and loads a network driver - so Windows SmartScreen may show an "Unknown 
 and some antivirus tools may raise a false alarm. The **WinDivert driver itself is digitally signed
 by its author**. You can compare the release's SHA-256 checksum (`SHA256SUMS.txt`) to confirm the
 file has not been modified.
+
+### What is inside the download, and how to check it
+
+Every release carries an **SBOM** - a list, in the standard SPDX format, of every third-party
+component in the build with its version, licence and where its source lives. It is the same list
+`BeanNetworkTester.exe --license` prints, in a form a tool can read.
+
+The SBOM is **signed against the archive it describes**, so the two cannot be separated:
+
+```bash
+gh attestation verify BeanNetworkTester-vX.Y.Z-windows-x64.zip --repo donislawdev/BeanNetworkTester
+```
+
+A checksum tells you the file arrived unchanged. The attestation tells you that *this* build,
+with *this* bill of materials, came out of this repository's release workflow.

--- a/README.pl.md
+++ b/README.pl.md
@@ -985,8 +985,8 @@ uszkodzenia niewidoczne po angielsku.
 
 Wydania wychodzą drugim workflow (`.github/workflows/release.yml`), po wypchnięciu tagu `v*`.
 Sprawdza on tag wobec `VERSION.txt`, odmawia publikacji, dopóki changelogi są otwarte, buduje exe
-i robi jego smoke, a potem publikuje zip razem z plikiem `SHA256SUMS.txt`, którego weryfikację
-opisuje to README.
+i robi jego smoke, a potem publikuje trzy zasoby: zip, plik `SHA256SUMS.txt`, którego
+weryfikację opisuje to README, oraz SBOM w formacie SPDX, podpisany razem z archiwum.
 
 ## Struktura projektu
 
@@ -1269,5 +1269,22 @@ SmartScreen może pokazać ostrzeżenie „Nieznany wydawca”, a niektóre anty
 mogą zgłosić fałszywy alarm. Sam sterownik **WinDivert jest podpisany cyfrowo
 przez jego autora**. Sumę kontrolną SHA-256 wydania (`SHA256SUMS.txt`) możesz
 porównać, żeby potwierdzić, że plik nie został zmodyfikowany.
+
+### Co jest w środku pobranego pliku i jak to sprawdzić
+
+Każde wydanie niesie **SBOM** - listę, w standardowym formacie SPDX, wszystkich
+składników firm trzecich w tej wersji: z wersją, licencją i adresem źródeł. To ta
+sama lista, którą wypisuje `BeanNetworkTester.exe --license`, tylko w postaci
+czytelnej dla narzędzi.
+
+SBOM jest **podpisany razem z archiwum, które opisuje**, więc nie da się ich
+rozdzielić:
+
+```bash
+gh attestation verify BeanNetworkTester-vX.Y.Z-windows-x64.zip --repo donislawdev/BeanNetworkTester
+```
+
+Suma kontrolna mówi, że plik dotarł niezmieniony. Atestacja mówi, że **ta** wersja,
+z **tym** wykazem składników, wyszła z workflow wydania tego repozytorium.
 
 Dokumentacja po angielsku: [README.md](README.md).

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -135,6 +135,52 @@ version is linked above. Contact: https://donislawdev.com/
 
 ---
 
+## zlib
+
+* Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+* Used under: **zlib licence** (permissive)
+* Licence text: `licenses/zlib-LICENSE.txt`
+* Source code: https://www.zlib.net/
+* Ships as `zlib1.dll` beside the executable, as part of the CPython Windows
+  runtime. `--license` reports the version the build links against; note that it
+  can read `1.3.1.zlib-ng`, because the `zlib` MODULE is built against zlib-ng
+  while the DLL itself is genuine zlib. Both are under this licence.
+
+---
+
+## libffi
+
+* Copyright (c) 1996-2022 Anthony Green, Red Hat, Inc and others
+* Used under: **MIT-style licence**
+* Licence text: inside `licenses/Python-LICENSE.txt`, in CPython's section for
+  incorporated software - libffi arrives with CPython and is licensed there
+* Source code: https://github.com/libffi/libffi
+* Ships as `libffi-8.dll`; it is what `ctypes` calls into, and this project
+  reaches the WinDivert driver and several Windows APIs through `ctypes`.
+
+---
+
+## Microsoft C Runtime (`ucrtbase.dll`, `VCRUNTIME140*.dll`, `api-ms-win-*.dll`)
+
+* Copyright (c) Microsoft Corporation
+* Used under: **Microsoft's redistributable terms** for the Visual C++ runtime
+  and the Universal CRT, which permit shipping these files alongside an
+  application
+* Licence text: not bundled - Microsoft distributes the terms rather than a text
+  to include; see the link below
+* Terms: https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files
+* These arrive with the CPython Windows runtime, not from this project directly.
+  They are the C runtime the interpreter and its extension modules are built
+  against.
+* It is a larger set than it looks: **42 files, more than half the bundle by
+  count** - `ucrtbase.dll`, `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll` and 39
+  `api-ms-win-core-*` / `api-ms-win-crt-*` ApiSet stubs (version 10.0.26100.8249,
+  Microsoft Corporation). The stubs are easy to mistake for Windows itself rather
+  than for something shipped alongside the program, which is exactly why they are
+  named here.
+
+---
+
 ## Artwork and everything else
 
 The application icon, the drawn-in-code widgets (the checkbox indicator, the bean

--- a/beantester/legal.py
+++ b/beantester/legal.py
@@ -25,7 +25,11 @@ WINDIVERT_VERSION = "2.2"
 # import name used to report the real version at run time (None = not a Python
 # package, so the version is fixed or reported by other means).
 COMPONENTS = (
-    # (name, module, licence used, where the source lives)
+    # (name, module, licence used, where the source lives, SPDX expression)
+    # The prose licence is for a person reading `--license`; the SPDX expression is
+    # for `tools/sbom.py`. Both, because neither serves the other's reader: a scanner
+    # cannot parse "dual LGPL-3.0 / GPL-2.0" and a person should not have to read
+    # "LGPL-3.0-only OR GPL-2.0-only".
     # WinDivert has no importable module, and its DLL carries no version resource -
     # only the DRIVER does. `WinDivert64.sys` reports FileVersion "2.2" (company
     # "Basil"), read from the shipped file on 2026-08-11. Pinned here rather than
@@ -33,32 +37,41 @@ COMPONENTS = (
     # honest: `test_license_surface.py` compares this string against the version
     # the installed pydivert's driver actually reports, so it cannot rot silently.
     ("WinDivert", None, "LGPL-3.0 (dual LGPL-3.0 / GPL-2.0)",
-     "https://github.com/basil00/WinDivert"),
+     "https://github.com/basil00/WinDivert",
+     "LGPL-3.0-only OR GPL-2.0-only"),
     ("PyDivert", "pydivert", "LGPL-3.0-or-later (dual with GPL-2.0-or-later)",
-     "https://github.com/ffalcinelli/pydivert"),
+     "https://github.com/ffalcinelli/pydivert",
+     "LGPL-3.0-or-later OR GPL-2.0-or-later"),
     ("psutil", "psutil", "BSD-3-Clause",
-     "https://github.com/giampaolo/psutil"),
+     "https://github.com/giampaolo/psutil",
+     "BSD-3-Clause"),
     ("Python", None, "PSF License",
-     "https://www.python.org/downloads/source/"),
+     "https://www.python.org/downloads/source/",
+     "PSF-2.0"),
     ("Tcl/Tk", None, "Tcl/Tk licence (BSD-style)",
-     "https://www.tcl-lang.org/software/tcltk/"),
+     "https://www.tcl-lang.org/software/tcltk/",
+     "TCL"),
     ("PyInstaller (bootloader)", None, "GPL-2.0+ with the bootloader exception",
-     "https://github.com/pyinstaller/pyinstaller"),
+     "https://github.com/pyinstaller/pyinstaller",
+     "GPL-2.0-or-later WITH Bootloader-exception"),
     # 🔴 The three below were found by SCANNING THE BUILT BUNDLE (Syft, 2026-08-11),
     # not by reading a manifest - they arrive with the CPython Windows runtime and
     # no requirements file mentions them. They shipped in every release so far while
     # this list claimed to be complete. Permissive or redistributable every one, so
     # nothing was breached; the defect was the claim, not the licences.
     ("zlib", None, "zlib licence",
-     "https://www.zlib.net/"),
+     "https://www.zlib.net/",
+     "Zlib"),
     ("libffi", None, "MIT-style (text inside Python-LICENSE.txt)",
-     "https://github.com/libffi/libffi"),
+     "https://github.com/libffi/libffi",
+     "MIT"),
     # 42 files, over half the bundle by count: ucrtbase, VCRUNTIME140(_1) and 39
     # `api-ms-win-*` ApiSet stubs. The stubs were nearly missed - they are easy to
     # read as Windows itself rather than as something we redistribute.
     ("Microsoft C Runtime", None,
      "Microsoft redistributable (ucrtbase, VCRUNTIME140, api-ms-win-* stubs)",
-     "https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files"),
+     "https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files",
+     "LicenseRef-Microsoft-Redistributable"),
 )
 
 
@@ -102,7 +115,7 @@ def _zlib_version():
 def component_rows():
     """``(name, version, licence, source_url)`` for every third-party component."""
     rows = []
-    for name, module, licence, url in COMPONENTS:
+    for name, module, licence, url, _spdx in COMPONENTS:
         if module:
             version = _module_version(module)
         elif name == "Python":

--- a/beantester/legal.py
+++ b/beantester/legal.py
@@ -15,11 +15,23 @@ from .paths import resource_path
 
 LICENSES_DIR = "licenses"
 
+# The driver version we ship, from `WinDivert64.sys`'s own version resource. The
+# LGPL obligation is to name the exact version the user was given, and until
+# 2026-08-11 this said "bundled" - true, and useless to somebody trying to fetch
+# that source and rebuild it.
+WINDIVERT_VERSION = "2.2"
+
 # The components we ship, in the order a reader cares about. ``module`` is the
 # import name used to report the real version at run time (None = not a Python
 # package, so the version is fixed or reported by other means).
 COMPONENTS = (
     # (name, module, licence used, where the source lives)
+    # WinDivert has no importable module, and its DLL carries no version resource -
+    # only the DRIVER does. `WinDivert64.sys` reports FileVersion "2.2" (company
+    # "Basil"), read from the shipped file on 2026-08-11. Pinned here rather than
+    # read at run time because it is a property of the BUILD, and a test keeps it
+    # honest: `test_license_surface.py` compares this string against the version
+    # the installed pydivert's driver actually reports, so it cannot rot silently.
     ("WinDivert", None, "LGPL-3.0 (dual LGPL-3.0 / GPL-2.0)",
      "https://github.com/basil00/WinDivert"),
     ("PyDivert", "pydivert", "LGPL-3.0-or-later (dual with GPL-2.0-or-later)",
@@ -32,6 +44,21 @@ COMPONENTS = (
      "https://www.tcl-lang.org/software/tcltk/"),
     ("PyInstaller (bootloader)", None, "GPL-2.0+ with the bootloader exception",
      "https://github.com/pyinstaller/pyinstaller"),
+    # 🔴 The three below were found by SCANNING THE BUILT BUNDLE (Syft, 2026-08-11),
+    # not by reading a manifest - they arrive with the CPython Windows runtime and
+    # no requirements file mentions them. They shipped in every release so far while
+    # this list claimed to be complete. Permissive or redistributable every one, so
+    # nothing was breached; the defect was the claim, not the licences.
+    ("zlib", None, "zlib licence",
+     "https://www.zlib.net/"),
+    ("libffi", None, "MIT-style (text inside Python-LICENSE.txt)",
+     "https://github.com/libffi/libffi"),
+    # 42 files, over half the bundle by count: ucrtbase, VCRUNTIME140(_1) and 39
+    # `api-ms-win-*` ApiSet stubs. The stubs were nearly missed - they are easy to
+    # read as Windows itself rather than as something we redistribute.
+    ("Microsoft C Runtime", None,
+     "Microsoft redistributable (ucrtbase, VCRUNTIME140, api-ms-win-* stubs)",
+     "https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files"),
 )
 
 
@@ -55,6 +82,23 @@ def _tk_version():
         return "-"
 
 
+def _zlib_version():
+    """The zlib the build links against.
+
+    `ZLIB_VERSION` can carry a suffix - CPython 3.14 reports "1.3.1.zlib-ng",
+    because the `zlib` MODULE is built against zlib-ng while `zlib1.dll` beside
+    the exe is genuine zlib (its own strings say "deflate 1.3.1 Copyright
+    1995-2024 Jean-loup Gailly and Mark Adler"). Both carry the zlib licence, so
+    one entry covers them; the suffix is kept rather than trimmed, because it is
+    the honest answer to "what is in this build".
+    """
+    try:
+        import zlib
+        return str(zlib.ZLIB_VERSION)
+    except Exception:              # noqa: BLE001 - absence is an answer
+        return "-"
+
+
 def component_rows():
     """``(name, version, licence, source_url)`` for every third-party component."""
     rows = []
@@ -65,8 +109,12 @@ def component_rows():
             version = "%d.%d.%d" % sys.version_info[:3]
         elif name == "Tcl/Tk":
             version = _tk_version()
+        elif name == "zlib":
+            version = _zlib_version()
+        elif name == "WinDivert":
+            version = WINDIVERT_VERSION
         else:
-            version = "bundled"          # WinDivert ships inside PyDivert
+            version = "bundled"          # libffi and the MS runtime carry no version
         rows.append((name, version, licence, url))
     return rows
 

--- a/licenses/Python-LICENSE.txt
+++ b/licenses/Python-LICENSE.txt
@@ -275,3 +275,402 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+
+
+Additional Conditions for this Windows binary build
+---------------------------------------------------
+
+This program is linked with and uses Microsoft Distributable Code,
+copyrighted by Microsoft Corporation. The Microsoft Distributable Code
+is embedded in each .exe, .dll and .pyd file as a result of running
+the code through a linker.
+
+If you further distribute programs that include the Microsoft
+Distributable Code, you must comply with the restrictions on
+distribution specified by Microsoft. In particular, you must require
+distributors and external end users to agree to terms that protect the
+Microsoft Distributable Code at least as much as Microsoft's own
+requirements for the Distributable Code. See Microsoft's documentation
+(included in its developer tools and on its website at microsoft.com)
+for specific details.
+
+Redistribution of the Windows binary build of the Python interpreter
+complies with this agreement, provided that you do not:
+
+- alter any copyright, trademark or patent notice in Microsoft's
+Distributable Code;
+
+- use Microsoft's trademarks in your programs' names or in a way that
+suggests your programs come from or are endorsed by Microsoft;
+
+- distribute Microsoft's Distributable Code to run on a platform other
+than Microsoft operating systems, run-time technologies or application
+platforms; or
+
+- include Microsoft Distributable Code in malicious, deceptive or
+unlawful programs.
+
+These restrictions apply only to the Microsoft Distributable Code as
+defined above, not to Python itself or any programs running on the
+Python interpreter. The redistribution of the Python interpreter and
+libraries is governed by the Python Software License included with this
+file, or by other licenses as marked.
+
+
+
+--------------------------------------------------------------------------
+
+This program, "bzip2", the associated library "libbzip2", and all
+documentation, are copyright (C) 1996-2019 Julian R Seward.  All
+rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. The origin of this software must not be misrepresented; you must 
+   not claim that you wrote the original software.  If you use this 
+   software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+3. Altered source versions must be plainly marked as such, and must
+   not be misrepresented as being the original software.
+
+4. The name of the author may not be used to endorse or promote 
+   products derived from this software without specific prior written 
+   permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Julian Seward, jseward@acm.org
+bzip2/libbzip2 version 1.0.8 of 13 July 2019
+
+--------------------------------------------------------------------------
+
+libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
+See source files for details.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+BSD License
+
+For Zstandard software
+
+Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook, nor Meta, nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+This software is copyrighted by the Regents of the University of
+California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
+Corporation and other parties.  The following terms apply to all files
+associated with the software unless explicitly disclaimed in
+individual files.
+
+The authors hereby grant permission to use, copy, modify, distribute,
+and license this software and its documentation for any purpose, provided
+that existing copyright notices are retained in all copies and that this
+notice is included verbatim in any distributions. No written agreement,
+license, or royalty fee is required for any of the authorized uses.
+Modifications to this software may be copyrighted by their authors
+and need not follow the licensing terms described here, provided that
+the new terms are clearly indicated on the first page of each file where
+they apply.
+
+IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+
+GOVERNMENT USE: If you are acquiring this software on behalf of the
+U.S. government, the Government shall have only "Restricted Rights"
+in the software and related documentation as defined in the Federal
+Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
+are acquiring the software on behalf of the Department of Defense, the
+software shall be classified as "Commercial Computer Software" and the
+Government shall have only "Restricted Rights" as defined in Clause
+252.227-7014 (b) (3) of DFARs.  Notwithstanding the foregoing, the
+authors grant the U.S. Government and others acting in its behalf
+permission to use and distribute the software in accordance with the
+terms specified in this license.
+
+This software is copyrighted by the Regents of the University of
+California, Sun Microsystems, Inc., Scriptics Corporation, ActiveState
+Corporation, Apple Inc. and other parties.  The following terms apply to
+all files associated with the software unless explicitly disclaimed in
+individual files.
+
+The authors hereby grant permission to use, copy, modify, distribute,
+and license this software and its documentation for any purpose, provided
+that existing copyright notices are retained in all copies and that this
+notice is included verbatim in any distributions. No written agreement,
+license, or royalty fee is required for any of the authorized uses.
+Modifications to this software may be copyrighted by their authors
+and need not follow the licensing terms described here, provided that
+the new terms are clearly indicated on the first page of each file where
+they apply.
+
+IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+
+GOVERNMENT USE: If you are acquiring this software on behalf of the
+U.S. government, the Government shall have only "Restricted Rights"
+in the software and related documentation as defined in the Federal
+Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
+are acquiring the software on behalf of the Department of Defense, the
+software shall be classified as "Commercial Computer Software" and the
+Government shall have only "Restricted Rights" as defined in Clause
+252.227-7013 (b) (3) of DFARs.  Notwithstanding the foregoing, the
+authors grant the U.S. Government and others acting in its behalf
+permission to use and distribute the software in accordance with the
+terms specified in this license.
+

--- a/licenses/zlib-LICENSE.txt
+++ b/licenses/zlib-LICENSE.txt
@@ -1,0 +1,30 @@
+zlib License
+
+The licence of zlib, the general purpose compression library by Jean-loup
+Gailly and Mark Adler. Bean Network Tester ships zlib1.dll as part of the
+CPython Windows runtime; the exact version is reported by `--license` and named
+in THIRD-PARTY-NOTICES.md.
+
+Reproduced as the project publishes it at https://www.zlib.net/zlib_license.html
+(retrieved 2026-08-11). The permission text is identical across zlib releases;
+only the copyright year range moves, and the range below is the one carried by
+the binary actually shipped here - `zlib1.dll` reports "deflate 1.3.1 Copyright
+1995-2024 Jean-loup Gailly and Mark Adler" in its own strings.
+
+  Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,15 @@
 # Runtime dependencies (traffic capture works only on Windows).
-# We always ship the newest pydivert; it bundles the WinDivert DLL + driver.
-pydivert; sys_platform == "win32"
-psutil
+#
+# 🔴 PINNED, and the pin is the point. Measured 2026-08-11: with `pydivert` and
+# `psutil` unpinned, an SBOM scanner reads this file and reports NOTHING - not a
+# quirk of one tool but the rule, since a requirement without a version is not a
+# component, it is a wish. Three one-line files proved it: unpinned -> 0 packages
+# found, `pydivert==2.1.0` -> 2. So nobody could say afterwards which pydivert a
+# given release actually shipped.
+#
+# The cost is honest: these numbers now need raising by hand. Do that
+# deliberately - `pydivert` carries the WinDivert DLL and the kernel driver, so
+# bumping it changes what we ship to users and what THIRD-PARTY-NOTICES.md has to
+# say. Check the notices and `beantester/legal.py` in the same change.
+pydivert==3.1.3; sys_platform == "win32"
+psutil==7.2.2

--- a/tests/test_license_surface.py
+++ b/tests/test_license_surface.py
@@ -55,7 +55,101 @@ def test_every_shipped_component_is_named_with_a_version_and_a_source():
         check(f"{name} carries a source URL", str(url).startswith("http"), f"({url})")
 
 
-def test_the_report_carries_the_licence_the_components_and_the_no_telemetry_line():
+def test_the_declared_windivert_version_matches_the_driver_we_ship():
+    """The LGPL obligation is to name the EXACT version the user was given.
+
+    Until 2026-08-11 the report said "bundled", which is true and useless to
+    somebody trying to fetch that source and rebuild it. The number is pinned in
+    `legal.WINDIVERT_VERSION` because it is a property of the build, and this test
+    is what stops it rotting: it reads the version resource of the driver in the
+    INSTALLED pydivert and requires the two to agree.
+
+    Note which file is asked. `WinDivert64.dll` carries NO version resource at all
+    - only `WinDivert64.sys` does - which is also why a bundle scanner reports the
+    DLL with an unknown version.
+    """
+    import os
+    import sys as _sys
+
+    from beantester import legal as _legal
+
+    found = _windivert_binaries()
+    if found is None or not _sys.platform.startswith("win"):
+        return                      # Linux runner: the Windows-only dep is absent
+    relative, _names = found
+    import pydivert
+    root = os.path.dirname(os.path.dirname(os.path.abspath(pydivert.__file__)))
+    driver = os.path.join(root, relative.replace("/", os.sep), "WinDivert64.sys")
+    if not os.path.exists(driver):
+        return
+
+    import ctypes
+    import ctypes.wintypes as wintypes
+    version_dll = ctypes.WinDLL("version")
+    size = version_dll.GetFileVersionInfoSizeW(driver, None)
+    check("the driver carries a version resource at all", size > 0, f"({size})")
+    if not size:
+        return
+    buffer = ctypes.create_string_buffer(size)
+    version_dll.GetFileVersionInfoW(driver, 0, size, buffer)
+    block = ctypes.c_void_p()
+    length = wintypes.UINT()
+
+    # 🔴 The STRING block, not the numeric one. A version resource carries both,
+    # and for this driver they DISAGREE: VS_FIXEDFILEINFO says 2.0.0.0 while
+    # StringFileInfo says "2.2", which is the version WinDivert is released and
+    # documented under. The first draft of this test read the numeric field and
+    # reported a mismatch that did not exist - the instrument, not the data.
+    version_dll.VerQueryValueW(buffer, "\\VarFileInfo\\Translation",
+                               ctypes.byref(block), ctypes.byref(length))
+    codes = ctypes.cast(block, ctypes.POINTER(ctypes.c_uint16 * 2)).contents
+    key = "\\StringFileInfo\\%04x%04x\\FileVersion" % (codes[0], codes[1])
+    text = ctypes.c_wchar_p()
+    found_string = version_dll.VerQueryValueW(buffer, key,
+                                              ctypes.byref(text), ctypes.byref(length))
+    check("the driver's version resource carries a FileVersion string",
+          bool(found_string) and bool(text.value), f"({key})")
+    if not found_string:
+        return
+    reported = str(text.value).strip()
+
+    check("the declared WinDivert version is the one on disk",
+          reported == _legal.WINDIVERT_VERSION,
+          f"(driver says {reported!r}, registry says {_legal.WINDIVERT_VERSION!r})")
+
+
+def test_the_registry_and_the_notices_describe_the_same_set():
+    """Three lists have to agree, and until 2026-08-11 they silently did not.
+
+    `legal.COMPONENTS` is what `--license` reports, THIRD-PARTY-NOTICES.md is what
+    the user reads, and `licenses/` is what they can open. Scanning the BUILT
+    BUNDLE with Syft found three components shipping in every release so far that
+    no list mentioned: zlib, libffi and the Microsoft C runtime. All permissive or
+    redistributable, so nothing was breached - the defect was the CLAIM of
+    completeness, which is the kind that survives review because each file looks
+    fine on its own.
+
+    This test cannot see the bundle, so it cannot find the next unlisted DLL. What
+    it does is cheaper and still worth having: it stops the three lists drifting
+    apart once somebody adds a component to one of them.
+    """
+    import os
+    from fakes import ROOT
+
+    notices = open(os.path.join(ROOT, "THIRD-PARTY-NOTICES.md"),
+                   encoding="utf-8").read()
+    for name, *_ in legal.COMPONENTS:
+        # The notices head each component with "## <name>", sometimes followed by
+        # the file names - so match the start, not the whole line.
+        stem = name.split(" (")[0]
+        check(f"the notices have a section for {stem}",
+              ("## " + stem) in notices, f"({stem})")
+
+    texts = sorted(f for f in os.listdir(os.path.join(ROOT, "licenses"))
+                   if f.endswith(".txt"))
+    for text in texts:
+        check(f"licenses/{text} is referenced by the notices",
+              text in notices, f"({text} ships but nothing points at it)")
     report = legal.cli_report()
     check("report opens with the licence itself",
           "GNU GENERAL PUBLIC LICENSE" in report)

--- a/tests/test_sbom.py
+++ b/tests/test_sbom.py
@@ -1,0 +1,140 @@
+"""The SBOM must describe the same build the licence report describes.
+
+An SBOM is a claim about what a user received, published as a release asset and
+signed. Two ways it can go wrong, and only one of them is obvious:
+
+* it can be malformed - caught the moment anything tries to read it;
+* it can be WELL-FORMED AND INCOMPLETE, which is worse, because a document that
+  claims to be a bill of materials and omits a component is more misleading than
+  no document at all.
+
+So the tests below spend most of their effort on the second: every registry entry
+reaches the SBOM, every SPDX identifier is a real one, and the licence the SBOM
+declares is the licence the registry declares.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+from beantester import appinfo, legal
+from fakes import ROOT, check
+
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+import sbom                                                        # noqa: E402
+
+
+def test_the_document_has_the_shape_spdx_requires():
+    doc = sbom.build()
+    check("declares SPDX 2.3", doc["spdxVersion"] == "SPDX-2.3", f"({doc['spdxVersion']})")
+    check("carries the data licence SPDX mandates", doc["dataLicense"] == "CC0-1.0")
+    check("the document has the reserved id", doc["SPDXID"] == "SPDXRef-DOCUMENT")
+    check("the namespace is absolute",
+          doc["documentNamespace"].startswith("https://"), f"({doc['documentNamespace']})")
+    check("creation info names a creator",
+          bool(doc["creationInfo"]["creators"]), f"({doc['creationInfo']})")
+    check("the created stamp is UTC and second-resolution",
+          re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", doc["creationInfo"]["created"]),
+          f"({doc['creationInfo']['created']})")
+
+    for package in doc["packages"]:
+        check(f"{package['name']}: the SPDXID obeys the identifier grammar",
+              re.match(r"^SPDXRef-[A-Za-z0-9.-]+$", package["SPDXID"]),
+              f"({package['SPDXID']})")
+        for field in ("name", "versionInfo", "downloadLocation",
+                      "licenseConcluded", "licenseDeclared", "copyrightText"):
+            check(f"{package['name']}: {field} is present",
+                  field in package and package[field] != "", f"({package})")
+
+
+def test_every_registry_component_reaches_the_sbom():
+    """The failure this exists for: a component added to the registry and not to
+    the SBOM would leave a signed document quietly claiming it is not there."""
+    doc = sbom.build()
+    named = {p["name"] for p in doc["packages"]}
+    for name, *_ in legal.COMPONENTS:
+        check(f"{name} is in the SBOM", name in named, f"({sorted(named)})")
+    check("the program itself is described too", appinfo.APP_NAME in named)
+
+    root = [p for p in doc["packages"] if p["name"] == appinfo.APP_NAME][0]
+    describes = [r for r in doc["relationships"] if r["relationshipType"] == "DESCRIBES"]
+    check("exactly one DESCRIBES relationship", len(describes) == 1, f"({describes})")
+    check("and it points at the program", describes[0]["relatedSpdxElement"] == root["SPDXID"])
+    contains = {r["relatedSpdxElement"] for r in doc["relationships"]
+                if r["relationshipType"] == "CONTAINS"}
+    check("every component is CONTAINED by the program",
+          len(contains) == len(legal.COMPONENTS), f"({len(contains)})")
+
+
+def test_the_declared_licences_are_real_spdx_and_match_the_registry():
+    """A licence expression that is not a real SPDX id is worse than NOASSERTION:
+    it looks authoritative to a tool that cannot check it."""
+    doc = sbom.build()
+    by_name = {p["name"]: p for p in doc["packages"]}
+    known_ids = {
+        "GPL-3.0-only", "LGPL-3.0-only", "GPL-2.0-only", "LGPL-3.0-or-later",
+        "GPL-2.0-or-later", "BSD-3-Clause", "PSF-2.0", "TCL", "Zlib", "MIT",
+    }
+    known_exceptions = {"Bootloader-exception"}
+
+    for name, _module, _prose, _url, expression in legal.COMPONENTS:
+        package = by_name[name]
+        check(f"{name}: the SBOM declares the registry's expression",
+              package["licenseDeclared"] == expression, f"({package['licenseDeclared']})")
+        for token in re.split(r"\s+(?:OR|AND|WITH)\s+", expression):
+            token = token.strip("()")
+            if token.startswith("LicenseRef-"):
+                declared = {e["licenseId"]
+                            for e in doc.get("hasExtractedLicensingInfo", [])}
+                check(f"{name}: {token} is defined in the document",
+                      token in declared, f"({sorted(declared)})")
+                continue
+            check(f"{name}: {token} is a real SPDX identifier",
+                  token in known_ids or token in known_exceptions, f"({expression})")
+
+
+def test_the_generator_runs_as_a_script_and_writes_valid_json(tmp_path):
+    """The release workflow calls it as a script, so that is what gets tested."""
+    out = tmp_path / "sbom.spdx.json"
+    run = subprocess.run([sys.executable, os.path.join(ROOT, "tools", "sbom.py"),
+                          "-o", str(out), "--namespace-seed", "v9.9.9"],
+                         capture_output=True, text=True, cwd=ROOT)
+    check("the script exits clean", run.returncode == 0, f"({run.stderr[-200:]})")
+    check("it wrote the file", out.exists())
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    check("the file parses as the document we built",
+          doc["spdxVersion"] == "SPDX-2.3" and len(doc["packages"]) > 1)
+
+    again = tmp_path / "again.json"
+    subprocess.run([sys.executable, os.path.join(ROOT, "tools", "sbom.py"),
+                    "-o", str(again), "--namespace-seed", "v9.9.9"],
+                   capture_output=True, text=True, cwd=ROOT)
+    second = json.loads(again.read_text(encoding="utf-8"))
+    check("the same seed gives the same namespace, so two runs can be compared",
+          doc["documentNamespace"] == second["documentNamespace"],
+          f"({doc['documentNamespace']} vs {second['documentNamespace']})")
+
+
+def test_the_bundle_guard_notices_a_component_the_registry_lacks(tmp_path):
+    """Guard mode is the half that found zlib, libffi and the Microsoft runtime.
+
+    It is fed a Syft scan and must object when the scan names something no
+    registry entry accounts for. Tested with a synthetic scan rather than a real
+    one, so it runs anywhere and does not need a build.
+    """
+    clean = tmp_path / "clean.json"
+    clean.write_text(json.dumps({"artifacts": [
+        {"name": "Python"}, {"name": "zlib"}, {"name": "WinDivert64"},
+        {"name": "api-ms-win-core-file-l1-1-0.dll"}, {"name": "Bean Network Tester"},
+    ]}), encoding="utf-8")
+    check("a scan of known components is accepted", sbom.audit_bundle(str(clean)) == [],
+          f"({sbom.audit_bundle(str(clean))})")
+
+    dirty = tmp_path / "dirty.json"
+    dirty.write_text(json.dumps({"artifacts": [
+        {"name": "Python"}, {"name": "libcurl"}, {"name": "OpenSSL"},
+    ]}), encoding="utf-8")
+    found = sbom.audit_bundle(str(dirty))
+    check("an unknown component is reported", "libcurl" in found and "OpenSSL" in found,
+          f"({found})")

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -61,7 +61,8 @@ def test_legal_files_are_present():
     licenses = os.path.join(ROOT, "licenses")
     check("licenses/ directory ships", os.path.isdir(licenses))
     for text in ("LGPL-3.0.txt", "GPL-2.0.txt", "psutil-LICENSE.txt",
-                 "Python-LICENSE.txt", "PyInstaller-COPYING.txt"):
+                 "Python-LICENSE.txt", "PyInstaller-COPYING.txt",
+                 "zlib-LICENSE.txt"):
         check(f"licenses/{text} is present",
               os.path.exists(os.path.join(licenses, text)))
 

--- a/tools/sbom.py
+++ b/tools/sbom.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Write an SPDX 2.3 SBOM for the build, from the licence registry.
+
+Why the registry and not a scanner
+----------------------------------
+Both were measured on 2026-08-11 before this was written, and neither is
+sufficient alone:
+
+* a scanner (Syft) reading the BUILT BUNDLE finds CPython, Tcl and Tk with exact
+  versions, and misses psutil, PyDivert and PyInstaller entirely, because
+  PyInstaller strips ``.dist-info``. It sees ``WinDivert64.dll`` with no version,
+  never sees ``WinDivert64.sys`` at all, and attaches **no licence to anything**;
+* the registry (``beantester.legal.COMPONENTS``) carries the licences, the SPDX
+  expressions and the source URLs - the half a scanner cannot infer - and is the
+  list a human has actually reviewed.
+
+So the SBOM is generated from the registry, and the scanner's job is to be its
+GUARD: ``tools/sbom.py --audit-bundle`` fails when the built bundle contains a
+component the registry does not know. That direction is the one that has already
+paid - the same scan found zlib, libffi and 42 Microsoft runtime files shipping
+in every release while every list claimed to be complete.
+
+An SBOM that omits what it cannot see is worse than no SBOM: it is a document
+that claims completeness. This one is only as complete as the registry, and the
+registry now has three tests holding it to the bundle.
+
+Usage:
+    python tools/sbom.py                       # SPDX JSON to stdout
+    python tools/sbom.py -o sbom.spdx.json     # ...or to a file
+    python tools/sbom.py --audit-bundle dist/BeanNetworkTester   # guard mode
+"""
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from beantester import appinfo, legal                              # noqa: E402
+
+SPDX_VERSION = "SPDX-2.3"
+DATA_LICENSE = "CC0-1.0"
+
+# The one licence with no SPDX identifier: Microsoft distributes terms rather
+# than a text to include, so SPDX requires it to be declared as a LicenseRef with
+# the text spelled out here.
+EXTRACTED = {
+    "LicenseRef-Microsoft-Redistributable":
+        "Microsoft Visual C++ runtime and Universal CRT files, redistributed "
+        "under Microsoft's redistributable-code terms for Visual Studio. "
+        "Microsoft publishes the terms rather than a licence text to bundle: "
+        "https://learn.microsoft.com/cpp/windows/redistributing-visual-cpp-files",
+}
+
+
+def _spdx_id(prefix, name):
+    """``SPDXRef-...`` - the identifier grammar allows only letters, digits, . and -."""
+    return "SPDXRef-%s-%s" % (prefix, re.sub(r"[^A-Za-z0-9.-]", "-", name).strip("-"))
+
+
+def _package(name, version, url, spdx_expression):
+    return {
+        "SPDXID": _spdx_id("Package", name),
+        "name": name,
+        "versionInfo": version or "NOASSERTION",
+        "downloadLocation": url or "NOASSERTION",
+        # False, and deliberately: this describes COMPONENTS, not the individual
+        # files they arrive as. Claiming otherwise would oblige us to list and
+        # checksum every file, and a half-filled file list reads as a complete one.
+        "filesAnalyzed": False,
+        "licenseConcluded": spdx_expression or "NOASSERTION",
+        "licenseDeclared": spdx_expression or "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+    }
+
+
+def build(namespace_seed=None):
+    """The SBOM as a dict, ready for ``json.dump``."""
+    version = appinfo.__version__
+    root_id = _spdx_id("Package", appinfo.APP_NAME)
+    created = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # The namespace must be unique per document. Seeded from the build when the
+    # caller has something stable to offer (a tag), so two runs on the same tag
+    # produce the same URI instead of a random one nobody can correlate.
+    seed = namespace_seed or created
+    digest = hashlib.sha256(("%s|%s" % (version, seed)).encode("utf-8")).hexdigest()[:16]
+
+    packages = [{
+        "SPDXID": root_id,
+        "name": appinfo.APP_NAME,
+        "versionInfo": version,
+        "downloadLocation": "https://github.com/donislawdev/BeanNetworkTester",
+        "filesAnalyzed": False,
+        "licenseConcluded": "GPL-3.0-only",
+        "licenseDeclared": "GPL-3.0-only",
+        "copyrightText": "NOASSERTION",
+    }]
+    relationships = [{
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relationshipType": "DESCRIBES",
+        "relatedSpdxElement": root_id,
+    }]
+
+    rows = {name: version for name, version, _lic, _url in legal.component_rows()}
+    for name, _module, _prose, url, spdx_expression in legal.COMPONENTS:
+        reported = rows.get(name, "")
+        packages.append(_package(
+            name,
+            "" if reported in ("bundled", "-", "present") else reported,
+            url, spdx_expression))
+        relationships.append({
+            "spdxElementId": root_id,
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": _spdx_id("Package", name),
+        })
+
+    used = {c[4] for c in legal.COMPONENTS}
+    document = {
+        "spdxVersion": SPDX_VERSION,
+        "dataLicense": DATA_LICENSE,
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "%s-%s" % (appinfo.APP_NAME, version),
+        "documentNamespace":
+            "https://github.com/donislawdev/BeanNetworkTester/spdx/%s-%s" % (version, digest),
+        "creationInfo": {
+            "created": created,
+            "creators": ["Tool: beantester-sbom", "Organization: DonislawDev"],
+            "comment": "Generated from beantester.legal.COMPONENTS, the reviewed "
+                       "list of what this build ships. See tools/sbom.py for why "
+                       "that is the source rather than a filesystem scan.",
+        },
+        "packages": packages,
+        "relationships": relationships,
+    }
+    extracted = [{"licenseId": key, "extractedText": text}
+                 for key, text in sorted(EXTRACTED.items()) if key in used]
+    if extracted:
+        document["hasExtractedLicensingInfo"] = extracted
+    return document
+
+
+# --------------------------------------------------------------------------- #
+# guard mode: the scanner checks the registry, not the other way round
+# --------------------------------------------------------------------------- #
+
+# What a Syft scan of the bundle reports, mapped to the registry entry that
+# accounts for it. Everything the scan can produce must land somewhere here, or
+# the registry has a hole - which is exactly how zlib, libffi and the Microsoft
+# runtime were found.
+BUNDLE_PATTERNS = (
+    (r"^api-ms-win-|^ucrtbase|^vcruntime140|c runtime|apiset stub", "Microsoft C Runtime"),
+    (r"^python$|^python3", "Python"),
+    (r"^tcl|^tk\b|^tk ", "Tcl/Tk"),
+    (r"windivert", "WinDivert"),
+    (r"^zlib", "zlib"),
+    (r"libffi", "libffi"),
+    (r"^pydivert", "PyDivert"),
+    (r"^psutil", "psutil"),
+    (r"pyinstaller", "PyInstaller (bootloader)"),
+    (r"^bean network tester$|^beannetworktester", None),      # the program itself
+)
+
+
+def audit_bundle(scan_json):
+    """Names in a Syft scan that no registry entry accounts for."""
+    with open(scan_json, encoding="utf-8") as handle:
+        scan = json.load(handle)
+    known = {name for name, *_ in legal.COMPONENTS}
+    unaccounted = []
+    for artifact in scan.get("artifacts", []):
+        name = str(artifact.get("name", "")).strip()
+        low = name.lower()
+        for pattern, entry in BUNDLE_PATTERNS:
+            if re.search(pattern, low):
+                if entry is not None and entry not in known:
+                    unaccounted.append("%s -> registry has no %r" % (name, entry))
+                break
+        else:
+            unaccounted.append(name)
+    return sorted(set(unaccounted))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("-o", "--output", help="write here instead of stdout")
+    parser.add_argument("--namespace-seed",
+                        help="stable seed for the document namespace (e.g. the tag)")
+    parser.add_argument("--audit-bundle", metavar="SYFT_JSON",
+                        help="guard mode: fail when a Syft scan names something "
+                             "the registry does not account for")
+    args = parser.parse_args()
+
+    if args.audit_bundle:
+        missing = audit_bundle(args.audit_bundle)
+        if missing:
+            print("The built bundle contains components the licence registry does "
+                  "not account for.\nAdd them to beantester/legal.py, "
+                  "THIRD-PARTY-NOTICES.md and licenses/ before releasing:\n")
+            for line in missing:
+                print("  %s" % line)
+            return 1
+        print("bundle audit: every component maps to a registry entry")
+        return 0
+
+    text = json.dumps(build(args.namespace_seed), indent=2, sort_keys=False) + "\n"
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        print("wrote %s (%d packages)" % (args.output, len(build()["packages"])))
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds an SBOM to every release. The work started as "wire up an SBOM action" and the first step -
measuring what a scanner actually sees - found a compliance gap instead, so that gets fixed first.

## Chunk 0: the measurement that changed the design

Syft 1.51.0 (checksum verified against the publisher's file) on the built bundle:

| | found | missing |
|---|---|---|
| **scanner** | Python 3.14.6, Tcl/Tk 8.6.15 with **exact versions**, zlib, libffi, the MS runtime | psutil, PyDivert, PyInstaller (PyInstaller strips `.dist-info`); `WinDivert64.sys` never seen; `WinDivert64.dll` has no version; **no licence on any entry** |
| **registry** | every licence, SPDX expression and source URL | the components it had never been told about |

Neither is sufficient alone, and that decides the roles: **the registry is the document, the
scanner is its guard.**

Scanning the repo found only GitHub Actions and zero Python packages. Isolated with three one-line
files: the cause is unpinned versions, not the environment marker - `pydivert` alone yields 0,
`pydivert==2.1.0` yields 2. `requirements.txt` is now pinned.

## The compliance gap it exposed

Three components shipped in **every release so far** while every list claimed completeness: zlib
(`zlib1.dll`), libffi (`libffi-8.dll`), and the Microsoft C runtime - the last being **42 files,
more than half the bundle by count**, since 39 `api-ms-win-*` ApiSet stubs belong to it.

Worse: `licenses/Python-LICENSE.txt` was a **truncated copy** - identical to upstream for 278 lines
and then simply cut, dropping the 399 lines that cover the software CPython incorporates, libffi
among them. Now the complete text.

All permissive or redistributable, so no obligation was breached. The defect was the *claim* of
completeness - the kind that survives review because each file looks fine on its own. A sweep now
maps all 264 shipped files to a registry entry with zero unassigned binaries.

`--license` also stops saying "bundled" for WinDivert. The driver reports 2.2, and the guard
reading it went wrong first: the numeric version resource says `2.0.0.0` while the string resource
says `"2.2"`. Caught by measuring the same file two ways - the instrument, not the data.

## The SBOM

`tools/sbom.py` emits SPDX 2.3 from the registry: 10 packages, one DESCRIBES, nine CONTAINS. The
registry gained a fifth field, the SPDX expression, because "dual LGPL-3.0 / GPL-2.0" is prose no
tool can read. Every identifier checked against the SPDX list rather than recalled - `PSF-2.0`
(**not** `Python-2.0`), `TCL`, `Zlib`, and `Bootloader-exception`, which does exist. Microsoft's
runtime has no identifier at all, so it is a `LicenseRef-` with its text in the document.

**Validated by an external consumer, not by assertion:** Syft reads the document back and lists all
ten packages.

Releases now publish three assets, and `actions/attest-sbom` signs the SBOM against the zip:

```bash
gh attestation verify BeanNetworkTester-vX.Y.Z-windows-x64.zip --repo donislawdev/BeanNetworkTester
```

A checksum says the file arrived unchanged. The attestation says where it came from.

## The guard, and where it runs

`tools/sbom.py --audit-bundle` fails when a Syft scan names a component the registry does not
account for. It runs in **ci.yml, not in the release**: that job holds `contents: read` and cuts no
tag, so a third-party action costs far less there, and a hole found at PR time beats one found
while publishing.

Both new actions are **pinned by SHA read from the API**. Worth stating plainly: the first draft
carried an invented SHA for `attest-sbom`, which would have failed the release. Both pins were
re-verified against their tags after the fact.

## Verification

- `python -m pytest tests` - **1043 passed**, run bare and as the last action after the prose.
- `python smoke_gui.py` - green; both Stop hooks green.
- Guard mode run against a real bundle scan, and mutation-checked twice (drop zlib from the
  registry, rename the Microsoft entry - both caught).
- Three licence guards mutation-checked: registry versus notices both ways, every licence text
  referenced, and the WinDivert version matching the driver on disk.
- 🔴 **Not verifiable before a tag exists:** the attestation step itself. Syntax and permissions are
  right, but the signature is only produced on a real release. Worth knowing before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
