### PR TITLE
feat(site): a project website on GitHub Pages, in English and Polish

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,158 @@
+name: Pages
+
+# Publishes the website in `site/` to GitHub Pages. It has nothing to do with the
+# program's release path: this builds static files and deploys them, and it is the
+# only workflow allowed to write to Pages.
+#
+# Requires two things done ONCE by the owner, outside this file:
+#   * Settings -> Pages, source "GitHub Actions" (without it, the first step that
+#     talks to the Pages API fails, and says so);
+#   * the custom domain, in the same settings, plus its DNS record. The build below
+#     REFUSES to publish to an address the pages do not claim as their own, so this
+#     is enforced rather than remembered - see the step that compares the two.
+on:
+  push:
+    branches: [master]
+    # Everything the page is built FROM. Miss one and the site keeps serving the
+    # previous version of it, which looks exactly like a page nobody edited. The
+    # asset sources are here because `site/site.json` lists them, and a test derives
+    # this list from that file so the two cannot drift.
+    paths:
+      - "site/**"
+      - "tools/build_site.py"
+      - "tests/test_site.py"
+      - "beantester/gui/theme.py"
+      - "beantester/appinfo.py"
+      - "bean.png"
+      - "docs/demo.gif"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+# Least privilege, same rule as ci.yml: the token reads the repository, and the one
+# job that has to write to Pages raises it for itself.
+permissions:
+  contents: read
+
+# One deployment at a time, and never cancel one in flight. A half-replaced site is
+# worse than a late one, and there is no way to roll back a partial upload.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build the site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # READ, not write. This job asks the Pages API which address the repository
+    # publishes to, and nothing more - it never deploys. GitHub's own starter
+    # workflow grants `pages: write` to the whole file instead, which would hand
+    # that power to every job here.
+    # 🔴 Not verifiable off the runner: the action's own documentation does not state
+    # the scope it needs, and the API call is a plain GET, so read should be enough.
+    # If the first run fails with 403 on "Read the Pages configuration", this is the
+    # line to raise to `write` - not the workflow-level permissions.
+    permissions:
+      contents: read
+      pages: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      # Reads the Pages configuration and tells us the address this repository
+      # publishes to. It runs HERE, before anything is uploaded, so a mismatch stops
+      # the run instead of publishing a site whose every canonical points elsewhere.
+      - name: Read the Pages configuration
+        id: pages
+        uses: actions/configure-pages@v6
+
+      - name: The address it publishes to must be the address the pages claim
+        env:
+          # The action publishes the host on its own, so nothing here has to parse
+          # a URL that GitHub already took apart.
+          DEPLOY_HOST: ${{ steps.pages.outputs.host }}
+          DEPLOY_URL: ${{ steps.pages.outputs.base_url }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+          from urllib.parse import urlsplit
+          claimed = json.load(open("site/site.json"))["base_url"]
+          deployed = os.environ["DEPLOY_URL"]
+          claimed_host = urlsplit(claimed).netloc.lower()
+          deployed_host = (os.environ.get("DEPLOY_HOST")
+                           or urlsplit(deployed).netloc).lower()
+          print("pages claim %s, this repository publishes to %s (%s)"
+                % (claimed_host, deployed_host, deployed))
+          if claimed_host != deployed_host:
+              print("::error::Every canonical, hreflang and sitemap entry names %s, "
+                    "but this repository publishes to %s. Set the custom domain in "
+                    "Settings -> Pages (and its DNS record) before publishing, or "
+                    "change base_url in site/site.json to match."
+                    % (claimed_host, deployed_host))
+              sys.exit(1)
+          PY
+
+      - name: Install the test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      # The generator refuses to build a broken page, but "it did not crash" is a
+      # weaker claim than "the guards agree". These read the OUTPUT: the canonical,
+      # the reciprocal hreflang, the download link, the palette, the error page.
+      - name: Let the site guards have a say before anything is published
+        run: python -m pytest tests/test_site.py
+
+      - name: Build
+        run: python tools/build_site.py --out _site
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy and read it back
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Raised on THIS job only: the deployment writes to Pages and mints an OIDC
+    # token, and nothing else in this workflow needs either.
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v5
+        id: deployment
+
+      # A deployment that reports success proves the upload happened, not that the
+      # site answers. This fetches the published page and checks the two things a
+      # crawler needs and a screenshot cannot show.
+      - name: Read the published page back
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          for attempt in 1 2 3; do
+            if curl -sSfL --max-time 20 "$PAGE_URL" -o page.html; then break; fi
+            echo "attempt $attempt did not answer, waiting"
+            sleep 15
+          done
+          if [ ! -s page.html ]; then
+            echo "::error::$PAGE_URL did not answer. If the custom domain is new, its"
+            echo "DNS record or its certificate may not be ready yet - the deployment"
+            echo "itself succeeded, so re-run this job once the address resolves."
+            exit 1
+          fi
+          grep -q '<link rel="canonical"' page.html \
+            || { echo "::error::the published page carries no canonical"; exit 1; }
+          grep -q 'hreflang="x-default"' page.html \
+            || { echo "::error::the published page carries no x-default"; exit 1; }
+          curl -sSfL --max-time 20 "${PAGE_URL}sitemap.xml" -o sitemap.xml
+          grep -q "<loc>" sitemap.xml \
+            || { echo "::error::the published sitemap lists nothing"; exit 1; }
+          echo "published and readable: $PAGE_URL"

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1,0 +1,243 @@
+/* Bean Network Tester website: dark theme, system fonts, nothing loaded from
+   anywhere else.
+
+   COLOURS ARE NOT DECLARED HERE. The custom properties this file uses are written
+   in front of it by tools/build_site.py, straight out of beantester/gui/theme.py -
+   so the page and the program cannot drift into two different dark themes. That is
+   also why a hex literal anywhere under site/ fails the suite: it would be a second
+   place where a colour lives. Derived shades come from color-mix, not from a second
+   hand-picked value. */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: "Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif;
+  font-size: 17px;
+  line-height: 1.6;
+}
+
+/* Keyboard users must be able to see where they are. The program follows the same
+   rule: hover is the fill, focus is the ring. */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.skip {
+  position: absolute;
+  left: -9999px;
+}
+.skip:focus {
+  left: 1rem;
+  top: 1rem;
+  z-index: 10;
+  padding: .6rem 1rem;
+  background: var(--bg-card);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+a { color: var(--accent); }
+a:hover { color: color-mix(in srgb, var(--accent) 75%, var(--fg)); }
+
+code {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: .1em .35em;
+  font-family: Consolas, "Cascadia Mono", ui-monospace, monospace;
+  font-size: .92em;
+}
+
+/* -- top bar ------------------------------------------------------------- */
+.bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: .6rem;
+  color: var(--fg);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.bar-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .35rem 1rem;
+}
+
+.bar-link { text-decoration: none; }
+.bar-link:hover { text-decoration: underline; }
+
+.langs {
+  display: inline-flex;
+  gap: .35rem;
+  align-items: center;
+}
+.langs a, .langs span {
+  padding: .15rem .5rem;
+  border-radius: 4px;
+  font-size: .92rem;
+  text-decoration: none;
+}
+.langs span[aria-current] {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  color: var(--muted);
+}
+
+/* -- page body ----------------------------------------------------------- */
+main {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 1.25rem 4rem;
+}
+
+section { margin: 3.5rem 0; }
+
+h1 {
+  font-size: clamp(2rem, 6vw, 3rem);
+  line-height: 1.15;
+  margin: 0 0 1rem;
+  letter-spacing: -.01em;
+}
+
+h2 {
+  font-size: clamp(1.4rem, 3.5vw, 1.9rem);
+  margin: 0 0 1.25rem;
+}
+
+h3 {
+  font-size: 1.1rem;
+  margin: 0 0 .5rem;
+}
+
+.hero { margin-top: 3rem; }
+
+.lead {
+  font-size: 1.15rem;
+  max-width: 62ch;
+  color: color-mix(in srgb, var(--fg) 88%, var(--muted));
+}
+
+.note {
+  color: var(--muted);
+  font-size: .95rem;
+  max-width: 62ch;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  margin: 1.75rem 0 1rem;
+}
+
+.btn {
+  display: inline-block;
+  padding: .8rem 1.4rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: var(--fg);
+  font-weight: 600;
+  text-decoration: none;
+}
+.btn:hover {
+  background: color-mix(in srgb, var(--bg-card) 80%, var(--fg));
+  color: var(--fg);
+}
+
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg-input);
+}
+.btn-primary:hover {
+  background: color-mix(in srgb, var(--accent) 85%, var(--fg));
+  color: var(--bg-input);
+}
+
+/* -- cards and lists ----------------------------------------------------- */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem;
+}
+.card p { margin: 0; color: color-mix(in srgb, var(--fg) 85%, var(--muted)); }
+
+.steps {
+  margin: 0;
+  padding-left: 1.4rem;
+  max-width: 70ch;
+}
+.steps li { margin-bottom: .6rem; }
+
+.shot {
+  margin: 2.5rem 0;
+  text-align: center;
+}
+.shot img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+}
+.shot figcaption {
+  color: var(--muted);
+  font-size: .9rem;
+  margin-top: .6rem;
+}
+
+.closing {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+.closing h2 { margin-bottom: 0; }
+.closing .actions { justify-content: center; margin-bottom: 0; }
+
+/* -- footer -------------------------------------------------------------- */
+.foot {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: .95rem;
+}
+.foot p { margin: .35rem 0; }
+.foot .copy { margin-top: 1rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -7,6 +7,7 @@
   "nav.skip": "Skip to content",
   "nav.home": "Home",
   "nav.source": "Source on GitHub",
+  "nav.primary": "Site",
   "nav.language": "Language",
 
   "cta.download": "Download for Windows",

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -10,6 +10,8 @@
   "nav.primary": "Site",
   "nav.language": "Language",
 
+  "og.image_alt": "The Bean Network Tester window, showing a session in progress",
+
   "cta.download": "Download for Windows",
   "cta.source": "See the code on GitHub",
   "cta.note": "Free and open source under the GPLv3. Windows 10 and 11, 64-bit. No account, no telemetry.",

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -1,0 +1,21 @@
+{
+  "_meta": {"code": "en", "name": "English"},
+
+  "site.name": "Bean Network Tester",
+  "site.tagline": "Simulate a bad network on Windows",
+
+  "nav.skip": "Skip to content",
+  "nav.home": "Home",
+  "nav.source": "Source on GitHub",
+  "nav.language": "Language",
+
+  "cta.download": "Download for Windows",
+  "cta.source": "See the code on GitHub",
+  "cta.note": "Free and open source under the GPLv3. Windows 10 and 11, 64-bit. No account, no telemetry.",
+  "cta.closing": "Ready to break your own network on purpose?",
+
+  "footer.license": "Free and open source under the GNU General Public License v3.0.",
+  "footer.no_telemetry": "The program sends no data anywhere. This page loads nothing from anyone else.",
+  "footer.author": "Made by DonislawDev.",
+  "footer.issues": "Found a bug? Report it on GitHub."
+}

--- a/site/i18n/pl.json
+++ b/site/i18n/pl.json
@@ -10,6 +10,8 @@
   "nav.primary": "Witryna",
   "nav.language": "Język",
 
+  "og.image_alt": "Okno programu Bean Network Tester w trakcie sesji",
+
   "cta.download": "Pobierz na Windows",
   "cta.source": "Zobacz kod na GitHubie",
   "cta.note": "Darmowe i otwarte na licencji GPLv3. Windows 10 i 11, 64-bit. Bez konta, bez telemetrii.",

--- a/site/i18n/pl.json
+++ b/site/i18n/pl.json
@@ -1,0 +1,21 @@
+{
+  "_meta": {"code": "pl", "name": "Polski"},
+
+  "site.name": "Bean Network Tester",
+  "site.tagline": "Symulator słabego internetu dla Windows",
+
+  "nav.skip": "Przejdź do treści",
+  "nav.home": "Strona główna",
+  "nav.source": "Kod na GitHubie",
+  "nav.language": "Język",
+
+  "cta.download": "Pobierz na Windows",
+  "cta.source": "Zobacz kod na GitHubie",
+  "cta.note": "Darmowe i otwarte na licencji GPLv3. Windows 10 i 11, 64-bit. Bez konta, bez telemetrii.",
+  "cta.closing": "Chcesz zepsuć sobie sieć specjalnie?",
+
+  "footer.license": "Darmowe i otwarte oprogramowanie na licencji GNU General Public License v3.0.",
+  "footer.no_telemetry": "Program nie wysyła nigdzie żadnych danych. Ta strona nie ładuje niczego z obcych serwerów.",
+  "footer.author": "Autor: DonislawDev.",
+  "footer.issues": "Znalazłeś błąd? Zgłoś go na GitHubie."
+}

--- a/site/i18n/pl.json
+++ b/site/i18n/pl.json
@@ -7,6 +7,7 @@
   "nav.skip": "Przejdź do treści",
   "nav.home": "Strona główna",
   "nav.source": "Kod na GitHubie",
+  "nav.primary": "Witryna",
   "nav.language": "Język",
 
   "cta.download": "Pobierz na Windows",

--- a/site/pages/404/en.html
+++ b/site/pages/404/en.html
@@ -1,0 +1,10 @@
+<section class="hero">
+  <h1>That page is not here</h1>
+  <p class="lead">The address you followed does not exist on this site. It may have been a typo,
+  or a link that pointed at something that moved.</p>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{page.home_url}}">{{nav.home}}</a>
+    <a class="btn" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+  <p class="note"><a href="{{site.base_url}}/pl/" hreflang="pl" lang="pl">Ta strona po polsku</a></p>
+</section>

--- a/site/pages/404/page.json
+++ b/site/pages/404/page.json
@@ -1,0 +1,13 @@
+{
+  "id": "404",
+  "order": 900,
+  "output": "404.html",
+  "noindex": true,
+  "languages": {
+    "en": {
+      "slug": "404",
+      "title": "Page not found - Bean Network Tester",
+      "description": "That address does not exist on this site. The links below reach the home page and the download."
+    }
+  }
+}

--- a/site/pages/home/en.html
+++ b/site/pages/home/en.html
@@ -1,0 +1,74 @@
+<section class="hero">
+  <h1>Test your app on a bad network</h1>
+  <p class="lead">Bean Network Tester adds lag, packet loss and speed limits to a single Windows
+  application. You get to see what your users see on a train, on hotel WiFi, or on a phone with
+  one bar of signal.</p>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+    <a class="btn" href="{{site.repo_url}}">{{cta.source}}</a>
+  </p>
+  <p class="note">{{cta.note}}</p>
+</section>
+
+<figure class="shot">
+  <img src="{{page.asset_prefix}}assets/demo.gif" width="820" height="461" loading="lazy"
+       decoding="async"
+       alt="A live ping losing packets and gaining delay while the tool is running">
+  <figcaption>Adding delay and packet loss to a running connection.</figcaption>
+</figure>
+
+<section>
+  <h2>What it does to your network</h2>
+  <div class="grid">
+    <article class="card">
+      <h3>Slows it down</h3>
+      <p>Add a fixed or random delay. Find out what 300 ms of ping does to your loading spinner.</p>
+    </article>
+    <article class="card">
+      <h3>Loses packets</h3>
+      <p>Drop, duplicate or corrupt them, then watch whether your app recovers or just hangs.</p>
+    </article>
+    <article class="card">
+      <h3>Caps the speed</h3>
+      <p>Hold download or upload to a set number of KB per second, the way a weak mobile link does.</p>
+    </article>
+    <article class="card">
+      <h3>Breaks the link</h3>
+      <p>Tear connections down, block a port or an address, or make the network come and go.</p>
+    </article>
+    <article class="card">
+      <h3>Aims at one app</h3>
+      <p>Pick a process, a PID, an address or a port. The rest of the machine keeps working normally.</p>
+    </article>
+    <article class="card">
+      <h3>Repeats exactly</h3>
+      <p>The same seed replays the same run. That is the difference between a bug report and a story.</p>
+    </article>
+  </div>
+</section>
+
+<section>
+  <h2>Running it takes three steps</h2>
+  <ol class="steps">
+    <li>Download the zip from the releases page and unpack it anywhere.</li>
+    <li>Start <code>BeanNetworkTester.exe</code>. It asks for administrator rights by itself, because
+    capturing traffic needs them.</li>
+    <li>Pick a ready profile such as "3G network", press START, and use your app.</li>
+  </ol>
+  <p>There is a text mode in the same file, so the whole thing also runs in a pipeline.
+  One command is enough to check that your service survives 10 percent packet loss.</p>
+</section>
+
+<section>
+  <h2>Who uses it</h2>
+  <p>Testers who have to reproduce "it works on my machine". Developers who need a timeout to
+  actually happen. Game developers checking what lag does to their netcode. Anyone who has ever
+  been asked whether the app works on a weak connection and had no honest way to find out.</p>
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/home/page.json
+++ b/site/pages/home/page.json
@@ -1,0 +1,17 @@
+{
+  "id": "home",
+  "order": 1,
+  "in_nav": true,
+  "languages": {
+    "en": {
+      "slug": "",
+      "title": "Bean Network Tester - simulate a bad network on Windows",
+      "description": "Free Windows tool that adds lag, packet loss and speed limits to one app, so you can test how it behaves on a bad connection."
+    },
+    "pl": {
+      "slug": "",
+      "title": "Bean Network Tester - symulator słabego internetu (Windows)",
+      "description": "Darmowe narzędzie dla Windows. Dodaje opóźnienie, utratę pakietów i limit prędkości wybranej aplikacji, żeby sprawdzić, jak działa przy słabym połączeniu."
+    }
+  }
+}

--- a/site/pages/home/page.json
+++ b/site/pages/home/page.json
@@ -1,7 +1,6 @@
 {
   "id": "home",
   "order": 1,
-  "in_nav": true,
   "languages": {
     "en": {
       "slug": "",
@@ -13,5 +12,6 @@
       "title": "Bean Network Tester - symulator słabego internetu (Windows)",
       "description": "Darmowe narzędzie dla Windows. Dodaje opóźnienie, utratę pakietów i limit prędkości wybranej aplikacji, żeby sprawdzić, jak działa przy słabym połączeniu."
     }
-  }
+  },
+  "schema": "software_application"
 }

