### PR TITLE
docs(site): point both READMEs and the changelog at the live website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   "Apply changes" to put them into a running session.
 
 ### Docs
+- **The project has a website: <https://beannetworktester.donislawdev.com/>** In English and
+  Polish, dark like the program, with the download one click away. It says what the tool does to a
+  network and how to start in three steps. It loads nothing from anywhere else - no trackers, no
+  cookies, no outside fonts - and sets no cookies of its own. Polish version: `/pl/`.
 - **The licence notices now list everything the download actually contains.** Scanning the built
   package turned up three things shipping in every release that no list mentioned: zlib, libffi and
   Microsoft's C runtime - 42 files of the latter, over half the bundle. All permissive or

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
 
+🌐 **Website: [beannetworktester.donislawdev.com](https://beannetworktester.donislawdev.com/)** -
+what it does, in short, with the download one click away.
+
 **Bean Network Tester** is a tool for testers and developers: check how your application behaves
 on a poor connection. Like Clumsy or NetLimiter, it lets you deliberately degrade the network -
 add ping, drop packets, cap the speed, tear connections down, and more. It works by intercepting

--- a/README.pl.md
+++ b/README.pl.md
@@ -6,6 +6,9 @@
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
 
+🌐 **Strona projektu: [beannetworktester.donislawdev.com](https://beannetworktester.donislawdev.com/pl/)** -
+krótko o tym, co program robi, i pobieranie w jednym kliknięciu.
+
 **Bean Network Tester** to narzędzie dla testerów i deweloperów: sprawdź, jak aplikacja zachowuje
 się przy słabym internecie. Podobnie jak Clumsy czy NetLimiter, pozwala celowo pogarszać sieć -
 dodać ping, gubić pakiety, ograniczyć prędkość, zrywać połączenia i więcej. Działa przez


### PR DESCRIPTION
The website from #120 is deployed and answering, so the links to it can exist. They were held back
until now on purpose: a README pointing at an address that does not resolve is worse than no link.

- Both READMEs get one line under the badges, each to its own language - the English file to the
  root, the Polish file to `/pl/`.
- `CHANGELOG.md` gets a `Docs` entry naming the address, what the page is for, and the fact that it
  loads nothing from anywhere else. 62 words, against the 100-word ceiling that
  `test_no_user_facing_entry_grows_into_an_essay` enforces.

## Verified against the live site, not against the intent

- `/` and `/pl/` answer **200**, each declaring its own language, its own self-referencing
  canonical, `hreflang` for both languages and one `x-default`.
- `http://` answers **301** to `https://`.
- `sitemap.xml`, `robots.txt` and the stylesheet answer 200.
- `theme-color` on the live page is the page background from `beantester/gui/theme.py`, so the
  single source reached the address bar.
- A miss at a nested path (`/pl/<something that does not exist>/`) returns a **real 404 status**
  with our error page: `noindex`, no canonical, and a stylesheet addressed from the site root that
  answers 200 from there. That is the one behaviour that could not be checked before deploying,
  because Pages serves the error document at the address that missed without redirecting - the
  first version of that page would have rendered unstyled with a button pointing back at the
  address that had just failed.

## Verification

- The four guards that read these two files: `test_readme_guards.py`, `test_cli_docs.py`,
  `test_repo_conventions.py`, `test_version_and_release.py` - **38 passed**.
- The full suite was deliberately not run locally for a two-file documentation change. CI runs it
  on this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
