### PR TITLE
ci: say what the weekly build actually watches now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,19 @@ on:
   push:
     branches: [master]
   pull_request:
-  # Weekly run (Mon 06:00 UTC): requirements are not fully pinned (pydivert/psutil
-  # track latest), so a scheduled build catches upstream breakage before a push does.
+  # Weekly run (Mon 06:00 UTC). The reason MOVED on 2026-08-11 and is worth keeping
+  # straight: `requirements.txt` is now pinned, so pydivert and psutil no longer
+  # drift. Three things still do, and a scheduled build is the only thing watching
+  # them between pushes:
+  #   * `requirements-dev.txt` is deliberately unpinned - pytest, hypothesis and
+  #     pytest-cov track latest, and a new pytest can redden a green suite;
+  #   * **pyinstaller is installed unpinned** (`pip install -r requirements.txt
+  #     pyinstaller`) in the build job here AND in release.yml, so an upstream
+  #     release changes the executable we ship without a commit of ours;
+  #   * the runner image and the 3.14.x patch `setup-python` resolves both move
+  #     under us.
+  # In other words the cron catches less than it used to on the runtime side and
+  # exactly as much on the side that builds the binary.
   schedule:
     - cron: "0 6 * * 1"
   # Allow running the pipeline by hand from the Actions tab.


### PR DESCRIPTION
A comment-only change, but it was explaining a decision with a fact that had stopped being true.

## What was wrong

The Monday cron justified itself like this:

> requirements are not fully pinned (pydivert/psutil track latest), so a scheduled build catches
> upstream breakage before a push does

That held until #118 pinned `requirements.txt`, and was false from the next commit. A schedule
whose stated reason no longer applies is the kind of thing that gets deleted by a future reader as
dead weight - or kept for a reason nobody can check.

## What the cron still earns

Checking that turned out to be the useful part. Three things still drift between pushes:

- **`requirements-dev.txt` is deliberately unpinned** - pytest, hypothesis and pytest-cov track
  latest, and a new pytest can redden a green suite with no commit of ours;
- **the runner image and the 3.14.x patch** that `setup-python` resolves both move under us;
- 🔴 **`pyinstaller` is installed unpinned** - `pip install -r requirements.txt pyinstaller` - in
  this build job *and* in `release.yml`.

## The finding worth more than the comment

That last one means **the executable we ship is built by whatever PyInstaller was on PyPI that
morning**. The runtime dependencies were pinned in #118 precisely so a release could say what it
contains; the tool that builds the binary was left floating. The SBOM also lists PyInstaller with
no version, and its bootloader ships inside the exe under its own licence.

Recorded as backlog **B-12** rather than fixed here. It is an inconsistency, not a defect - nothing
has broken and there is no measurement saying otherwise - and the choice between "pin it and bump
by hand, like the runtime" and "leave it and write down that this is deliberate" belongs to the
owner, not to a comment rewrite.

## Verification

- `python -m pytest tests` - **1043 passed**, run bare and last.
- `python smoke_gui.py` - green; both Stop hooks green.
- YAML re-parsed; the schedule itself is unchanged (`0 6 * * 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