--- a/site/pages/home/pl.html
+++ b/site/pages/home/pl.html
@@ -1,0 +1,78 @@
+<section class="hero">
+  <h1>Sprawdź swoją aplikację na słabej sieci</h1>
+  <p class="lead">Bean Network Tester dokłada opóźnienie, utratę pakietów i limit prędkości jednej
+  aplikacji na Windows. Zobaczysz to, co widzą Twoi użytkownicy w pociągu, na hotelowym WiFi albo
+  na telefonie z jedną kreską zasięgu.</p>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+    <a class="btn" href="{{site.repo_url}}">{{cta.source}}</a>
+  </p>
+  <p class="note">{{cta.note}}</p>
+</section>
+
+<figure class="shot">
+  <img src="{{page.asset_prefix}}assets/demo.gif" width="820" height="461" loading="lazy"
+       decoding="async"
+       alt="Działający ping traci pakiety i dostaje opóźnienie w trakcie pracy narzędzia">
+  <figcaption>Dokładanie opóźnienia i utraty pakietów do trwającego połączenia.</figcaption>
+</figure>
+
+<section>
+  <h2>Co robi z siecią</h2>
+  <div class="grid">
+    <article class="card">
+      <h3>Zwalnia ją</h3>
+      <p>Dokłada stałe albo losowe opóźnienie. Zobaczysz, co 300 ms pingu robi z Twoim ekranem
+      ładowania.</p>
+    </article>
+    <article class="card">
+      <h3>Gubi pakiety</h3>
+      <p>Odrzuca je, duplikuje albo psuje. Wtedy widać, czy aplikacja się podnosi, czy tylko wisi.</p>
+    </article>
+    <article class="card">
+      <h3>Ogranicza prędkość</h3>
+      <p>Trzyma pobieranie albo wysyłanie na zadanej liczbie KB na sekundę, jak słabe łącze
+      mobilne.</p>
+    </article>
+    <article class="card">
+      <h3>Zrywa łącze</h3>
+      <p>Zamyka połączenia, blokuje port albo adres, potrafi też włączać i wyłączać sieć na
+      przemian.</p>
+    </article>
+    <article class="card">
+      <h3>Celuje w jedną aplikację</h3>
+      <p>Wskazujesz proces, PID, adres albo port. Reszta komputera pracuje normalnie.</p>
+    </article>
+    <article class="card">
+      <h3>Powtarza dokładnie</h3>
+      <p>To samo ziarno losowości odtwarza ten sam przebieg. Na tym polega różnica między
+      zgłoszeniem błędu a opowieścią.</p>
+    </article>
+  </div>
+</section>
+
+<section>
+  <h2>Uruchomienie to trzy kroki</h2>
+  <ol class="steps">
+    <li>Pobierz archiwum ze strony wydań i rozpakuj je w dowolnym miejscu.</li>
+    <li>Uruchom <code>BeanNetworkTester.exe</code>. Sam poprosi o prawa administratora, bo
+    przechwytywanie ruchu ich wymaga.</li>
+    <li>Wybierz gotowy profil, na przykład "Sieć 3G", wciśnij START i korzystaj z aplikacji.</li>
+  </ol>
+  <p>W tym samym pliku jest tryb tekstowy, więc całość działa też w pipeline. Jedna komenda
+  wystarczy, żeby sprawdzić, czy Twoja usługa przetrwa 10 procent utraty pakietów.</p>
+</section>
+
+<section>
+  <h2>Kto z tego korzysta</h2>
+  <p>Testerzy, którzy muszą odtworzyć "u mnie działa". Programiści, którym timeout ma się wreszcie
+  wydarzyć. Twórcy gier sprawdzający, co lag robi z ich siecią. Każdy, kto usłyszał pytanie, czy
+  aplikacja działa na słabym połączeniu, i nie miał uczciwego sposobu, żeby to stwierdzić.</p>
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/site.json
+++ b/site/site.json
@@ -3,9 +3,15 @@
   "repo_url": "https://github.com/donislawdev/BeanNetworkTester",
   "default_language": "en",
   "languages": [
-    {"code": "en", "name": "English", "html_lang": "en", "dir": ""},
-    {"code": "pl", "name": "Polski", "html_lang": "pl", "dir": "pl"}
+    {"code": "en", "name": "English", "dir": "", "og_locale": "en_US"},
+    {"code": "pl", "name": "Polski", "dir": "pl", "og_locale": "pl_PL"}
   ],
+  "og_image": "assets/bean.png",
+  "software": {
+    "application_category": "DeveloperApplication",
+    "operating_system": "Windows 10, Windows 11",
+    "license_url": "https://www.gnu.org/licenses/gpl-3.0.html"
+  },
   "palette": {
     "--bg": "BG",
     "--bg-card": "BG2",

--- a/site/site.json
+++ b/site/site.json
@@ -1,0 +1,27 @@
+{
+  "base_url": "https://beannetworktester.donislawdev.com",
+  "repo_url": "https://github.com/donislawdev/BeanNetworkTester",
+  "default_language": "en",
+  "languages": [
+    {"code": "en", "name": "English", "html_lang": "en", "dir": ""},
+    {"code": "pl", "name": "Polski", "html_lang": "pl", "dir": "pl"}
+  ],
+  "palette": {
+    "--bg": "BG",
+    "--bg-card": "BG2",
+    "--bg-input": "FIELD",
+    "--border": "BORDER",
+    "--line": "LINE_C",
+    "--fg": "FG",
+    "--muted": "MUT",
+    "--accent": "ACC",
+    "--ok": "OK",
+    "--warn": "WARN",
+    "--stop": "STOP_C",
+    "--donate": "DONATE_C"
+  },
+  "assets": [
+    {"source": "bean.png", "target": "assets/bean.png"},
+    {"source": "docs/demo.gif", "target": "assets/demo.gif"}
+  ]
+}

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
+<meta name="theme-color" content="{{site.theme_color}}">
 <title>{{page.title}}</title>
 <meta name="description" content="{{page.description}}">
 <!-- Canonical, hreflang, social cards and structured data. Composed by

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="{{page.html_lang}}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<title>{{page.title}}</title>
+<meta name="description" content="{{page.description}}">
+<link rel="icon" href="{{page.asset_prefix}}assets/bean.png" type="image/png">
+<link rel="stylesheet" href="{{page.asset_prefix}}assets/style.css">
+</head>
+<body>
+<a class="skip" href="#main">{{nav.skip}}</a>
+
+<header class="bar">
+  <a class="brand" href="{{page.home_url}}">
+    <img src="{{page.asset_prefix}}assets/bean.png" width="28" height="28" alt="">
+    <span>{{site.name}}</span>
+  </a>
+  <nav class="bar-nav" aria-label="{{nav.language}}">
+    {{page.language_switcher}}
+    <a class="bar-link" href="{{site.repo_url}}">{{nav.source}}</a>
+  </nav>
+</header>
+
+<main id="main">
+{{page.body}}
+</main>
+
+<footer class="foot">
+  <p>{{footer.license}}</p>
+  <p>{{footer.no_telemetry}}</p>
+  <p>{{footer.author}} <a href="{{site.issues_url}}">{{footer.issues}}</a></p>
+  <p class="copy">{{site.copyright}}</p>
+</footer>
+</body>
+</html>

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -1,11 +1,16 @@
 <!doctype html>
-<html lang="{{page.html_lang}}">
+<html lang="{{page.lang}}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
 <title>{{page.title}}</title>
 <meta name="description" content="{{page.description}}">
+<!-- Canonical, hreflang, social cards and structured data. Composed by
+     tools/build_site.py because they differ per page: an indexable page carries all
+     of them, and the 404 carries a noindex instead. One placeholder rather than a
+     template with conditionals it cannot express. -->
+{{page.head_meta}}
 <link rel="icon" href="{{page.asset_prefix}}assets/bean.png" type="image/png">
 <link rel="stylesheet" href="{{page.asset_prefix}}assets/style.css">
 </head>
@@ -17,7 +22,7 @@
     <img src="{{page.asset_prefix}}assets/bean.png" width="28" height="28" alt="">
     <span>{{site.name}}</span>
   </a>
-  <nav class="bar-nav" aria-label="{{nav.language}}">
+  <nav class="bar-nav" aria-label="{{nav.primary}}">
     {{page.language_switcher}}
     <a class="bar-link" href="{{site.repo_url}}">{{nav.source}}</a>
   </nav>

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -403,11 +403,30 @@ MUTATIONS = [
     {
         "label": "public: the privacy scan reads an empty file list",
         "file": "tests/test_repo_conventions.py",
-        "old": "    files = repo_text_files((\".py\", \".md\", \".json\", \".txt\", \".toml\", \".spec\", \".yml\"))\n"
+        "old": "    files = repo_text_files((\".py\", \".md\", \".json\", \".txt\", \".toml\", \".spec\", \".yml\")\n"
+               "                            + WEB_EXTS)\n"
                "    check(\"the privacy scan actually read the repository\"",
         "new": "    files = []\n"
                "    check(\"the privacy scan actually read the repository\"",
         "test": "test_nothing_private_to_this_machine_reaches_the_public_repository",
+    },
+    {
+        # The site exists to produce this one click. A generator that points it a
+        # level up still builds, still renders and still looks right.
+        "label": "site: the download button stops at the releases list",
+        "file": "tools/build_site.py",
+        "old": "        \"site.download_url\": \"%s/releases/latest\" % repo,",
+        "new": "        \"site.download_url\": \"%s/releases\" % repo,",
+        "test": "test_the_download_button_points_at_the_release_page",
+    },
+    {
+        # Two dark themes drifting apart is the failure nobody reports: each page
+        # looks fine on its own, and only a side-by-side would show it.
+        "label": "site: the palette stops coming from theme.py",
+        "file": "tools/build_site.py",
+        "old": "    colours = palette(root, registry[\"palette\"])",
+        "new": "    colours = {var: \"#010203\" for var in registry[\"palette\"]}",
+        "test": "test_the_palette_is_read_out_of_the_theme_module",
     },
     {
         "label": "licence: the notices name a WinDivert file that is not shipped",

--- a/tests/test_repo_conventions.py
+++ b/tests/test_repo_conventions.py
@@ -27,6 +27,14 @@ SKIP_FILES = {"PROJECT_NOTES.md", "HISTORY_NOTES.md", "CLAUDE.md",
 # Same reason, by prefix: HANDOFF-*.md are maintainer briefs kept out of git.
 SKIP_PREFIXES = ("HANDOFF-",)
 
+# The website sources under site/ are public text like any other, and until they
+# existed every scanner below stopped at the extensions a Python project has. The
+# conventions do not stop there: a dash, a machine path or an address in a page
+# template is published to a browser instead of to a reader of the repository,
+# which is worse, not better. Kept as its own tuple so the addition is visible
+# rather than buried in three separate literals.
+WEB_EXTS = (".html", ".css", ".js", ".xml", ".svg")
+
 
 def repo_text_files(exts):
     """Every text file that is actually IN the repository, with the given suffixes.
@@ -155,7 +163,7 @@ def test_no_em_or_en_dashes_in_repo_text():
     banned = {"\u2014": "em dash", "\u2013": "en dash", "\u2012": "figure dash",
               "\u2212": "minus sign", "\u2015": "horizontal bar"}
     exts = (".py", ".md", ".json", ".toml", ".spec", ".yml", ".yaml", ".txt",
-            ".cfg", ".ini")
+            ".cfg", ".ini") + WEB_EXTS
     offenders = []
     for path in repo_text_files(exts):
         text = open(path, encoding="utf-8", errors="replace").read()
@@ -267,6 +275,10 @@ def test_the_repository_scanners_actually_read_files():
             ("_gui_files", _gui_files(), "app.py", 10),
             ("repo_text_files(.py)", repo_text_files((".py",)), "engine.py", 60),
             ("repo_text_files(.md)", repo_text_files((".md",)), "README.md", 4),
+            # The website sources: without this line the three scans above would
+            # keep passing if site/ vanished or moved, which is the exact failure
+            # this test exists for - an empty collection satisfies every check.
+            ("repo_text_files(web)", repo_text_files(WEB_EXTS), "style.css", 4),
             ("code_hygiene._pkg_files", test_code_hygiene._pkg_files(), "core.py", 20),
             ("layering._top_level_modules",
              test_layering._top_level_modules(), "engine.py", 15),
@@ -306,7 +318,16 @@ def test_the_repository_scanners_stay_out_of_what_is_not_in_the_repository():
 # Things that must never reach a public repository. Only the mechanical half of
 # the rule lives here - see the note next to the test about the other half.
 PRIVATE_PATTERNS = (
-    (r"[A-Za-z]:[\/]{1,2}Users[\/]", "a Windows user-profile path"),
+    # The backslash spelling is the one that actually leaks - it is what cmd,
+    # PowerShell and a Python traceback print - and until 2026-08-11 this pattern did
+    # not match it. Inside a character class, an escaped forward slash is just a
+    # forward slash, so the class held ONE character and the guard only ever caught
+    # the URL-style spelling. Found by mutation while extending these scans to the
+    # website sources: a probe file carrying a profile path in backslash form passed
+    # this test. After the fix both spellings match and the tracked tree has no hit.
+    # No example is written out here on purpose: this file is repository text, so it
+    # is scanned by the rule it defines, and a literal one would fail the suite.
+    (r"[A-Za-z]:[\\/]{1,2}Users[\\/]", "a Windows user-profile path"),
     (r"/home/[a-z][\w.-]*/", "a Linux home path"),
     (r"/Users/[A-Za-z][\w.-]*/", "a macOS home path"),
     (r"\bgh[pousr]_[A-Za-z0-9]{16,}", "a GitHub token"),
@@ -333,7 +354,8 @@ def test_nothing_private_to_this_machine_reaches_the_public_repository():
     the presence of this test is not mistaken for full coverage.
     """
     import re
-    files = repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml"))
+    files = repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml")
+                            + WEB_EXTS)
     check("the privacy scan actually read the repository", len(files) >= 30,
           f"({len(files)} files)")
     for pattern, what in PRIVATE_PATTERNS:
@@ -359,7 +381,8 @@ def test_no_stray_email_addresses_in_the_public_tree():
     import re
     rx = re.compile(r"[\w.+-]+@[\w-]+\.[A-Za-z]{2,}")
     offenders = []
-    for path in repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml")):
+    for path in repo_text_files((".py", ".md", ".json", ".txt", ".toml", ".spec", ".yml")
+                                + WEB_EXTS):
         name = os.path.basename(path)
         if name in EMAIL_ALLOWED_IN:
             continue

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -426,6 +426,151 @@ def test_the_error_page_is_a_file_pages_serves_and_asks_not_to_be_indexed(tmp_pa
     check(".nojekyll is written", ".nojekyll" in written)
 
 
+# -- the workflow that publishes it --------------------------------------------- #
+# Read as text, not through a YAML library: PyYAML is not in requirements-dev.txt, so
+# importing it would make these tests an error on a fresh checkout. Every scan below
+# fails when it cannot find what it expects - a guard that passes vacuously because
+# the file moved under it is not a guard. Same approach as
+# test_version_and_release.py::test_ci_and_release_freeze_the_same_python.
+
+WORKFLOW = os.path.join(ROOT, ".github", "workflows", "pages.yml")
+
+
+def _workflow():
+    """The workflow with its comment lines removed.
+
+    A comment is not configuration, and a scan over raw text cannot tell them apart.
+    Found immediately: the first version of the permissions check below failed on this
+    very workflow, because a comment explaining why `pages: write` is NOT granted to
+    the whole file contains those two words. Reading the prose as settings would have
+    been the other failure too - a guard satisfied by a comment claiming the right
+    thing while the setting says something else.
+    """
+    raw = _read(WORKFLOW)
+    check("the Pages workflow is still there and non-trivial", len(raw) > 500,
+          f"({len(raw)} bytes)")
+    return "\n".join(line for line in raw.splitlines()
+                     if not line.lstrip().startswith("#"))
+
+
+def _jobs(text):
+    """The workflow's jobs, as {name: block}. Only what follows the `jobs:` line."""
+    lines = text.splitlines()
+    start = [i for i, line in enumerate(lines) if line.rstrip() == "jobs:"]
+    check("the workflow declares jobs", len(start) == 1, f"({start})")
+    body = lines[start[0] + 1:]
+    heads = [i for i, line in enumerate(body) if re.match(r"^  [A-Za-z0-9_-]+:\s*$", line)]
+    check("the jobs are named", heads, "(none found)")
+    out = {}
+    for position, index in enumerate(heads):
+        end = heads[position + 1] if position + 1 < len(heads) else len(body)
+        out[body[index].strip().rstrip(":")] = "\n".join(body[index:end])
+    return out
+
+
+def test_the_workflow_uploads_exactly_what_it_built(tmp_path):
+    """The directory the generator writes and the directory Pages takes are one.
+
+    A mismatch here is the quietest failure in the whole chain: the build is green,
+    the deployment is green, and the site that goes live is whatever was in the other
+    directory - which is nothing.
+    """
+    text = _workflow()
+    built = re.findall(r"build_site\.py --out (\S+)", text)
+    uploaded = re.findall(r"^\s+path:\s*(\S+)\s*$", text, re.M)
+    check("the workflow builds the site", len(built) == 1, f"({built})")
+    check("the workflow uploads one directory", len(uploaded) == 1, f"({uploaded})")
+    check("it uploads what it built", built[0] == uploaded[0],
+          f"(built {built[0]}, uploaded {uploaded[0]})")
+
+
+def test_the_workflow_rebuilds_when_any_source_of_the_page_changes(tmp_path):
+    """Every input the page is built from is in the paths filter.
+
+    Derived from the registry rather than typed twice: the asset list in
+    `site/site.json` names the files the page ships, and an asset missing from the
+    filter means replacing the icon or the screenshot changes nothing on the live
+    site - and looks exactly like a page nobody edited.
+    """
+    text = _workflow()
+    registry = build_site.load_registry(ROOT)
+    needed = ["site/**", "tools/build_site.py", build_site.THEME_FILE.replace(os.sep, "/")]
+    needed += [asset["source"] for asset in registry.get("assets", [])]
+    for path in needed:
+        check(f"the paths filter covers {path}", f'"{path}"' in text, "(missing)")
+
+
+def test_only_the_job_that_deploys_may_write_to_pages():
+    """Least privilege, and the comment in ci.yml said where it belongs.
+
+    A workflow-level `pages: write` would hand that power to every job in the file,
+    including the one that runs a build and could one day run something else.
+    """
+    text = _workflow()
+    jobs = _jobs(text)
+    top = text.split("jobs:")[0]
+    check("the workflow token only reads the repository by default",
+          re.search(r"(?m)^permissions:\s*$\s+contents: read\s*$", top), f"({top[-200:]})")
+    for scope in ("pages: write", "id-token: write"):
+        check(f"{scope} is not granted at the top of the file", scope not in top)
+        owners = [name for name, block in jobs.items() if scope in block]
+        check(f"exactly one job asks for {scope}", len(owners) == 1, f"({owners})")
+        check(f"{scope} belongs to the job that deploys",
+              "deploy-pages" in jobs[owners[0]], f"({owners})")
+    builders = [name for name, block in jobs.items() if "build_site.py --out" in block]
+    check("the building job asks to READ the Pages configuration, not to write it",
+          "pages: read" in jobs[builders[0]], "(missing)")
+
+
+def test_the_site_guards_run_before_anything_is_published():
+    """The tests in this file gate the publication, in the job that builds it."""
+    text = _workflow()
+    jobs = _jobs(text)
+    builders = [name for name, block in jobs.items() if "build_site.py --out" in block]
+    check("one job builds the site", len(builders) == 1, f"({builders})")
+    block = jobs[builders[0]]
+    check("it runs the site guards", "pytest tests/test_site.py" in block, "(missing)")
+    check("the guards run before the build, not after",
+          block.index("pytest tests/test_site.py") < block.index("build_site.py --out"))
+
+
+def test_a_deployment_is_never_cancelled_half_way():
+    """Cancelling a deploy in flight can leave a half-replaced site, and Pages has
+    no rollback. Late is better."""
+    text = _workflow()
+    check("the workflow serialises deployments",
+          re.search(r"(?m)^concurrency:\s*$\s+group: pages\s*$", text), "(missing)")
+    check("a running deployment is not cancelled",
+          re.search(r"(?m)^\s+cancel-in-progress: false\s*$", text), "(missing)")
+
+
+def test_the_workflow_refuses_to_publish_to_an_address_the_pages_do_not_claim():
+    """The owner's DNS step, enforced instead of remembered.
+
+    Every canonical, hreflang and sitemap entry in the output names `base_url`. If the
+    repository publishes somewhere else - because the custom domain is not set yet -
+    the pages would point at an address that does not serve them, and Google would be
+    reading a set of canonicals aimed into the dark. So the build compares the two and
+    stops, before anything is uploaded.
+    """
+    text = _workflow()
+    jobs = _jobs(text)
+    builders = [name for name, block in jobs.items() if "build_site.py --out" in block]
+    block = jobs[builders[0]]
+    check("the build reads the Pages configuration",
+          "actions/configure-pages@" in block, "(missing)")
+    check("it compares that address with base_url", "base_url" in block, "(missing)")
+    check("the comparison happens before the upload",
+          block.index("base_url") < block.index("upload-pages-artifact"))
+    check("a mismatch stops the run", "sys.exit(1)" in block, "(missing)")
+    deployers = [name for name, b in jobs.items() if "deploy-pages@" in b]
+    check("one job deploys", len(deployers) == 1, f"({deployers})")
+    after = jobs[deployers[0]]
+    for evidence in ('<link rel="canonical"', 'hreflang="x-default"', "sitemap.xml"):
+        check(f"the deployed site is read back for {evidence}", evidence in after,
+              "(missing)")
+
+
 # -- the single sources --------------------------------------------------------- #
 
 def test_the_palette_is_read_out_of_the_theme_module(tmp_path):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -294,8 +294,41 @@ def test_the_social_card_says_the_same_thing_as_the_page(tmp_path):
             check(f"{rel}: {key} matches the page", meta.get(key) == value,
                   f"(got {meta.get(key)!r})")
         for key in ("og:type", "og:site_name", "og:image", "og:locale", "twitter:card",
-                    "twitter:image"):
+                    "twitter:image", "og:image:alt", "twitter:image:alt"):
             check(f"{rel}: {key} is set", meta.get(key), "(missing)")
+
+
+def test_the_card_image_reports_the_size_the_file_really_has(tmp_path):
+    """Dimensions read from the PNG, not typed next to it.
+
+    A number typed into a registry beside an image is a number that stops being true
+    the day the image is replaced, and a card with wrong dimensions reflows or crops
+    in somebody else's timeline, where we never see it.
+    """
+    out, written = _build(tmp_path, "card")
+    registry = build_site.load_registry(ROOT)
+    source = build_site.asset_source(registry, ROOT, registry["og_image"])
+    width, height = build_site._png_size(source)
+    check("the icon is a PNG with real dimensions", width > 0 and height > 0,
+          f"({width}x{height})")
+    for rel in [p for p in written if p.endswith("index.html")]:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        check(f"{rel}: the declared width is the file's width",
+              f'content="{width}"' in page, f"({width})")
+        check(f"{rel}: the declared height is the file's height",
+              f'content="{height}"' in page, f"({height})")
+
+
+def test_the_browser_chrome_colour_comes_from_the_programs_palette(tmp_path):
+    """`theme-color` paints the address bar on a phone, so it is a colour like any
+    other: it lives in theme.py or it becomes a second dark theme."""
+    out, written = _build(tmp_path, "chrome")
+    registry = build_site.load_registry(ROOT)
+    expected = build_site.palette(ROOT, registry["palette"])["--bg"]
+    for rel in [p for p in written if p.endswith(".html")]:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        check(f"{rel}: theme-color is the page background from theme.py",
+              f'<meta name="theme-color" content="{expected}">' in page, f"({expected})")
 
 
 def test_the_structured_data_invents_neither_a_rating_nor_a_version(tmp_path):
@@ -359,6 +392,26 @@ def test_robots_lets_everything_in_and_names_the_sitemap(tmp_path):
     text = _read(os.path.join(out, "robots.txt"))
     check("robots.txt allows crawling", "Disallow: /\n" not in text, f"({text})")
     check("robots.txt names the sitemap", f"Sitemap: {base}/sitemap.xml" in text, f"({text})")
+
+
+def test_the_error_page_works_from_an_address_that_does_not_exist(tmp_path):
+    """The one page whose own address is unknown when it is served.
+
+    GitHub Pages returns `404.html` AT the path that missed and does not redirect, so
+    a relative reference resolves against that path: a miss at `/pl/x/y/` would fetch
+    `/pl/x/y/assets/style.css` and the error page would render unstyled, with a home
+    button pointing back at the address that had just failed. Measured on the built
+    file, because the first version of this page did exactly that.
+    """
+    out, _ = _build(tmp_path, "notfound")
+    page = _read(os.path.join(out, "404.html"))
+    prefix = build_site._root_prefix(build_site.load_registry(ROOT))
+    refs = re.findall(r'(?:href|src)="([^"]+)"', page)
+    check("the error page has links to check", refs, "(none)")
+    for ref in refs:
+        ok = ref.startswith(("http://", "https://", "#")) or ref.startswith(prefix)
+        check(f"404.html: {ref} does not depend on where the page was served from", ok,
+              f"(expected an absolute URL, a fragment, or a path under {prefix})")
 
 
 def test_the_error_page_is_a_file_pages_serves_and_asks_not_to_be_indexed(tmp_path):
@@ -452,7 +505,7 @@ def test_the_sandbox_the_rejection_tests_use_is_itself_valid(tmp_path):
     """An UNMUTATED sandbox has to build, or every rejection test below is vacuous.
 
     ``_fails`` accepts any ``SiteError``, so a sandbox missing one file of its own
-    would make all seven mutations "pass" while proving nothing - the same shape as
+    would make every mutation below "pass" while proving nothing - the same shape as
     the fake packet whose two ports were equal, which made assertions about
     direction hold without checking anything. Measured, not assumed: this builds,
     and each mutation then fails with its own message.
@@ -463,7 +516,7 @@ def test_the_sandbox_the_rejection_tests_use_is_itself_valid(tmp_path):
 
 
 def test_the_build_refuses_a_source_that_would_publish_a_broken_page(tmp_path):
-    """Seven ways to be wrong, each of which still renders a plausible page.
+    """Ten ways to be wrong, each of which still renders a plausible page.
 
     This is the half of the guard that matters: every one of these would go
     unnoticed for months, because the page would look fine.
@@ -503,6 +556,11 @@ def test_the_build_refuses_a_source_that_would_publish_a_broken_page(tmp_path):
     root = _sandbox(tmp_path / "missing_asset")
     os.remove(os.path.join(root, "bean.png"))
     _fails(root, out, "a listed asset is not in the repository")
+
+    root = _sandbox(tmp_path / "card_image_nothing_produces")
+    _edit_json(os.path.join(root, "site", "site.json"),
+               lambda d: d.update({"og_image": "assets/nothing-makes-this.png"}))
+    _fails(root, out, "the social card names an image the build does not produce")
 
     root = _sandbox(tmp_path / "unknown_schema")
     _edit_json(os.path.join(root, "site", "pages", "home", "page.json"),

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,363 @@
+"""The website generator: the page must never publish quietly-broken SEO.
+
+Why these guards and not others
+-------------------------------
+A landing page fails differently from a program. Nothing crashes: the page renders,
+the visitor sees something reasonable, and the mistake is a truncated description,
+a language nobody can reach, a stylesheet with a misspelled variable, or a download
+button pointing at a stale address. None of that shows up in a screenshot, and the
+whole point of the site is the click that leaves it. So the tests spend their effort
+on the two failure modes that are invisible:
+
+* the SOURCES are wrong in a way that still builds (a missing translation, a
+  description search engines will cut, two pages claiming one address) - the builder
+  has to refuse, and here it is held to refusing;
+* the OUTPUT drifts away from the program (a second dark theme, a link that no
+  longer reaches the releases page) - the palette is read out of ``theme.py`` and
+  the URLs out of one registry, and these check that it stayed that way.
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+from fakes import ROOT, check
+
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+import build_site                                                   # noqa: E402
+
+SITE = os.path.join(ROOT, "site")
+HEX = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b")
+EXTERNAL = re.compile(r'(?:href|src)="((?:https?:)?//[^"]+)"')
+
+
+def _build(tmp_path, name="out"):
+    """Build the real site into a temporary directory and return (out, files)."""
+    out = str(tmp_path / name)
+    return out, build_site.build(ROOT, out)
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _sandbox(base):
+    """A copy of ``site/`` plus the two files the builder reads outside it.
+
+    The listed assets are only copied, never parsed, so a one-byte stand-in keeps a
+    sandbox cheap enough to make one per mutation.
+    """
+    root = str(base)
+    os.makedirs(root, exist_ok=True)
+    shutil.copytree(SITE, os.path.join(root, "site"))
+    gui = os.path.join(root, "beantester", "gui")
+    os.makedirs(gui)
+    shutil.copyfile(os.path.join(ROOT, build_site.THEME_FILE), os.path.join(gui, "theme.py"))
+    for asset in build_site.load_registry(ROOT).get("assets", []):
+        target = os.path.join(root, asset["source"].replace("/", os.sep))
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as handle:
+            handle.write(b"x")
+    return root
+
+
+def _fails(root, out, why):
+    """Assert the build refuses, and say what it should have refused."""
+    try:
+        build_site.build(root, out)
+    except build_site.SiteError:
+        return
+    check("the build refuses when %s" % why, False)
+
+
+def _edit_json(path, mutate):
+    import json
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    mutate(data)
+    with open(path, "w", encoding="utf-8", newline="\n") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2)
+
+
+# -- the output ----------------------------------------------------------------- #
+
+def test_the_builder_writes_a_page_for_every_language(tmp_path):
+    """Every declared language gets a real file, and the default one sits at the root."""
+    out, written = _build(tmp_path)
+    registry = build_site.load_registry(ROOT)
+    check("the build wrote files at all (an empty build passes every check below)",
+          len(written) >= 4, f"({written})")
+    for lang in registry["languages"]:
+        target = os.path.join(out, lang["dir"], "index.html") if lang["dir"] else \
+            os.path.join(out, "index.html")
+        check(f"{lang['code']}: the page exists at {lang['dir'] or '/'}",
+              os.path.isfile(target), f"({target})")
+        html = _read(target)
+        check(f"{lang['code']}: the document declares its language",
+              f'<html lang="{lang["html_lang"]}"' in html)
+        check(f"{lang['code']}: nothing is left unsubstituted",
+              "{{" not in html, f"({[m for m in re.findall(r'{{.*?}}', html)][:3]})")
+
+
+def test_every_page_carries_a_title_and_a_description_search_engines_can_show(tmp_path):
+    """Bounds, not presence: a description cut in half is invisible from the source."""
+    out, written = _build(tmp_path)
+    pages = [p for p in written if p.endswith("index.html")]
+    check("there are pages to measure", pages, "(none)")
+    for rel in pages:
+        html = _read(os.path.join(out, rel.replace("/", os.sep)))
+        title = re.search(r"<title>(.*?)</title>", html, re.S)
+        desc = re.search(r'<meta name="description" content="(.*?)">', html, re.S)
+        check(f"{rel}: has a title", title and title.group(1).strip())
+        check(f"{rel}: has a description", desc and desc.group(1).strip())
+        check(f"{rel}: the title fits in {build_site.TITLE_LEN[1]} characters",
+              len(title.group(1)) <= build_site.TITLE_LEN[1], f"({len(title.group(1))})")
+        check(f"{rel}: the description fits in {build_site.DESC_LEN[1]} characters",
+              len(desc.group(1)) <= build_site.DESC_LEN[1], f"({len(desc.group(1))})")
+
+
+def test_the_download_button_points_at_the_release_page(tmp_path):
+    """The site has exactly one job: send the visitor to the download.
+
+    Pinned to ``/releases/latest`` rather than to an asset file name, because the
+    asset carries the version (``BeanNetworkTester-v0.4.0-windows-x64.zip``), so a
+    direct link would 404 for every release after the one it was written for.
+    """
+    out, written = _build(tmp_path)
+    expected = "%s/releases/latest" % build_site.load_registry(ROOT)["repo_url"].rstrip("/")
+    for rel in [p for p in written if p.endswith("index.html")]:
+        html = _read(os.path.join(out, rel.replace("/", os.sep)))
+        check(f"{rel}: links to the releases page", f'href="{expected}"' in html,
+              f"(expected {expected})")
+
+
+def test_the_page_asks_nothing_of_a_third_party(tmp_path):
+    """No external font, script, image or tracker - measured on the output.
+
+    Two reasons, and the second is the one a test can hold: the program sends no
+    data anywhere, so a page that quietly reports its visitors to somebody else
+    would contradict it, and every third-party request is a request that can be
+    slow, blocked or gone.
+    """
+    out, written = _build(tmp_path)
+    registry = build_site.load_registry(ROOT)
+    allowed = (registry["base_url"], registry["repo_url"].rstrip("/"))
+    for rel in [p for p in written if p.endswith(".html")]:
+        html = _read(os.path.join(out, rel.replace("/", os.sep)))
+        for url in EXTERNAL.findall(html):
+            check(f"{rel}: {url} is one of ours", url.startswith(allowed),
+                  f"(allowed: {allowed})")
+
+
+def test_the_language_switcher_reaches_every_language_and_marks_the_current_one(tmp_path):
+    """A language nobody can click is a language that does not exist."""
+    out, _ = _build(tmp_path)
+    registry = build_site.load_registry(ROOT)
+    for lang in registry["languages"]:
+        rel = os.path.join(lang["dir"], "index.html") if lang["dir"] else "index.html"
+        html = _read(os.path.join(out, rel))
+        check(f"{lang['code']}: the current language is marked, not linked",
+              f'<span aria-current="page" lang="{lang["html_lang"]}">{lang["name"]}</span>' in html)
+        for other in registry["languages"]:
+            if other["code"] == lang["code"]:
+                continue
+            check(f"{lang['code']}: links to {other['code']}",
+                  f'hreflang="{other["code"]}"' in html)
+
+
+def test_building_twice_writes_the_same_bytes(tmp_path):
+    """Second run, same target: the class of bug only a repeat can see.
+
+    A timestamp, a set iterated in hash order or a file left behind by the first run
+    all look perfect once. This is also what keeps a deploy from reporting changes
+    that are not changes.
+    """
+    out = str(tmp_path / "twice")
+    first = build_site.build(ROOT, out)
+    snapshot = {rel: _read(os.path.join(out, rel.replace("/", os.sep)))
+                for rel in first if rel.endswith((".html", ".css"))}
+    second = build_site.build(ROOT, out)
+    check("the same files are written", first == second,
+          f"(only in one run: {set(first) ^ set(second)})")
+    for rel, text in snapshot.items():
+        check(f"{rel}: identical on the second build",
+              text == _read(os.path.join(out, rel.replace("/", os.sep))))
+
+
+def test_the_builder_runs_as_a_script(tmp_path):
+    """The workflow calls it as a script, so the script path is the one under test."""
+    out = str(tmp_path / "cli")
+    proc = subprocess.run([sys.executable, os.path.join(ROOT, "tools", "build_site.py"),
+                           "--out", out], capture_output=True, text=True)
+    check("the builder exits clean", proc.returncode == 0, f"({proc.stderr[-400:]})")
+    check("it says what it wrote", "wrote" in proc.stdout, f"({proc.stdout[:200]})")
+    check("the page is there", os.path.isfile(os.path.join(out, "index.html")))
+
+
+# -- the single sources --------------------------------------------------------- #
+
+def test_the_palette_is_read_out_of_the_theme_module(tmp_path):
+    """The page and the program must not become two different dark themes.
+
+    The parser also has to survive the shape ``theme.py`` really uses: ``FG, MUT``
+    and ``ACC, OK, WARN`` are tuple assignments, and a reader that only understood
+    ``NAME = value`` would miss five of the colours and fall back to nothing.
+    """
+    registry = build_site.load_registry(ROOT)
+    colours = build_site.palette(ROOT, registry["palette"])
+    check("every mapped variable got a colour",
+          set(colours) == set(registry["palette"]), f"({sorted(colours)})")
+    theme = _read(os.path.join(ROOT, build_site.THEME_FILE))
+    for var, name in registry["palette"].items():
+        value = colours[var]
+        check(f"{var} is {name} from theme.py, verbatim",
+              re.search(r"\b%s\b[^\n]*%s" % (re.escape(name), re.escape(value)), theme),
+              f"({value})")
+    out, _ = _build(tmp_path, "palette")
+    css = _read(os.path.join(out, "assets", "style.css"))
+    for var, value in colours.items():
+        check(f"the stylesheet declares {var}", "%s: %s;" % (var, value) in css)
+
+
+def test_no_colour_is_written_down_a_second_time(tmp_path):
+    """A hex literal under site/ would be a colour living in two places.
+
+    Derived shades come from ``color-mix`` so that "slightly lighter accent" cannot
+    become an independent value that stops following the program.
+    """
+    offenders = []
+    for dirpath, _dirnames, filenames in os.walk(SITE):
+        for name in filenames:
+            if not name.endswith((".html", ".css", ".json", ".svg", ".js")):
+                continue
+            path = os.path.join(dirpath, name)
+            for number, line in enumerate(_read(path).splitlines(), 1):
+                if HEX.search(line):
+                    offenders.append("%s:%d" % (os.path.relpath(path, ROOT), number))
+    check("no hex colour under site/ (they live in beantester/gui/theme.py)",
+          not offenders, f"({offenders[:5]})")
+
+
+def test_the_stylesheet_uses_only_variables_it_declares(tmp_path):
+    """A misspelled ``var(--acccent)`` renders an unstyled page and nothing else."""
+    out, _ = _build(tmp_path, "vars")
+    css = _read(os.path.join(out, "assets", "style.css"))
+    declared = set(re.findall(r"^\s*(--[a-z0-9-]+):", css, re.M))
+    used = set(re.findall(r"var\((--[a-z0-9-]+)", css))
+    check("the scan found variables at all", declared and used,
+          f"(declared {len(declared)}, used {len(used)})")
+    check("every variable the CSS uses is declared", not used - declared,
+          f"({sorted(used - declared)})")
+
+
+def test_every_language_file_carries_the_same_keys_and_real_text():
+    """Convention 9, applied to the site: identical key sets, nothing empty.
+
+    Same rule as ``lang/*.json`` and for the same reason - a half-translated page
+    looks finished, so nobody reports it.
+    """
+    registry = build_site.load_registry(ROOT)
+    codes = build_site.language_codes(registry)
+    texts = build_site.load_i18n(ROOT, codes, registry["default_language"])
+    reference = set(texts[registry["default_language"]])
+    check("there are texts to compare", len(reference) >= 10, f"({len(reference)})")
+    for code in codes:
+        check(f"{code}: the same keys as {registry['default_language']}",
+              set(texts[code]) == reference,
+              f"({sorted(set(texts[code]) ^ reference)[:5]})")
+
+
+# -- refusing to publish something broken --------------------------------------- #
+
+def test_the_sandbox_the_rejection_tests_use_is_itself_valid(tmp_path):
+    """An UNMUTATED sandbox has to build, or every rejection test below is vacuous.
+
+    ``_fails`` accepts any ``SiteError``, so a sandbox missing one file of its own
+    would make all seven mutations "pass" while proving nothing - the same shape as
+    the fake packet whose two ports were equal, which made assertions about
+    direction hold without checking anything. Measured, not assumed: this builds,
+    and each mutation then fails with its own message.
+    """
+    root = _sandbox(tmp_path / "clean")
+    written = build_site.build(root, str(tmp_path / "clean-out"))
+    check("the sandbox builds when nothing is mutated", len(written) >= 4, f"({written})")
+
+
+def test_the_build_refuses_a_source_that_would_publish_a_broken_page(tmp_path):
+    """Seven ways to be wrong, each of which still renders a plausible page.
+
+    This is the half of the guard that matters: every one of these would go
+    unnoticed for months, because the page would look fine.
+    """
+    out = str(tmp_path / "rejected")
+
+    root = _sandbox(tmp_path / "no_translation")
+    _edit_json(os.path.join(root, "site", "i18n", "pl.json"),
+               lambda d: d.pop("cta.download"))
+    _fails(root, out, "a language is missing a key")
+
+    root = _sandbox(tmp_path / "empty_text")
+    _edit_json(os.path.join(root, "site", "i18n", "pl.json"),
+               lambda d: d.update({"cta.download": "   "}))
+    _fails(root, out, "a translation is blank")
+
+    root = _sandbox(tmp_path / "unknown_placeholder")
+    body = os.path.join(root, "site", "pages", "home", "en.html")
+    with open(body, "a", encoding="utf-8") as handle:
+        handle.write("\n<p>{{cta.nothing_defines_this}}</p>\n")
+    _fails(root, out, "a body names a placeholder nobody defines")
+
+    root = _sandbox(tmp_path / "long_description")
+    _edit_json(os.path.join(root, "site", "pages", "home", "page.json"),
+               lambda d: d["languages"]["en"].update({"description": "x" * 400}))
+    _fails(root, out, "a description is longer than a search result shows")
+
+    root = _sandbox(tmp_path / "missing_body")
+    os.remove(os.path.join(root, "site", "pages", "home", "pl.html"))
+    _fails(root, out, "a page has no body in one of the languages")
+
+    root = _sandbox(tmp_path / "renamed_colour")
+    _edit_json(os.path.join(root, "site", "site.json"),
+               lambda d: d["palette"].update({"--bg": "NO_SUCH_COLOUR"}))
+    _fails(root, out, "theme.py no longer declares a mapped colour")
+
+    root = _sandbox(tmp_path / "missing_asset")
+    os.remove(os.path.join(root, "bean.png"))
+    _fails(root, out, "a listed asset is not in the repository")
+
+
+def test_two_pages_may_not_claim_one_address(tmp_path):
+    """A duplicate slug means one of the two pages silently never ships."""
+    root = _sandbox(tmp_path / "duplicate")
+    home = os.path.join(root, "site", "pages", "home")
+    clone = os.path.join(root, "site", "pages", "zzz-clone")
+    shutil.copytree(home, clone)
+    _edit_json(os.path.join(clone, "page.json"), lambda d: d.update({"id": "zzz-clone"}))
+    _fails(root, str(tmp_path / "dup-out"), "two pages resolve to the same address")
+
+
+def test_the_builder_will_not_write_into_a_directory_that_is_not_a_site(tmp_path):
+    """`--out` is a path a human types, and pruning deletes files.
+
+    So the builder only prunes what looks like its own previous output. Anything
+    else, it refuses to touch.
+    """
+    out = tmp_path / "someones_folder"
+    out.mkdir()
+    (out / "important.txt").write_text("not mine", encoding="utf-8")
+    _fails(ROOT, str(out), "the target holds files that are not a previous build")
+    check("the stranger's file is still there", (out / "important.txt").is_file())
+
+
+def test_a_renamed_page_stops_being_served(tmp_path):
+    """Stale output is the one kind of stale a visitor sees and we do not."""
+    out = str(tmp_path / "pruned")
+    build_site.build(ROOT, out)
+    stale = os.path.join(out, "old-page", "index.html")
+    os.makedirs(os.path.dirname(stale), exist_ok=True)
+    with open(stale, "w", encoding="utf-8") as handle:
+        handle.write("<!doctype html>")
+    build_site.build(ROOT, out)
+    check("the file left by an earlier build is gone", not os.path.exists(stale))

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -29,7 +29,10 @@ import build_site                                                   # noqa: E402
 
 SITE = os.path.join(ROOT, "site")
 HEX = re.compile(r"#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\b")
-EXTERNAL = re.compile(r'(?:href|src)="((?:https?:)?//[^"]+)"')
+EXTERNAL = re.compile(r'(?:href|src|srcset|content)="((?:https?:)?//[^"]+)"')
+# A stylesheet reaches the network too, and a web font is exactly how a page starts
+# telling somebody else who is reading it.
+CSS_EXTERNAL = re.compile(r'(?:@import\s+|url\()\s*["\']?((?:https?:)?//[^"\')\s]+)')
 
 
 def _build(tmp_path, name="out"):
@@ -96,7 +99,7 @@ def test_the_builder_writes_a_page_for_every_language(tmp_path):
               os.path.isfile(target), f"({target})")
         html = _read(target)
         check(f"{lang['code']}: the document declares its language",
-              f'<html lang="{lang["html_lang"]}"' in html)
+              f'<html lang="{lang["code"]}"' in html)
         check(f"{lang['code']}: nothing is left unsubstituted",
               "{{" not in html, f"({[m for m in re.findall(r'{{.*?}}', html)][:3]})")
 
@@ -104,7 +107,7 @@ def test_the_builder_writes_a_page_for_every_language(tmp_path):
 def test_every_page_carries_a_title_and_a_description_search_engines_can_show(tmp_path):
     """Bounds, not presence: a description cut in half is invisible from the source."""
     out, written = _build(tmp_path)
-    pages = [p for p in written if p.endswith("index.html")]
+    pages = [p for p in written if p.endswith(".html")]
     check("there are pages to measure", pages, "(none)")
     for rel in pages:
         html = _read(os.path.join(out, rel.replace("/", os.sep)))
@@ -140,15 +143,47 @@ def test_the_page_asks_nothing_of_a_third_party(tmp_path):
     data anywhere, so a page that quietly reports its visitors to somebody else
     would contradict it, and every third-party request is a request that can be
     slow, blocked or gone.
+
+    Checked by HOST, not by string prefix: a first version compared the start of the
+    URL against ours, which a host like `github.com.example.net` satisfies. And the
+    CSS is scanned too - `@import` and `url()` are requests as much as a `src` is,
+    and the first version could not see a web font at all.
     """
+    from urllib.parse import urlsplit
     out, written = _build(tmp_path)
     registry = build_site.load_registry(ROOT)
-    allowed = (registry["base_url"], registry["repo_url"].rstrip("/"))
+    allowed = {urlsplit(registry["base_url"]).netloc.lower(),
+               urlsplit(registry["repo_url"]).netloc.lower()}
+    check("the allow list resolved to real hosts", all(allowed) and len(allowed) == 2,
+          f"({allowed})")
+
+    urls = []
+    for rel in written:
+        if not rel.endswith((".html", ".css")):
+            continue
+        text = _read(os.path.join(out, rel.replace("/", os.sep)))
+        urls += [(rel, u) for u in EXTERNAL.findall(text)]
+        urls += [(rel, u) for u in CSS_EXTERNAL.findall(text)]
+    for rel, url in urls:
+        host = urlsplit(url if "//" in url else "//" + url).netloc.lower()
+        check(f"{rel}: {url} is one of ours", host in allowed, f"(allowed: {sorted(allowed)})")
+
+
+def test_every_page_has_one_headline_and_no_image_without_a_description(tmp_path):
+    """Two mechanical rules that no screenshot shows.
+
+    A page with two ``h1`` elements, or none, tells a crawler nothing about what it
+    is. An image without ``alt`` is invisible to a screen reader and to image search
+    alike, and it is the easiest thing in the world to leave out.
+    """
+    out, written = _build(tmp_path)
     for rel in [p for p in written if p.endswith(".html")]:
-        html = _read(os.path.join(out, rel.replace("/", os.sep)))
-        for url in EXTERNAL.findall(html):
-            check(f"{rel}: {url} is one of ours", url.startswith(allowed),
-                  f"(allowed: {allowed})")
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        check(f"{rel}: exactly one h1", len(re.findall(r"<h1[\s>]", page)) == 1,
+              f"({len(re.findall(r'<h1[\\s>]', page))})")
+        for tag in re.findall(r"<img\b[^>]*>", page):
+            check(f"{rel}: every image describes itself ({tag[:60]})",
+                  re.search(r'\balt="', tag))
 
 
 def test_the_language_switcher_reaches_every_language_and_marks_the_current_one(tmp_path):
@@ -159,7 +194,7 @@ def test_the_language_switcher_reaches_every_language_and_marks_the_current_one(
         rel = os.path.join(lang["dir"], "index.html") if lang["dir"] else "index.html"
         html = _read(os.path.join(out, rel))
         check(f"{lang['code']}: the current language is marked, not linked",
-              f'<span aria-current="page" lang="{lang["html_lang"]}">{lang["name"]}</span>' in html)
+              f'<span aria-current="page" lang="{lang["code"]}">{lang["name"]}</span>' in html)
         for other in registry["languages"]:
             if other["code"] == lang["code"]:
                 continue
@@ -194,6 +229,148 @@ def test_the_builder_runs_as_a_script(tmp_path):
     check("the builder exits clean", proc.returncode == 0, f"({proc.stderr[-400:]})")
     check("it says what it wrote", "wrote" in proc.stdout, f"({proc.stdout[:200]})")
     check("the page is there", os.path.isfile(os.path.join(out, "index.html")))
+
+
+# -- the layer search engines read ---------------------------------------------- #
+
+def test_every_indexable_page_declares_itself_canonical(tmp_path):
+    """One canonical, absolute, and pointing at the page it sits on.
+
+    A relative or missing canonical lets a crawler pick which of several addresses
+    is the real one, and a canonical copied from another page hands the ranking to
+    that page. Both are silent.
+    """
+    out, written = _build(tmp_path)
+    base = build_site.load_registry(ROOT)["base_url"]
+    for rel in [p for p in written if p.endswith("index.html")]:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        found = re.findall(r'<link rel="canonical" href="([^"]+)">', page)
+        check(f"{rel}: exactly one canonical", len(found) == 1, f"({found})")
+        expected = "%s/%s" % (base, rel[:-len("index.html")])
+        check(f"{rel}: the canonical is this page, absolute", found[0] == expected,
+              f"(got {found[0]}, expected {expected})")
+
+
+def test_the_language_annotations_are_reciprocal_with_one_x_default(tmp_path):
+    """Google's two hard requirements for hreflang, checked across the real files.
+
+    Each version must list ITSELF as well as every other, or the whole set can be
+    ignored - so this reads every page and compares the sets, rather than trusting
+    that one generator wrote them all the same way. And exactly one ``x-default``,
+    because two is undefined behaviour dressed as thoroughness.
+    """
+    out, written = _build(tmp_path)
+    registry = build_site.load_registry(ROOT)
+    base = registry["base_url"]
+    pages = [p for p in written if p.endswith("index.html")]
+    expected = {lang["code"]: "%s/%s" % (base, lang["dir"] + "/" if lang["dir"] else "")
+                for lang in registry["languages"]}
+    for rel in pages:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        pairs = dict(re.findall(r'<link rel="alternate" hreflang="([^"]+)" href="([^"]+)">',
+                                page))
+        for code, url in expected.items():
+            check(f"{rel}: lists {code} (including itself)", pairs.get(code) == url,
+                  f"(got {pairs.get(code)}, expected {url})")
+        x_default = re.findall(r'hreflang="x-default" href="([^"]+)"', page)
+        check(f"{rel}: exactly one x-default", len(x_default) == 1, f"({x_default})")
+        check(f"{rel}: x-default is the default language",
+              x_default[0] == expected[registry["default_language"]], f"({x_default[0]})")
+
+
+def test_the_social_card_says_the_same_thing_as_the_page(tmp_path):
+    """A card that contradicts the page is what gets shared, not the page."""
+    out, written = _build(tmp_path)
+    for rel in [p for p in written if p.endswith("index.html")]:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        title = re.search(r"<title>(.*?)</title>", page, re.S).group(1)
+        desc = re.search(r'<meta name="description" content="(.*?)">', page, re.S).group(1)
+        canonical = re.search(r'<link rel="canonical" href="([^"]+)">', page).group(1)
+        meta = dict(re.findall(r'<meta (?:property|name)="((?:og|twitter):[^"]+)" '
+                               r'content="([^"]*)">', page))
+        for key, value in (("og:title", title), ("og:description", desc),
+                           ("og:url", canonical), ("twitter:title", title),
+                           ("twitter:description", desc)):
+            check(f"{rel}: {key} matches the page", meta.get(key) == value,
+                  f"(got {meta.get(key)!r})")
+        for key in ("og:type", "og:site_name", "og:image", "og:locale", "twitter:card",
+                    "twitter:image"):
+            check(f"{rel}: {key} is set", meta.get(key), "(missing)")
+
+
+def test_the_structured_data_invents_neither_a_rating_nor_a_version(tmp_path):
+    """The honest half of the schema, and the half a later session might "fix".
+
+    Google's software-app rich result needs ``aggregateRating`` or ``review``. This
+    project has neither, so the markup is not rich-result eligible - and the fix for
+    that is NOT to write a number down. A rating nobody gave is a fabricated review.
+    ``softwareVersion`` is absent for the same reason the page prints no version: the
+    file naming it names the NEXT release from the moment it is bumped.
+    """
+    import json as jsonlib
+    out, written = _build(tmp_path)
+    blocks = 0
+    for rel in [p for p in written if p.endswith(".html")]:
+        page = _read(os.path.join(out, rel.replace("/", os.sep)))
+        for raw in re.findall(r'<script type="application/ld\+json">\n(.*?)\n</script>',
+                              page, re.S):
+            blocks += 1
+            check(f"{rel}: the block does not close its own script element",
+                  "</script>" not in raw)
+            data = jsonlib.loads(raw.replace("\\u003c", "<"))
+            check(f"{rel}: it is a SoftwareApplication",
+                  data.get("@type") == "SoftwareApplication", f"({data.get('@type')})")
+            for field in ("name", "url", "operatingSystem", "downloadUrl"):
+                check(f"{rel}: {field} is set", data.get(field), "(missing)")
+            check(f"{rel}: a free app declares the price Google requires",
+                  data.get("offers", {}).get("price") == "0", f"({data.get('offers')})")
+            for invented in ("aggregateRating", "review", "ratingValue", "softwareVersion"):
+                check(f"{rel}: no {invented} (nobody gave us one)", invented not in data)
+    check("the site carries structured data at all", blocks >= 1, f"({blocks})")
+
+
+def test_the_sitemap_lists_exactly_the_pages_that_may_be_indexed(tmp_path):
+    """Both directions: every indexable page is in it, and nothing else is.
+
+    A missing page is a page Google finds late. An extra entry is worse - a sitemap
+    that lists a 404 or a noindex page is a sitemap Search Console reports as broken,
+    and the report is about the sitemap, not about the page.
+    """
+    from xml.etree import ElementTree
+    out, written = _build(tmp_path)
+    base = build_site.load_registry(ROOT)["base_url"]
+    xml = _read(os.path.join(out, "sitemap.xml"))
+    root = ElementTree.fromstring(xml)
+    ns = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    listed = sorted(node.text for node in root.findall("s:url/s:loc", ns))
+    indexable = sorted("%s/%s" % (base, rel[:-len("index.html")])
+                       for rel in written if rel.endswith("index.html"))
+    check("the sitemap lists every indexable page", listed == indexable,
+          f"(only in one: {set(listed) ^ set(indexable)})")
+    check("the 404 page is not offered as a destination",
+          not any("404" in loc for loc in listed), f"({listed})")
+    check("every entry is absolute", all(loc.startswith(base) for loc in listed))
+
+
+def test_robots_lets_everything_in_and_names_the_sitemap(tmp_path):
+    """The pointer is the only line here that does any work."""
+    out, _ = _build(tmp_path)
+    base = build_site.load_registry(ROOT)["base_url"]
+    text = _read(os.path.join(out, "robots.txt"))
+    check("robots.txt allows crawling", "Disallow: /\n" not in text, f"({text})")
+    check("robots.txt names the sitemap", f"Sitemap: {base}/sitemap.xml" in text, f"({text})")
+
+
+def test_the_error_page_is_a_file_pages_serves_and_asks_not_to_be_indexed(tmp_path):
+    """GitHub Pages serves `/404.html` on a miss, and only that path."""
+    out, written = _build(tmp_path)
+    check("404.html sits at the root", "404.html" in written, f"({written})")
+    page = _read(os.path.join(out, "404.html"))
+    check("it asks not to be indexed", '<meta name="robots" content="noindex">' in page)
+    check("it carries no canonical", "rel=\"canonical\"" not in page)
+    check("it carries no language alternates", 'rel="alternate"' not in page)
+    check("it offers a way out", "href=" in page)
+    check(".nojekyll is written", ".nojekyll" in written)
 
 
 # -- the single sources --------------------------------------------------------- #
@@ -326,6 +503,16 @@ def test_the_build_refuses_a_source_that_would_publish_a_broken_page(tmp_path):
     root = _sandbox(tmp_path / "missing_asset")
     os.remove(os.path.join(root, "bean.png"))
     _fails(root, out, "a listed asset is not in the repository")
+
+    root = _sandbox(tmp_path / "unknown_schema")
+    _edit_json(os.path.join(root, "site", "pages", "home", "page.json"),
+               lambda d: d.update({"schema": "Prodcut"}))
+    _fails(root, out, "a page asks for a kind of structured data that does not exist")
+
+    root = _sandbox(tmp_path / "translated_error_page")
+    _edit_json(os.path.join(root, "site", "pages", "404", "page.json"),
+               lambda d: d["languages"].update({"pl": dict(d["languages"]["en"])}))
+    _fails(root, out, "a single-output page declares a language that will never be written")
 
 
 def test_two_pages_may_not_claim_one_address(tmp_path):

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -109,9 +109,15 @@ def load_registry(root):
     if reg["base_url"].endswith("/"):
         raise SiteError("site.json: base_url must not end with '/' (it is joined with paths)")
 
+    # One code per language, used for THREE things: the directory, the `lang`
+    # attribute and `hreflang`. There used to be a separate `html_lang` field
+    # holding the same value in both languages, which is a second place for one
+    # fact and would have drifted the day somebody edited one of them. The code is
+    # the BCP-47 tag (`pt-BR` if it ever comes to that), and tag matching is
+    # case-insensitive, so the lower-case directory name is the same tag.
     codes, dirs = [], []
     for lang in reg["languages"]:
-        for key in ("code", "name", "html_lang", "dir"):
+        for key in ("code", "name", "dir"):
             if key not in lang:
                 raise SiteError("site.json: language %r has no '%s'" % (lang, key))
         codes.append(lang["code"])
@@ -211,11 +217,18 @@ def load_pages(root, registry):
     A page exists in EVERY declared language or the build fails. Adding a language
     is meant to be a directory of files, and the honest moment to find out that a
     translation is missing is here, not in a search result.
+
+    Two declared exceptions, both data rather than a magic page name:
+    * ``output`` writes the page to one exact path (``404.html``, which is the file
+      GitHub Pages serves for a miss) in the default language only. Pages serves one
+      error document per site, so a translated set of them would be dead weight.
+    * ``noindex`` keeps the page out of the sitemap and gives it a robots meta
+      instead of a canonical. An error page that advertises itself as a destination
+      is an error page in search results.
     """
     base = os.path.join(root, SITE_DIR, "pages")
     if not os.path.isdir(base):
         raise SiteError("no page directory: %s" % base)
-    codes = language_codes(registry)
 
     pages, seen = [], {}
     for page_id in sorted(os.listdir(base)):
@@ -226,13 +239,24 @@ def load_pages(root, registry):
         if meta.get("id") != page_id:
             raise SiteError("pages/%s/page.json: 'id' must be %r, not %r"
                             % (page_id, page_id, meta.get("id")))
+        if meta.get("schema") not in (None, "software_application"):
+            raise SiteError("pages/%s/page.json: unknown schema %r "
+                            "(the only kind today is 'software_application')"
+                            % (page_id, meta.get("schema")))
+        codes = ([registry["default_language"]] if meta.get("output")
+                 else language_codes(registry))
         per_lang = meta.get("languages") or {}
         missing = [c for c in codes if c not in per_lang]
         if missing:
             raise SiteError("pages/%s: no metadata for language(s) %s" % (page_id, missing))
+        if meta.get("output") and sorted(per_lang) != codes:
+            raise SiteError("pages/%s: a page with 'output' is written once, in %s only, "
+                            "so it must declare exactly that language (declares %s)"
+                            % (page_id, codes[0], sorted(per_lang)))
 
-        page = {"id": page_id, "order": meta.get("order", 999),
-                "in_nav": bool(meta.get("in_nav", False)), "languages": {}}
+        page = {"id": page_id, "order": meta.get("order", 999), "languages": {},
+                "output": meta.get("output"), "noindex": bool(meta.get("noindex")),
+                "schema": meta.get("schema"), "codes": codes}
         for code in codes:
             entry = per_lang[code]
             slug = entry.get("slug", None)
@@ -250,11 +274,16 @@ def load_pages(root, registry):
                                 % (page_id, code, len(description), *DESC_LEN))
 
             lang = _language(registry, code)
-            dir_path = posixpath.join(lang["dir"], slug).strip("/")
-            if dir_path in seen:
-                raise SiteError("pages/%s [%s]: '%s' is already taken by %s"
-                                % (page_id, code, dir_path or "/", seen[dir_path]))
-            seen[dir_path] = "%s [%s]" % (page_id, code)
+            if page["output"]:
+                # Written to one exact file at the root, so it owns no directory and
+                # cannot collide with a page that does.
+                dir_path = ""
+            else:
+                dir_path = posixpath.join(lang["dir"], slug).strip("/")
+                if dir_path in seen:
+                    raise SiteError("pages/%s [%s]: '%s' is already taken by %s"
+                                    % (page_id, code, dir_path or "/", seen[dir_path]))
+                seen[dir_path] = "%s [%s]" % (page_id, code)
 
             page["languages"][code] = {
                 "slug": slug, "title": title, "description": description,
@@ -313,6 +342,147 @@ def _merge(context, extra, where):
     return context
 
 
+def _absolute(base_url, dir_path):
+    """The public address of a page directory, with the trailing slash Pages serves."""
+    return "%s/%s" % (base_url, dir_path + "/" if dir_path else "")
+
+
+def head_meta(page, code, registry, texts, description):
+    """Canonical, hreflang, social cards and structured data, as HTML.
+
+    Composed here and not in the template because the set differs per page and the
+    template language has no conditionals - and because every one of these is a
+    claim a test can then read back out of the output.
+
+    Two decisions worth keeping straight:
+    * ``hreflang`` is emitted for EVERY language including this one, which is what
+      makes the annotations reciprocal - Google ignores a set where a version does
+      not list itself. Exactly one ``x-default``, pointing at the default language.
+    * a page marked ``noindex`` (the 404) gets that and nothing else. A canonical or
+      an alternate on an error page tells a crawler the error page is a destination.
+    """
+    entry = page["languages"][code]
+    base = registry["base_url"]
+    if page.get("noindex"):
+        return Raw('<meta name="robots" content="noindex">')
+
+    canonical = _absolute(base, entry["dir_path"])
+    lines = ['<link rel="canonical" href="%s">' % html.escape(canonical, quote=True)]
+    for lang in registry["languages"]:
+        target = _absolute(base, page["languages"][lang["code"]]["dir_path"])
+        lines.append('<link rel="alternate" hreflang="%s" href="%s">'
+                     % (html.escape(lang["code"], quote=True),
+                        html.escape(target, quote=True)))
+    default_url = _absolute(base, page["languages"][registry["default_language"]]["dir_path"])
+    lines.append('<link rel="alternate" hreflang="x-default" href="%s">'
+                 % html.escape(default_url, quote=True))
+
+    # A square 256 px icon is what the project has. `summary` is the card that fits
+    # it: `summary_large_image` wants roughly 2:1 and would crop or letterbox this.
+    # A dedicated banner is a drawing job, not a build job.
+    image = "%s/%s" % (base, registry["og_image"].lstrip("/"))
+    lang = _language(registry, code)
+    social = [("og:type", "website"), ("og:site_name", texts[code]["site.name"]),
+              ("og:title", entry["title"]), ("og:description", description),
+              ("og:url", canonical), ("og:image", image),
+              ("og:locale", lang.get("og_locale", code))]
+    social += [("og:locale:alternate", other.get("og_locale", other["code"]))
+               for other in registry["languages"] if other["code"] != code]
+    for prop, value in social:
+        lines.append('<meta property="%s" content="%s">'
+                     % (prop, html.escape(str(value), quote=True)))
+    for name, value in (("twitter:card", "summary"), ("twitter:title", entry["title"]),
+                        ("twitter:description", description), ("twitter:image", image)):
+        lines.append('<meta name="%s" content="%s">'
+                     % (name, html.escape(str(value), quote=True)))
+
+    if page.get("schema") == "software_application":
+        lines.append(_software_json_ld(registry, texts[code], canonical, description, code))
+    return Raw("\n".join(lines))
+
+
+def _software_json_ld(registry, texts, canonical, description, code):
+    """``SoftwareApplication``, honestly: no rating, and no version.
+
+    Google's rich result for a software app needs ``aggregateRating`` or ``review``.
+    This project has neither - there is no rating to report - and inventing one
+    would be a fabricated review, so the markup describes the application and does
+    not become rich-result eligible. That is a deliberate trade, and the test
+    ``test_the_structured_data_invents_neither_a_rating_nor_a_version`` keeps a
+    later session from "fixing" it with a number nobody gave us.
+
+    ``softwareVersion`` is left out for the same reason the page does not print a
+    version: VERSION.txt names the next release from the moment it is bumped, which
+    is before that release exists.
+    """
+    software = registry.get("software") or {}
+    data = {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "applicationCategory": software.get("application_category", "DeveloperApplication"),
+        "author": {"@type": "Person", "name": appinfo.AUTHOR},
+        "description": description,
+        "downloadUrl": "%s/releases/latest" % registry["repo_url"].rstrip("/"),
+        "inLanguage": code,
+        "isAccessibleForFree": True,
+        "license": software.get("license_url", ""),
+        "name": texts["site.name"],
+        "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+        "operatingSystem": software.get("operating_system", ""),
+        "url": canonical,
+    }
+    # `</script>` inside the block would end the element early, so the one character
+    # that can do that is escaped. sort_keys keeps two builds byte-identical.
+    body = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+    return '<script type="application/ld+json">\n%s\n</script>' % body.replace("<", "\\u003c")
+
+
+def sitemap(pages, registry):
+    """Every indexable page, with its language alternates.
+
+    No ``lastmod``: it would need a clock, which would make two builds differ, and a
+    date that is not the real date of the change is worse than none. Sitemaps carry
+    the alternates as well as the pages do, which is what Google asks for when a set
+    of localised pages is meant to be read as one.
+    """
+    base = registry["base_url"]
+    out = ['<?xml version="1.0" encoding="UTF-8"?>',
+           '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"',
+           '        xmlns:xhtml="http://www.w3.org/1999/xhtml">']
+    for page in pages:
+        if page.get("noindex") or page.get("output"):
+            continue
+        for code in language_codes(registry):
+            out.append("  <url>")
+            out.append("    <loc>%s</loc>"
+                       % html.escape(_absolute(base, page["languages"][code]["dir_path"])))
+            for lang in registry["languages"]:
+                target = _absolute(base, page["languages"][lang["code"]]["dir_path"])
+                out.append('    <xhtml:link rel="alternate" hreflang="%s" href="%s"/>'
+                           % (html.escape(lang["code"], quote=True),
+                              html.escape(target, quote=True)))
+            default = _absolute(
+                base, page["languages"][registry["default_language"]]["dir_path"])
+            out.append('    <xhtml:link rel="alternate" hreflang="x-default" href="%s"/>'
+                       % html.escape(default, quote=True))
+            out.append("  </url>")
+    out.append("</urlset>")
+    return "\n".join(out) + "\n"
+
+
+def robots(registry):
+    """Open to everything, and it names the sitemap.
+
+    There is nothing here worth hiding, and the one line that earns its place is the
+    sitemap pointer: it is the only way a crawler finds the file without being told
+    in Search Console.
+    """
+    return ("User-agent: *\n"
+            "Allow: /\n"
+            "\n"
+            "Sitemap: %s/sitemap.xml\n" % registry["base_url"])
+
+
 def _asset_prefix(dir_path):
     depth = len([part for part in dir_path.split("/") if part])
     return "../" * depth
@@ -331,28 +501,37 @@ def _relative_url(from_dir, to_dir):
     return rel if rel.endswith("/") else rel + "/"
 
 
-def language_switcher(page, current_code, registry):
+def language_switcher(page, current_code, registry, label):
     """The language row in the header, as HTML.
 
     Built here rather than in the template because the template language has no
     loops, and a hand-written row would go stale the moment a third language is
     added - which is exactly the drift this project keeps losing to.
+
+    A page that exists in one language only (the 404) gets no row at all. Offering a
+    language this page does not have would be a link to a miss, from the page that
+    exists because of a miss.
     """
+    if len(page["codes"]) < 2:
+        return Raw("")
     parts = []
     here = page["languages"][current_code]["dir_path"]
     for lang in registry["languages"]:
         code = lang["code"]
+        if code not in page["languages"]:
+            continue
         name = html.escape(lang["name"], quote=True)
         if code == current_code:
             parts.append('<span aria-current="page" lang="%s">%s</span>'
-                         % (html.escape(lang["html_lang"], quote=True), name))
+                         % (html.escape(code, quote=True), name))
         else:
             target = page["languages"][code]["dir_path"]
             parts.append('<a href="%s" hreflang="%s" lang="%s">%s</a>'
                          % (html.escape(_relative_url(here, target), quote=True),
                             html.escape(code, quote=True),
-                            html.escape(lang["html_lang"], quote=True), name))
-    return Raw('<span class="langs">%s</span>' % "".join(parts))
+                            html.escape(code, quote=True), name))
+    return Raw('<span class="langs" role="group" aria-label="%s">%s</span>'
+               % (html.escape(label, quote=True), "".join(parts)))
 
 
 def page_context(page, code, registry, texts, home_dir):
@@ -369,13 +548,14 @@ def page_context(page, code, registry, texts, home_dir):
         "site.copyright": appinfo.COPYRIGHT,
         "page.title": entry["title"],
         "page.description": entry["description"],
-        "page.html_lang": lang["html_lang"],
         "page.lang": code,
         "page.url": "%s/%s" % (registry["base_url"],
                                entry["dir_path"] + "/" if entry["dir_path"] else ""),
         "page.asset_prefix": _asset_prefix(entry["dir_path"]),
         "page.home_url": _relative_url(entry["dir_path"], home_dir),
-        "page.language_switcher": language_switcher(page, code, registry),
+        "page.language_switcher": language_switcher(page, code, registry,
+                                                    texts[code]["nav.language"]),
+        "page.head_meta": head_meta(page, code, registry, texts, entry["description"]),
     }, "page %s [%s]" % (page["id"], code))
     return context
 
@@ -431,7 +611,7 @@ def build(root=ROOT, out=None):
     home = next((p for p in pages if p["id"] == "home"), pages[0])
     written = []
     for page in pages:
-        for code in language_codes(registry):
+        for code in page["codes"]:
             entry = page["languages"][code]
             home_dir = home["languages"][code]["dir_path"]
             context = page_context(page, code, registry, texts, home_dir)
@@ -439,9 +619,17 @@ def build(root=ROOT, out=None):
                           "pages/%s/%s.html" % (page["id"], code))
             context["page.body"] = Raw(body)
             document = render(template, context, "templates/base.html")
-            target = posixpath.join(entry["dir_path"], "index.html").lstrip("/")
+            target = page["output"] or posixpath.join(
+                entry["dir_path"], "index.html").lstrip("/")
             written.append(_write(out, target, document))
 
+    written.append(_write(out, "sitemap.xml", sitemap(pages, registry)))
+    written.append(_write(out, "robots.txt", robots(registry)))
+    # Pages built by a workflow are served as they are, so this changes nothing today.
+    # It costs one empty file and removes a whole class of surprise if the source is
+    # ever switched to a branch: Jekyll would then drop every path starting with an
+    # underscore, silently.
+    written.append(_write(out, ".nojekyll", ""))
     written.append(_write(out, "assets/style.css", _stylesheet(root, registry)))
     for asset in registry.get("assets", []):
         source = os.path.join(root, asset["source"].replace("/", os.sep))

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -44,7 +44,9 @@ import os
 import posixpath
 import re
 import shutil
+import struct
 import sys
+from urllib.parse import urlsplit
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
@@ -347,7 +349,62 @@ def _absolute(base_url, dir_path):
     return "%s/%s" % (base_url, dir_path + "/" if dir_path else "")
 
 
-def head_meta(page, code, registry, texts, description):
+def _root_prefix(registry):
+    """Path prefix for a document that can be served from ANY address.
+
+    Everything else on this site uses relative references, which keeps the output
+    working under a domain root and under a project path alike. The error document
+    cannot: GitHub Pages returns ``404.html`` AT the address that missed, without
+    redirecting, so a relative reference resolves against the missing path. A miss at
+    ``/pl/x/y/`` would look for ``/pl/x/y/assets/style.css`` and render the error page
+    with no styling, and its "home" button would point back at the address that had
+    just failed - the page would be broken exactly when it is used.
+
+    Taken from the configured address rather than hard-coded to "/", so a deployment
+    under a project path keeps working.
+    """
+    path = urlsplit(registry["base_url"]).path.rstrip("/")
+    return (path + "/") if path else "/"
+
+
+def asset_source(registry, root, target):
+    """The repository file that produces an output asset, or a loud failure.
+
+    ``og_image`` names a path on the SITE (``assets/bean.png``), while the file lives
+    somewhere else in the repository (``bean.png``), and the asset list is what ties
+    the two together. Looking it up instead of guessing means an ``og:image`` that
+    names a file nothing produces fails the build rather than the card: a social
+    preview pointing at a 404 is invisible until somebody shares the link.
+    """
+    for asset in registry.get("assets", []):
+        if asset["target"] == target:
+            path = os.path.join(root, asset["source"].replace("/", os.sep))
+            if not os.path.isfile(path):
+                # Reached before the copy step, so it has to say the same thing that
+                # step would: a missing source is a missing source, not an OSError
+                # from whoever happened to open it first.
+                raise SiteError("site.json lists an asset that is not there: %s"
+                                % asset["source"])
+            return path
+    raise SiteError("site.json: og_image is %r, which no entry in 'assets' produces "
+                    "(so the card would point at a missing file)" % target)
+
+
+def _png_size(path):
+    """(width, height) from a PNG header, or None for anything else.
+
+    Social cards render faster when the dimensions arrive with the tag, and the file
+    itself is the only honest source for them - a number typed into a registry beside
+    the image is a number that stops being true when the image is replaced.
+    """
+    with open(path, "rb") as handle:
+        head = handle.read(24)
+    if len(head) < 24 or head[:8] != b"\x89PNG\r\n\x1a\n":
+        return None
+    return struct.unpack(">II", head[16:24])
+
+
+def head_meta(page, code, registry, texts, description, root):
     """Canonical, hreflang, social cards and structured data, as HTML.
 
     Composed here and not in the template because the set differs per page and the
@@ -381,18 +438,23 @@ def head_meta(page, code, registry, texts, description):
     # it: `summary_large_image` wants roughly 2:1 and would crop or letterbox this.
     # A dedicated banner is a drawing job, not a build job.
     image = "%s/%s" % (base, registry["og_image"].lstrip("/"))
+    size = _png_size(asset_source(registry, root, registry["og_image"]))
     lang = _language(registry, code)
     social = [("og:type", "website"), ("og:site_name", texts[code]["site.name"]),
               ("og:title", entry["title"]), ("og:description", description),
               ("og:url", canonical), ("og:image", image),
-              ("og:locale", lang.get("og_locale", code))]
+              ("og:locale", lang.get("og_locale", code)),
+              ("og:image:alt", texts[code]["og.image_alt"])]
+    if size:
+        social += [("og:image:width", size[0]), ("og:image:height", size[1])]
     social += [("og:locale:alternate", other.get("og_locale", other["code"]))
                for other in registry["languages"] if other["code"] != code]
     for prop, value in social:
         lines.append('<meta property="%s" content="%s">'
                      % (prop, html.escape(str(value), quote=True)))
     for name, value in (("twitter:card", "summary"), ("twitter:title", entry["title"]),
-                        ("twitter:description", description), ("twitter:image", image)):
+                        ("twitter:description", description), ("twitter:image", image),
+                        ("twitter:image:alt", texts[code]["og.image_alt"])):
         lines.append('<meta name="%s" content="%s">'
                      % (name, html.escape(str(value), quote=True)))
 
@@ -534,7 +596,7 @@ def language_switcher(page, current_code, registry, label):
                % (html.escape(label, quote=True), "".join(parts)))
 
 
-def page_context(page, code, registry, texts, home_dir):
+def page_context(page, code, registry, texts, home_dir, colours, root):
     """Everything a page's template and body may refer to, for one language."""
     entry = page["languages"][code]
     lang = _language(registry, code)
@@ -551,11 +613,14 @@ def page_context(page, code, registry, texts, home_dir):
         "page.lang": code,
         "page.url": "%s/%s" % (registry["base_url"],
                                entry["dir_path"] + "/" if entry["dir_path"] else ""),
-        "page.asset_prefix": _asset_prefix(entry["dir_path"]),
-        "page.home_url": _relative_url(entry["dir_path"], home_dir),
+        "site.theme_color": colours["--bg"],
+        "page.asset_prefix": (_root_prefix(registry) if page["output"]
+                              else _asset_prefix(entry["dir_path"])),
+        "page.home_url": (_root_prefix(registry) if page["output"]
+                          else _relative_url(entry["dir_path"], home_dir)),
         "page.language_switcher": language_switcher(page, code, registry,
                                                     texts[code]["nav.language"]),
-        "page.head_meta": head_meta(page, code, registry, texts, entry["description"]),
+        "page.head_meta": head_meta(page, code, registry, texts, entry["description"], root),
     }, "page %s [%s]" % (page["id"], code))
     return context
 
@@ -606,6 +671,7 @@ def build(root=ROOT, out=None):
     registry = load_registry(root)
     texts = load_i18n(root, language_codes(registry), registry["default_language"])
     pages = load_pages(root, registry)
+    colours = palette(root, registry["palette"])
     template = _read_text(os.path.join(root, SITE_DIR, "templates", "base.html"))
 
     home = next((p for p in pages if p["id"] == "home"), pages[0])
@@ -614,7 +680,7 @@ def build(root=ROOT, out=None):
         for code in page["codes"]:
             entry = page["languages"][code]
             home_dir = home["languages"][code]["dir_path"]
-            context = page_context(page, code, registry, texts, home_dir)
+            context = page_context(page, code, registry, texts, home_dir, colours, root)
             body = render(entry["body"], context,
                           "pages/%s/%s.html" % (page["id"], code))
             context["page.body"] = Raw(body)
@@ -630,7 +696,7 @@ def build(root=ROOT, out=None):
     # ever switched to a branch: Jekyll would then drop every path starting with an
     # underscore, silently.
     written.append(_write(out, ".nojekyll", ""))
-    written.append(_write(out, "assets/style.css", _stylesheet(root, registry)))
+    written.append(_write(out, "assets/style.css", _stylesheet(root, colours)))
     for asset in registry.get("assets", []):
         source = os.path.join(root, asset["source"].replace("/", os.sep))
         if not os.path.isfile(source):
@@ -641,13 +707,12 @@ def build(root=ROOT, out=None):
     return sorted(written)
 
 
-def _stylesheet(root, registry):
+def _stylesheet(root, colours):
     """The palette from theme.py, in front of the hand-written CSS, in one file.
 
     One file rather than two: a second stylesheet is a second request for no
     benefit, and the variables have to arrive before the rules that use them.
     """
-    colours = palette(root, registry["palette"])
     lines = ["/* Generated by tools/build_site.py from beantester/gui/theme.py.",
              "   Do not edit: change the colour in theme.py, where the program reads it too. */",
              ":root {"]

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Build the project website from ``site/`` into a directory of static files.
+
+    python tools/build_site.py                 # -> build/site
+    python tools/build_site.py --out _site     # what the Pages workflow uses
+
+Why a generator of our own instead of a static-site generator
+-------------------------------------------------------------
+The page is a landing surface with a handful of subpages, and every candidate
+generator brings a second ecosystem (Node or Ruby) into a repository that ships
+one runtime dependency. What we would get in exchange - templating, i18n routing,
+asset pipelines - is a few hundred lines here, and what we would pay is a
+dependency tree, a second CI cache and a framework that changes its API. The
+decisive argument is the other direction: this project keeps only what a machine
+enforces, and a site built by our own code is a site the existing pytest suite can
+hold to the same conventions as the program (see tests/test_site.py).
+
+What is a single source, and what that buys
+-------------------------------------------
+* colours come from ``beantester/gui/theme.py``, read with ``ast`` rather than
+  imported - so this runs on a Linux runner with no tkinter, and the page cannot
+  drift into a second, slightly different dark theme;
+* the copyright line comes from ``beantester/appinfo.py``;
+* URLs are derived from one ``repo_url``, so the download button cannot point at a
+  stale place;
+* the version is deliberately NOT printed on the page. ``VERSION.txt`` is the next
+  version from the moment the owner bumps it, which is BEFORE that release exists,
+  so a page advertising it would offer a download that is not published yet. The
+  button points at ``/releases/latest``, which is correct at every moment.
+
+Failure is loud on purpose
+--------------------------
+Every mistake this thing can make - a missing translation, an empty description, a
+placeholder nobody defined, two pages claiming one slug - produces a page that
+looks fine and ranks nowhere, and nobody would notice for months. So each one
+raises ``SiteError`` instead of falling back to a default. The one thing a builder
+must never do is succeed quietly.
+"""
+import argparse
+import ast
+import html
+import json
+import os
+import posixpath
+import re
+import shutil
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from beantester import appinfo                                      # noqa: E402
+
+SITE_DIR = "site"
+DEFAULT_OUT = os.path.join("build", "site")
+THEME_FILE = os.path.join("beantester", "gui", "theme.py")
+
+# Search engines truncate a title around 60 characters and a description around
+# 160. These are the bounds a page has to live inside to be shown whole, and they
+# are checked rather than trusted, because "the description got cut in half" is
+# invisible from the source.
+TITLE_LEN = (15, 65)
+DESC_LEN = (50, 160)
+
+SLUG_RE = re.compile(r"^$|^[a-z0-9]+(?:-[a-z0-9]+)*(?:/[a-z0-9]+(?:-[a-z0-9]+)*)*$")
+PLACEHOLDER_RE = re.compile(r"\{\{([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)\}\}")
+
+
+class SiteError(Exception):
+    """A source file is wrong in a way that would publish a broken page."""
+
+
+class Raw(str):
+    """A context value that is already HTML and must not be escaped again.
+
+    Everything else IS escaped: page titles, descriptions and every translated
+    string land inside attributes and text nodes, and one apostrophe or ampersand
+    in Polish copy would otherwise break the markup around it.
+    """
+
+
+# -- reading the sources -------------------------------------------------------- #
+
+def _read_json(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        raise SiteError("missing file: %s" % path)
+    except json.JSONDecodeError as exc:
+        raise SiteError("%s is not valid JSON: %s" % (path, exc))
+
+
+def _read_text(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except FileNotFoundError:
+        raise SiteError("missing file: %s" % path)
+
+
+def load_registry(root):
+    """``site/site.json``: the one place the address, the languages and the palette
+    mapping live. A move to another domain is meant to be one line, here."""
+    reg = _read_json(os.path.join(root, SITE_DIR, "site.json"))
+    for key in ("base_url", "repo_url", "default_language", "languages", "palette"):
+        if not reg.get(key):
+            raise SiteError("site.json: '%s' is missing or empty" % key)
+    if reg["base_url"].endswith("/"):
+        raise SiteError("site.json: base_url must not end with '/' (it is joined with paths)")
+
+    codes, dirs = [], []
+    for lang in reg["languages"]:
+        for key in ("code", "name", "html_lang", "dir"):
+            if key not in lang:
+                raise SiteError("site.json: language %r has no '%s'" % (lang, key))
+        codes.append(lang["code"])
+        dirs.append(lang["dir"])
+    if len(set(codes)) != len(codes):
+        raise SiteError("site.json: duplicate language code in %s" % codes)
+    if len(set(dirs)) != len(dirs):
+        raise SiteError("site.json: two languages share one directory in %s" % dirs)
+    if reg["default_language"] not in codes:
+        raise SiteError("site.json: default_language %r is not one of %s"
+                        % (reg["default_language"], codes))
+    if dict(zip(codes, dirs))[reg["default_language"]] != "":
+        raise SiteError("site.json: the default language must live at the root (dir \"\")")
+    return reg
+
+
+def language_codes(registry):
+    return [lang["code"] for lang in registry["languages"]]
+
+
+def palette(root, mapping):
+    """CSS custom properties read out of ``theme.py`` WITHOUT importing it.
+
+    Importing would pull in tkinter, which the Linux runner does not need to have,
+    and would make a website build depend on the GUI stack. Parsing also has to
+    handle the shape the file really uses: ``FG, MUT = "#e4e6eb", "#9aa0aa"`` is a
+    tuple assignment, and a parser that only understood ``NAME = value`` would
+    silently miss five of the eleven colours (verified against theme.py, which
+    declares FG/MUT and ACC/OK/WARN that way).
+
+    A name that is no longer in theme.py raises. The alternative - falling back to
+    a literal - is how a renamed constant turns into two dark themes nobody
+    compared.
+    """
+    tree = ast.parse(_read_text(os.path.join(root, THEME_FILE)))
+    found = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target, value = node.targets[0], node.value
+        if isinstance(target, ast.Name) and isinstance(value, ast.Constant):
+            found[target.id] = value.value
+        elif isinstance(target, ast.Tuple) and isinstance(value, ast.Tuple):
+            for name, item in zip(target.elts, value.elts):
+                if isinstance(name, ast.Name) and isinstance(item, ast.Constant):
+                    found[name.id] = item.value
+
+    out = {}
+    for var, name in mapping.items():
+        if name not in found:
+            raise SiteError("theme.py no longer declares %r (mapped to %s in site.json)"
+                            % (name, var))
+        colour = found[name]
+        if not (isinstance(colour, str) and re.fullmatch(r"#[0-9a-fA-F]{6}", colour)):
+            raise SiteError("theme.py: %s is %r, which is not a 6-digit colour" % (name, colour))
+        out[var] = colour
+    return out
+
+
+def load_i18n(root, codes, default_code):
+    """One file per language, flat dotted keys, exactly like ``lang/*.json``.
+
+    The same three rules the program's own i18n test enforces (convention 9):
+    identical key sets, no empty text, and the default language never leaves a key
+    as its own translation. A half-translated page is worse than an untranslated
+    one, because it looks finished.
+    """
+    texts = {}
+    for code in codes:
+        data = _read_json(os.path.join(root, SITE_DIR, "i18n", "%s.json" % code))
+        meta = data.pop("_meta", None)
+        if not isinstance(meta, dict) or meta.get("code") != code:
+            raise SiteError("i18n/%s.json: _meta must declare {\"code\": \"%s\", \"name\": ...}"
+                            % (code, code))
+        texts[code] = data
+
+    reference = set(texts[default_code])
+    for code, data in texts.items():
+        missing = sorted(reference - set(data))
+        extra = sorted(set(data) - reference)
+        if missing or extra:
+            raise SiteError("i18n/%s.json: key sets differ from %s (missing: %s, extra: %s)"
+                            % (code, default_code, missing[:5], extra[:5]))
+        for key, value in sorted(data.items()):
+            if not isinstance(value, str) or not value.strip():
+                raise SiteError("i18n/%s.json: %r has no text" % (code, key))
+        if code == default_code:
+            same = sorted(k for k, v in data.items() if v == k)
+            if same:
+                raise SiteError("i18n/%s.json: %s left as its own key" % (code, same[:5]))
+    return texts
+
+
+def load_pages(root, registry):
+    """Every page directory under ``site/pages/``, with its metadata and bodies.
+
+    A page exists in EVERY declared language or the build fails. Adding a language
+    is meant to be a directory of files, and the honest moment to find out that a
+    translation is missing is here, not in a search result.
+    """
+    base = os.path.join(root, SITE_DIR, "pages")
+    if not os.path.isdir(base):
+        raise SiteError("no page directory: %s" % base)
+    codes = language_codes(registry)
+
+    pages, seen = [], {}
+    for page_id in sorted(os.listdir(base)):
+        page_dir = os.path.join(base, page_id)
+        if not os.path.isdir(page_dir):
+            continue
+        meta = _read_json(os.path.join(page_dir, "page.json"))
+        if meta.get("id") != page_id:
+            raise SiteError("pages/%s/page.json: 'id' must be %r, not %r"
+                            % (page_id, page_id, meta.get("id")))
+        per_lang = meta.get("languages") or {}
+        missing = [c for c in codes if c not in per_lang]
+        if missing:
+            raise SiteError("pages/%s: no metadata for language(s) %s" % (page_id, missing))
+
+        page = {"id": page_id, "order": meta.get("order", 999),
+                "in_nav": bool(meta.get("in_nav", False)), "languages": {}}
+        for code in codes:
+            entry = per_lang[code]
+            slug = entry.get("slug", None)
+            title = (entry.get("title") or "").strip()
+            description = (entry.get("description") or "").strip()
+            if slug is None or not SLUG_RE.match(slug):
+                raise SiteError("pages/%s [%s]: %r is not a valid slug "
+                                "(lower case, digits and '-', '/' between segments)"
+                                % (page_id, code, slug))
+            if not TITLE_LEN[0] <= len(title) <= TITLE_LEN[1]:
+                raise SiteError("pages/%s [%s]: the title is %d characters, allowed %d..%d"
+                                % (page_id, code, len(title), *TITLE_LEN))
+            if not DESC_LEN[0] <= len(description) <= DESC_LEN[1]:
+                raise SiteError("pages/%s [%s]: the description is %d characters, allowed %d..%d"
+                                % (page_id, code, len(description), *DESC_LEN))
+
+            lang = _language(registry, code)
+            dir_path = posixpath.join(lang["dir"], slug).strip("/")
+            if dir_path in seen:
+                raise SiteError("pages/%s [%s]: '%s' is already taken by %s"
+                                % (page_id, code, dir_path or "/", seen[dir_path]))
+            seen[dir_path] = "%s [%s]" % (page_id, code)
+
+            page["languages"][code] = {
+                "slug": slug, "title": title, "description": description,
+                "dir_path": dir_path,
+                "body": _read_text(os.path.join(page_dir, "%s.html" % code)),
+            }
+        pages.append(page)
+
+    if not pages:
+        raise SiteError("site/pages/ holds no pages")
+    return sorted(pages, key=lambda p: (p["order"], p["id"]))
+
+
+def _language(registry, code):
+    for lang in registry["languages"]:
+        if lang["code"] == code:
+            return lang
+    raise SiteError("no language %r in site.json" % code)
+
+
+# -- rendering ------------------------------------------------------------------ #
+
+def render(text, context, where):
+    """Substitute ``{{dotted.key}}`` from ``context``. An unknown key is an error.
+
+    A templating engine that leaves an unresolved placeholder on the page, or
+    quietly replaces it with an empty string, publishes the mistake. There is no
+    silent mode here on purpose.
+    """
+    missing = []
+
+    def one(match):
+        key = match.group(1)
+        if key not in context:
+            missing.append(key)
+            return match.group(0)
+        value = context[key]
+        return value if isinstance(value, Raw) else html.escape(str(value), quote=True)
+
+    out = PLACEHOLDER_RE.sub(one, text)
+    if missing:
+        raise SiteError("%s: nothing defines %s" % (where, sorted(set(missing))))
+    return out
+
+
+def _merge(context, extra, where):
+    """Add keys, refusing to shadow one that already exists.
+
+    Silent shadowing is how a translated string starts being overwritten by a
+    computed value that happens to share its name, and the page still renders.
+    """
+    for key, value in extra.items():
+        if key in context:
+            raise SiteError("%s: %r is defined twice" % (where, key))
+        context[key] = value
+    return context
+
+
+def _asset_prefix(dir_path):
+    depth = len([part for part in dir_path.split("/") if part])
+    return "../" * depth
+
+
+def _relative_url(from_dir, to_dir):
+    """A relative link between two page directories, always ending in '/'.
+
+    Relative rather than root-absolute so the same output works under a domain root
+    AND under a project path like /BeanNetworkTester/ - the fallback we may need if
+    the custom domain is ever dropped.
+    """
+    rel = posixpath.relpath(to_dir or ".", from_dir or ".")
+    if rel == ".":
+        return "./"
+    return rel if rel.endswith("/") else rel + "/"
+
+
+def language_switcher(page, current_code, registry):
+    """The language row in the header, as HTML.
+
+    Built here rather than in the template because the template language has no
+    loops, and a hand-written row would go stale the moment a third language is
+    added - which is exactly the drift this project keeps losing to.
+    """
+    parts = []
+    here = page["languages"][current_code]["dir_path"]
+    for lang in registry["languages"]:
+        code = lang["code"]
+        name = html.escape(lang["name"], quote=True)
+        if code == current_code:
+            parts.append('<span aria-current="page" lang="%s">%s</span>'
+                         % (html.escape(lang["html_lang"], quote=True), name))
+        else:
+            target = page["languages"][code]["dir_path"]
+            parts.append('<a href="%s" hreflang="%s" lang="%s">%s</a>'
+                         % (html.escape(_relative_url(here, target), quote=True),
+                            html.escape(code, quote=True),
+                            html.escape(lang["html_lang"], quote=True), name))
+    return Raw('<span class="langs">%s</span>' % "".join(parts))
+
+
+def page_context(page, code, registry, texts, home_dir):
+    """Everything a page's template and body may refer to, for one language."""
+    entry = page["languages"][code]
+    lang = _language(registry, code)
+    repo = registry["repo_url"].rstrip("/")
+    context = dict(texts[code])
+    _merge(context, {
+        "site.base_url": registry["base_url"],
+        "site.repo_url": repo,
+        "site.download_url": "%s/releases/latest" % repo,
+        "site.issues_url": "%s/issues" % repo,
+        "site.copyright": appinfo.COPYRIGHT,
+        "page.title": entry["title"],
+        "page.description": entry["description"],
+        "page.html_lang": lang["html_lang"],
+        "page.lang": code,
+        "page.url": "%s/%s" % (registry["base_url"],
+                               entry["dir_path"] + "/" if entry["dir_path"] else ""),
+        "page.asset_prefix": _asset_prefix(entry["dir_path"]),
+        "page.home_url": _relative_url(entry["dir_path"], home_dir),
+        "page.language_switcher": language_switcher(page, code, registry),
+    }, "page %s [%s]" % (page["id"], code))
+    return context
+
+
+# -- writing -------------------------------------------------------------------- #
+
+def _write(out, rel_path, text):
+    path = os.path.join(out, rel_path.replace("/", os.sep))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    # newline="\n" on purpose: the same bytes on Windows and on the CI runner, so
+    # "the build changed" never means "the machine changed".
+    with open(path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(text)
+    return rel_path
+
+
+def _copy(out, source, rel_path):
+    path = os.path.join(out, rel_path.replace("/", os.sep))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    shutil.copyfile(source, path)
+    return rel_path
+
+
+def _prune(out, written):
+    """Delete whatever a previous build left behind, and the empty directories.
+
+    Without this a renamed page keeps serving from its old address forever, which
+    is the one kind of stale that a visitor sees and we do not.
+    """
+    keep = {os.path.normpath(p.replace("/", os.sep)) for p in written}
+    for dirpath, _dirnames, filenames in os.walk(out, topdown=False):
+        for name in filenames:
+            full = os.path.join(dirpath, name)
+            if os.path.normpath(os.path.relpath(full, out)) not in keep:
+                os.remove(full)
+        if dirpath != out and not os.listdir(dirpath):
+            os.rmdir(dirpath)
+
+
+def build(root=ROOT, out=None):
+    """Generate the whole site. Returns the relative paths written, sorted."""
+    out = out or os.path.join(root, DEFAULT_OUT)
+    if os.path.isdir(out) and os.listdir(out) and not os.path.isfile(
+            os.path.join(out, "index.html")):
+        raise SiteError("refusing to write into %s: it holds files and no index.html, "
+                        "so it does not look like a previous site build" % out)
+
+    registry = load_registry(root)
+    texts = load_i18n(root, language_codes(registry), registry["default_language"])
+    pages = load_pages(root, registry)
+    template = _read_text(os.path.join(root, SITE_DIR, "templates", "base.html"))
+
+    home = next((p for p in pages if p["id"] == "home"), pages[0])
+    written = []
+    for page in pages:
+        for code in language_codes(registry):
+            entry = page["languages"][code]
+            home_dir = home["languages"][code]["dir_path"]
+            context = page_context(page, code, registry, texts, home_dir)
+            body = render(entry["body"], context,
+                          "pages/%s/%s.html" % (page["id"], code))
+            context["page.body"] = Raw(body)
+            document = render(template, context, "templates/base.html")
+            target = posixpath.join(entry["dir_path"], "index.html").lstrip("/")
+            written.append(_write(out, target, document))
+
+    written.append(_write(out, "assets/style.css", _stylesheet(root, registry)))
+    for asset in registry.get("assets", []):
+        source = os.path.join(root, asset["source"].replace("/", os.sep))
+        if not os.path.isfile(source):
+            raise SiteError("site.json lists an asset that is not there: %s" % asset["source"])
+        written.append(_copy(out, source, asset["target"]))
+
+    _prune(out, written)
+    return sorted(written)
+
+
+def _stylesheet(root, registry):
+    """The palette from theme.py, in front of the hand-written CSS, in one file.
+
+    One file rather than two: a second stylesheet is a second request for no
+    benefit, and the variables have to arrive before the rules that use them.
+    """
+    colours = palette(root, registry["palette"])
+    lines = ["/* Generated by tools/build_site.py from beantester/gui/theme.py.",
+             "   Do not edit: change the colour in theme.py, where the program reads it too. */",
+             ":root {"]
+    lines += ["  %s: %s;" % (var, value) for var, value in colours.items()]
+    lines += ["}", ""]
+    return "\n".join(lines) + _read_text(os.path.join(root, SITE_DIR, "assets", "style.css"))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Build the Bean Network Tester website.")
+    parser.add_argument("--out", default=None,
+                        help="output directory (default: %s)" % DEFAULT_OUT)
+    args = parser.parse_args(argv)
+    try:
+        written = build(ROOT, args.out)
+    except SiteError as exc:
+        print("site build failed: %s" % exc, file=sys.stderr)
+        return 1
+    print("wrote %d files to %s" % (len(written), args.out or DEFAULT_OUT))
+    for path in written:
+        print("  %s" % path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The project has no page of its own, so a search for what this tool does lands on a repository
README or on nothing. This branch adds one, in English and Polish, with a single job: the click
that goes to the releases page.

Nothing is published by the branch itself. Merging it is what triggers the first deployment.

## What is in here

Three steps, one commit each, plus one commit of corrections found by re-reading the first two.

- **The sources and the generator.** `site/` holds the address, the language list, the palette
  mapping, the shared strings and one directory per page. `tools/build_site.py` turns them into
  static files under `build/site`, which git ignores - no generated HTML is tracked. Written on the
  standard library, deliberately: Astro, Hugo and Jekyll each add a second ecosystem to a
  repository with one pinned runtime dependency, and what they would replace is a few hundred lines
  that this test suite can hold to the project's own conventions.
- **The layer a crawler reads.** A self-referencing absolute canonical, `hreflang` for every
  language including the page itself with exactly one `x-default`, Open Graph and Twitter tags,
  `SoftwareApplication` structured data, `sitemap.xml` with the language alternates, `robots.txt`
  naming it, and `404.html`.
- **The deployment.** `.github/workflows/pages.yml`: build, guard, upload, deploy, then fetch the
  published page back and require a canonical, an `x-default` and a sitemap with entries. A
  deployment reporting success proves the upload happened, not that the site answers.

## Single sources, so the page cannot drift from the program

- **Colours come from `beantester/gui/theme.py`**, read with `ast` rather than imported, so the
  build needs no tkinter on a Linux runner. They are emitted as CSS custom properties, and a hex
  literal anywhere under `site/` fails the suite - there is no second place a colour can live. The
  parser handles the tuple assignments the file really uses (`FG, MUT = ...`), which is five of the
  eleven colours.
- **The copyright line comes from `appinfo`**, and every URL from one `repo_url`.
- **The card image reports the size the file really has**, read from the PNG header at build time.
- **No version is printed anywhere on the page.** `VERSION.txt` names the next release from the
  moment it is bumped, which is before that release exists, so a page advertising it would offer a
  download that is not published yet. The button points at `/releases/latest`, which is correct at
  every moment, and is pinned to that rather than to an asset name because the asset carries the
  version.

## What is enforced rather than remembered

- **The build refuses to publish to an address the pages do not claim.** Every canonical, hreflang
  and sitemap entry names the configured address. If the repository published somewhere else, those
  canonicals would point at a host serving nothing. The comparison runs before the upload.
- **Ten ways a source file can be wrong fail the build** instead of shipping: a missing
  translation, blank text, a placeholder nobody defines, a title or description outside the bounds a
  search result shows, a missing body for a language, two pages resolving to one address, a mapped
  colour the theme no longer declares, a card image nothing produces, an unknown structured-data
  kind, and an error page declaring a language that will never be written. Each was run and each
  reports its own message.
- **A canary builds an unmutated sandbox**, because the rejection tests accept any refusal: a
  sandbox missing one file of its own would satisfy all ten while proving nothing.
- **Permissions are per job** - `contents: read` at the top, `pages: read` on the job that only
  reads the Pages configuration, `pages: write` and `id-token: write` on the deploying job alone.
- **Deployments are serialised and never cancelled half way.** A partly replaced site is worse than
  a late one, and there is no rollback.
- **The `paths` filter is derived from the registry** by a test, so replacing the icon or the
  screenshot cannot silently stop triggering a rebuild.

## Two guards that were fixed by being tested

- The private-data scan in `tests/test_repo_conventions.py` matched only the URL-style spelling of a
  Windows user-profile path, because a character class holding an escaped forward slash holds one
  character, not two. It therefore never matched the spelling that a shell or a traceback prints.
  Found by mutation while extending these scans to the website sources. Both spellings match now,
  and the tracked tree has no hit, so nothing was leaking - the guard was narrower than its own
  message.
- The workflow permissions test failed on the real workflow, and it was right to: it read raw text,
  so a comment explaining why `pages: write` is **not** granted file-wide counted as a grant. The
  scan strips comments now. A comment is not configuration, and a guard that reads prose can be
  satisfied by prose.

## Deliberately not here

- **No rating in the structured data, and no analytics on the page.** The software-app rich result
  needs `aggregateRating` or `review`. There is no rating to report and writing one down would be a
  fabricated review, so the markup describes the application and is not rich-result eligible. A test
  fails if anybody adds one, or a `softwareVersion`, so the reason survives a reader who never sees
  this description. Measurement uses Search Console, the repository's traffic view and
  `tools/downloads.py` instead of a third-party script, and a test fails on any external request,
  including an imported web font in the stylesheet.
- **No entry in `CHANGELOG.md` and no README links yet.** Both would point at an address that does
  not answer until this merges and the first deployment runs. They follow immediately after, in
  their own commit.
- The social card is `summary` rather than `summary_large_image`: the only image here is a square
  256 px icon, and the large card wants roughly 2:1.

## What merging does, and the one thing that cannot be checked before it

The merge triggers the first deployment. The workflow's address comparison, its permission scopes
and its read-back step have never run on a runner, and one of them is a genuine unknown: whether
`configure-pages` is satisfied by `pages: read`. The action's documentation does not state the
scope it needs and the call is a plain GET, so read should be enough. A 403 on that step means
raising that one line to `write`, and the comment beside it says so.

## Verification

- `python -m pytest tests` - **1076 passed**, run bare and last, on Windows.
- `python smoke_gui.py` - green. Both Stop hooks green.
- `python tools/build_site.py` twice into the same directory - **byte-identical** output.
- The pages were opened in a browser at desktop and at 375 px, in both languages.
- The workflow YAML re-parsed, and the address-comparison step executed locally in three states:
  address matching (exit 0), the fallback address (exit 1 with the actionable message), and the
  host output empty so it falls back to parsing the URL (exit 0).
- Five workflow guards mutation-checked by editing the workflow and watching the right test go red.
  Two entries added to the mutation registry, both `caught`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
