### PR TITLE
feat(site): eight guides in English and Polish, generated from the program's own strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   "Apply changes" to put them into a running session.
 
 ### Docs
+- **Eight guides on the website, in English and Polish.** Packet loss, latency and jitter, speed
+  limits, breaking connections, aiming at one application, running network tests in a pipeline, how
+  this compares with other Windows tools, and the questions people ask before downloading. Each one
+  says which numbers are worth trying and gives the command that does it. The field and profile names
+  in them come from the program's own language files, so they cannot drift from what the window
+  actually says.
 - **The project has a website: <https://beannetworktester.donislawdev.com/>** In English and
   Polish, dark like the program, with the download one click away. It says what the tool does to a
   network and how to start in three steps. It loads nothing from anywhere else - no trackers, no

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -241,3 +241,64 @@ h3 {
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; }
 }
+
+/* -- guides and the footer's page list ----------------------------------- */
+/* Both lists are GENERATED from the page registry (see tools/build_site.py):
+   a hand-written list forgets the page added after it, and a page nothing links
+   to is reachable only through the sitemap. */
+.guides {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: .75rem;
+}
+.guides li a {
+  display: block;
+  padding: 1rem 1.15rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 600;
+}
+.guides li a:hover { background: color-mix(in srgb, var(--bg-card) 80%, var(--fg)); }
+
+.foot-nav {
+  list-style: none;
+  margin: 0 0 1.25rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem 1.25rem;
+}
+.foot-nav a { text-decoration: none; }
+.foot-nav a:hover { text-decoration: underline; }
+
+/* -- command examples ---------------------------------------------------- */
+pre {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: .9rem 1rem;
+  overflow-x: auto;
+  font-family: Consolas, "Cascadia Mono", ui-monospace, monospace;
+  font-size: .9rem;
+  line-height: 1.5;
+}
+pre code { background: none; border: 0; padding: 0; font-size: 1em; }
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  display: block;
+  overflow-x: auto;
+}
+th, td {
+  border: 1px solid var(--border);
+  padding: .5rem .7rem;
+  text-align: left;
+  vertical-align: top;
+}
+th { background: var(--bg-card); }

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -8,6 +8,7 @@
   "nav.home": "Home",
   "nav.source": "Source on GitHub",
   "nav.primary": "Site",
+  "nav.pages": "Pages",
   "nav.language": "Language",
 
   "og.image_alt": "The Bean Network Tester window, showing a session in progress",

--- a/site/i18n/pl.json
+++ b/site/i18n/pl.json
@@ -8,6 +8,7 @@
   "nav.home": "Strona główna",
   "nav.source": "Kod na GitHubie",
   "nav.primary": "Witryna",
+  "nav.pages": "Strony",
   "nav.language": "Język",
 
   "og.image_alt": "Okno programu Bean Network Tester w trakcie sesji",

--- a/site/pages/404/page.json
+++ b/site/pages/404/page.json
@@ -7,7 +7,8 @@
     "en": {
       "slug": "404",
       "title": "Page not found - Bean Network Tester",
-      "description": "That address does not exist on this site. The links below reach the home page and the download."
+      "description": "That address does not exist on this site. The links below reach the home page and the download.",
+      "link_text": "Page not found"
     }
   }
 }

--- a/site/pages/bandwidth/en.html
+++ b/site/pages/bandwidth/en.html
@@ -1,0 +1,64 @@
+<section class="hero">
+  <h1>Limit download and upload speed</h1>
+  <p class="lead">Set a ceiling in kilobytes per second and the app gets no more than that. The two
+  directions are separate, so you can give it a fast download and a hopeless upload - which is
+  exactly what most home and mobile connections look like.</p>
+</section>
+
+<section>
+  <h2>In the window</h2>
+  <ol class="steps">
+    <li>Set <strong>{{app.fields.target_process}}</strong> to your application.</li>
+    <li>Fill <strong>{{app.fields.download}}</strong>, <strong>{{app.fields.upload}}</strong> or both, in KB/s. Leave a field at 0
+    to leave that direction alone.</li>
+    <li>Press <strong>{{app.buttons.start}}</strong>.</li>
+  </ol>
+<pre><code>BeanNetworkTester.exe --down 128 --up 32 --target myapp.exe --duration 120</code></pre>
+</section>
+
+<section>
+  <h2>What the numbers mean</h2>
+  <table>
+    <tr><th>KB/s</th><th>Roughly</th><th>What it is</th></tr>
+    <tr><td>6</td><td>56 kbit/s</td><td>A dial-up modem. The "{{app.presets.modem56k}}" profile.</td></tr>
+    <tr><td>128</td><td>1 Mbit/s</td><td>In-flight WiFi, a busy hotel, a bad mobile signal.</td></tr>
+    <tr><td>1024</td><td>8 Mbit/s</td><td>A modest home line. Enough for one video stream.</td></tr>
+    <tr><td>12800</td><td>100 Mbit/s</td><td>A normal fixed connection today.</td></tr>
+  </table>
+  <p>Kilobytes, not kilobits - so multiply by eight to compare with what an internet provider
+  advertises.</p>
+</section>
+
+<section>
+  <h2>The queue matters as much as the limit</h2>
+  <p>A speed limit needs somewhere to put the packets that do not fit yet. That is the
+  <strong>{{app.fields.buffer}}</strong> setting, in milliseconds, and it behaves like the queue at a checkout:</p>
+  <ul>
+    <li><strong>A short queue</strong> means packets get thrown away as soon as the line is full.
+    Your app sees loss and reacts quickly.</li>
+    <li><strong>A long queue</strong> means nothing is thrown away, but everything waits. Your app
+    sees the connection getting slower and slower instead of failing - the effect a congested home
+    line has, and the reason a video call degrades while a download keeps going.</li>
+  </ul>
+  <p>The "{{app.presets.bufferbloat}}" profile is exactly this: a limit with a long queue.
+  Try the same speed with a short queue and a long one, and watch how differently the app behaves.</p>
+</section>
+
+<section>
+  <h2>One thing to expect</h2>
+  <p>With a limit running, the counter for dropped packets can stay at zero. That is not a bug: a
+  limit first makes packets wait, and it only drops them when the queue is genuinely full. Give it a
+  small buffer and the drops appear.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/bandwidth/page.json
+++ b/site/pages/bandwidth/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "bandwidth-limit",
       "link_text": "Speed limit",
-      "title": "Limit download and upload speed",
+      "title": "Limit download and upload speed on Windows",
       "description": "Hold one Windows app to a set number of KB per second, in either direction, and see what a 56k modem or in-flight WiFi does to it."
     },
     "pl": {
       "slug": "limit-predkosci",
       "link_text": "Limit prędkości",
-      "title": "Limit prędkości pobierania i wysyłania",
+      "title": "Limit prędkości pobierania i wysyłania aplikacji",
       "description": "Utrzymaj jedną aplikację na Windows przy zadanej liczbie KB na sekundę, w wybranym kierunku, i sprawdź, co robi z nią modem 56k."
     }
   }

--- a/site/pages/bandwidth/page.json
+++ b/site/pages/bandwidth/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "bandwidth",
+  "order": 30,
+  "languages": {
+    "en": {
+      "slug": "bandwidth-limit",
+      "link_text": "Speed limit",
+      "title": "Limit download and upload speed",
+      "description": "Hold one Windows app to a set number of KB per second, in either direction, and see what a 56k modem or in-flight WiFi does to it."
+    },
+    "pl": {
+      "slug": "limit-predkosci",
+      "link_text": "Limit prędkości",
+      "title": "Limit prędkości pobierania i wysyłania",
+      "description": "Utrzymaj jedną aplikację na Windows przy zadanej liczbie KB na sekundę, w wybranym kierunku, i sprawdź, co robi z nią modem 56k."
+    }
+  }
+}

--- a/site/pages/bandwidth/pl.html
+++ b/site/pages/bandwidth/pl.html
@@ -1,0 +1,64 @@
+<section class="hero">
+  <h1>Limit prędkości pobierania i wysyłania</h1>
+  <p class="lead">Ustawiasz sufit w kilobajtach na sekundę i aplikacja nie dostaje więcej. Oba
+  kierunki są osobne, więc możesz dać jej szybkie pobieranie i beznadziejne wysyłanie - a tak
+  właśnie wygląda większość łączy domowych i mobilnych.</p>
+</section>
+
+<section>
+  <h2>W oknie programu</h2>
+  <ol class="steps">
+    <li>Ustaw <strong>{{app.fields.target_process}}</strong> na swoją aplikację.</li>
+    <li>Wypełnij <strong>{{app.fields.download}}</strong>, <strong>{{app.fields.upload}}</strong> albo oba, w KB/s. Pole
+    zostawione na 0 nie rusza tego kierunku.</li>
+    <li>Wciśnij <strong>{{app.buttons.start}}</strong>.</li>
+  </ol>
+<pre><code>BeanNetworkTester.exe --down 128 --up 32 --target myapp.exe --duration 120</code></pre>
+</section>
+
+<section>
+  <h2>Co znaczą te liczby</h2>
+  <table>
+    <tr><th>KB/s</th><th>W przybliżeniu</th><th>Co to jest</th></tr>
+    <tr><td>6</td><td>56 kbit/s</td><td>Modem wdzwaniany. Profil "{{app.presets.modem56k}}".</td></tr>
+    <tr><td>128</td><td>1 Mbit/s</td><td>WiFi w samolocie, zapchany hotel, słaby zasięg.</td></tr>
+    <tr><td>1024</td><td>8 Mbit/s</td><td>Skromne łącze domowe. Wystarczy na jeden strumień wideo.</td></tr>
+    <tr><td>12800</td><td>100 Mbit/s</td><td>Normalne dzisiejsze łącze stacjonarne.</td></tr>
+  </table>
+  <p>Kilobajty, nie kilobity - więc mnóż przez osiem, żeby porównać z tym, co reklamuje dostawca
+  internetu.</p>
+</section>
+
+<section>
+  <h2>Kolejka znaczy tyle samo, co sam limit</h2>
+  <p>Limit prędkości musi mieć gdzie odłożyć pakiety, które jeszcze się nie mieszczą. To jest
+  ustawienie <strong>{{app.fields.buffer}}</strong>, w milisekundach, i działa jak kolejka do kasy:</p>
+  <ul>
+    <li><strong>Krótka kolejka</strong> znaczy, że pakiety lecą do kosza, gdy tylko się zapełni.
+    Aplikacja widzi stratę i reaguje szybko.</li>
+    <li><strong>Długa kolejka</strong> znaczy, że nic nie ginie, ale wszystko czeka. Aplikacja widzi
+    łącze coraz wolniejsze, zamiast padającego - i to jest efekt zapchanego łącza domowego, powód,
+    dla którego rozmowa wideo się rozsypuje, a pobieranie leci dalej.</li>
+  </ul>
+  <p>Profil "{{app.presets.bufferbloat}}" to dokładnie to: limit z długą kolejką. Spróbuj
+  tej samej prędkości z krótką i z długą kolejką, i popatrz, jak inaczej zachowa się aplikacja.</p>
+</section>
+
+<section>
+  <h2>Jedna rzecz, której należy się spodziewać</h2>
+  <p>Przy działającym limicie licznik odrzuconych pakietów może zostać na zerze. To nie usterka:
+  limit najpierw każe pakietom czekać, a odrzuca je dopiero, gdy kolejka naprawdę się zapełni. Daj
+  mu mały bufor i odrzucenia się pojawią.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/break-connections/en.html
+++ b/site/pages/break-connections/en.html
@@ -1,0 +1,68 @@
+<section class="hero">
+  <h1>Break connections on purpose</h1>
+  <p class="lead">Slow is one kind of bad. Gone is another, and it is the one that finds the code
+  path nobody wrote: the reconnect, the retry, the message that tells the user what happened.</p>
+</section>
+
+<section>
+  <h2>Five different ways to be gone</h2>
+  <table>
+    <tr><th>Setting</th><th>What the app sees</th></tr>
+    <tr><td><strong>Reset connections</strong></td><td>Connections die mid-transfer, the way a
+    firewall or a load balancer kills them. Set how often, in percent.</td></tr>
+    <tr><td><strong>Link on and off</strong></td><td>The network disappears for a while, then comes
+    back, over and over. You set the cycle length and how much of it is downtime.</td></tr>
+    <tr><td><strong>Block a port</strong></td><td>Everything to that port vanishes. Nothing else is
+    touched.</td></tr>
+    <tr><td><strong>Block an address</strong></td><td>One server becomes unreachable while the rest
+    of the internet works.</td></tr>
+    <tr><td><strong>LAN mode</strong></td><td>The local network keeps working, the internet does
+    not. Exactly the shape of a captive portal or a dead uplink.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>From the command line</h2>
+  <p>Kill roughly one connection in ten, on one app:</p>
+<pre><code>BeanNetworkTester.exe --rst-prob 10 --target myapp.exe --duration 60</code></pre>
+  <p>Ten second cycles, down for four of them - a link that keeps coming and going:</p>
+<pre><code>BeanNetworkTester.exe --flap-period 10 --flap-down 40 --target myapp.exe</code></pre>
+  <p>One server unreachable, everything else fine:</p>
+<pre><code>BeanNetworkTester.exe --block-ip 203.0.113.10</code></pre>
+</section>
+
+<section>
+  <h2>Blocking only hits what it names</h2>
+  <p>Unlike loss or delay, blocking a port or an address affects <strong>only</strong> the traffic
+  matching it. That makes it the safest of these to run without a process target, and it is why
+  "make this one dependency disappear" is a one-line command.</p>
+</section>
+
+<section>
+  <h2>The dead-download trap</h2>
+  <p>There is also a maximum packet size. Lower it a little and large transfers slow down. Lower it
+  to a value like 576 and downloads stop completely, forever, with no error - because that is no
+  longer a smaller packet size, it is the classic black hole where the network drops what is too big
+  and never says so.</p>
+  <p>That is a real failure mode worth reproducing on purpose, and it is a genuinely confusing one
+  to meet by accident. If a download dies silently right after you changed this setting, that is why.</p>
+</section>
+
+<section>
+  <h2>Getting back to normal</h2>
+  <p>STOP restores everything. So does closing the program, and so does the time limit if you set
+  one. If the tool itself were ever to die mid-session, a watchdog inside it stops the capture rather
+  than leaving your network in a broken state.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/break-connections/page.json
+++ b/site/pages/break-connections/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "break-connections",
+  "order": 50,
+  "languages": {
+    "en": {
+      "slug": "break-connections",
+      "link_text": "Break connections",
+      "title": "Break connections on purpose",
+      "description": "Kill connections, block a port or an address, cut the link for a while, or shrink packets until nothing gets through - and see how the app recovers."
+    },
+    "pl": {
+      "slug": "zrywanie-polaczen",
+      "link_text": "Zrywanie połączeń",
+      "title": "Zrywanie połączeń na życzenie",
+      "description": "Zabijaj połączenia, blokuj port albo adres, wyłączaj łącze na chwilę lub zmniejsz pakiety tak, że nic nie przechodzi, i patrz, jak aplikacja wraca."
+    }
+  }
+}

--- a/site/pages/break-connections/page.json
+++ b/site/pages/break-connections/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "break-connections",
       "link_text": "Break connections",
-      "title": "Break connections on purpose",
+      "title": "Break connections and block ports on Windows",
       "description": "Kill connections, block a port or an address, cut the link for a while, or shrink packets until nothing gets through - and see how the app recovers."
     },
     "pl": {
       "slug": "zrywanie-polaczen",
       "link_text": "Zrywanie połączeń",
-      "title": "Zrywanie połączeń na życzenie",
+      "title": "Zrywanie połączeń i blokowanie portów",
       "description": "Zabijaj połączenia, blokuj port albo adres, wyłączaj łącze na chwilę lub zmniejsz pakiety tak, że nic nie przechodzi, i patrz, jak aplikacja wraca."
     }
   }

--- a/site/pages/break-connections/pl.html
+++ b/site/pages/break-connections/pl.html
@@ -1,0 +1,69 @@
+<section class="hero">
+  <h1>Zrywanie połączeń na życzenie</h1>
+  <p class="lead">Wolno to jeden rodzaj awarii. Brak łącza to drugi, i właśnie on znajduje ścieżkę
+  kodu, której nikt nie napisał: ponowne połączenie, ponowienie próby, komunikat mówiący
+  użytkownikowi, co się stało.</p>
+</section>
+
+<section>
+  <h2>Pięć różnych sposobów na brak łącza</h2>
+  <table>
+    <tr><th>Ustawienie</th><th>Co widzi aplikacja</th></tr>
+    <tr><td><strong>Zrywanie połączeń</strong></td><td>Połączenia padają w środku transferu, tak jak
+    je zabija firewall albo load balancer. Ustawiasz, jak często, w procentach.</td></tr>
+    <tr><td><strong>Łącze na przemian</strong></td><td>Sieć znika na chwilę i wraca, w kółko.
+    Ustawiasz długość cyklu i jaka jego część to przestój.</td></tr>
+    <tr><td><strong>Blokada portu</strong></td><td>Wszystko na ten port przepada. Nic innego nie jest
+    ruszane.</td></tr>
+    <tr><td><strong>Blokada adresu</strong></td><td>Jeden serwer staje się nieosiągalny, a reszta
+    internetu działa.</td></tr>
+    <tr><td><strong>Tryb LAN</strong></td><td>Sieć lokalna działa, internet nie. Dokładnie kształt
+    portalu logowania w hotelu albo padniętego łącza operatora.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Z linii komend</h2>
+  <p>Zabij mniej więcej co dziesiąte połączenie jednej aplikacji:</p>
+<pre><code>BeanNetworkTester.exe --rst-prob 10 --target myapp.exe --duration 60</code></pre>
+  <p>Cykle dziesięciosekundowe, cztery sekundy przestoju - łącze, które ciągle znika i wraca:</p>
+<pre><code>BeanNetworkTester.exe --flap-period 10 --flap-down 40 --target myapp.exe</code></pre>
+  <p>Jeden serwer nieosiągalny, wszystko inne w porządku:</p>
+<pre><code>BeanNetworkTester.exe --block-ip 203.0.113.10</code></pre>
+</section>
+
+<section>
+  <h2>Blokada rusza tylko to, co nazywa</h2>
+  <p>W odróżnieniu od straty czy opóźnienia, blokada portu albo adresu dotyczy <strong>wyłącznie</strong>
+  ruchu, który do niej pasuje. To czyni ją najbezpieczniejszą z tej piątki do uruchomienia bez celu
+  procesowego i dlatego "niech ta jedna zależność zniknie" to komenda w jednej linii.</p>
+</section>
+
+<section>
+  <h2>Pułapka martwego pobierania</h2>
+  <p>Jest też maksymalny rozmiar pakietu. Zmniejsz go trochę i duże transfery zwolnią. Zmniejsz do
+  wartości w rodzaju 576 i pobieranie stanie całkowicie, na zawsze, bez żadnego błędu - bo to już nie
+  jest mniejszy rozmiar pakietu, tylko klasyczna czarna dziura, w której sieć wyrzuca to, co za duże,
+  i nigdy o tym nie mówi.</p>
+  <p>To realny tryb awarii, wart odtworzenia specjalnie, i naprawdę mylący, gdy spotka się go
+  przypadkiem. Jeśli pobieranie zdechło po cichu zaraz po zmianie tego ustawienia - to jest powód.</p>
+</section>
+
+<section>
+  <h2>Powrót do normy</h2>
+  <p>STOP przywraca wszystko. Tak samo zamknięcie programu, tak samo limit czasu, jeśli go ustawisz.
+  Gdyby samo narzędzie kiedyś padło w środku sesji, jego wewnętrzny nadzorca zatrzymuje przechwyt,
+  zamiast zostawiać Twoją sieć w zepsutym stanie.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/ci/en.html
+++ b/site/pages/ci/en.html
@@ -1,0 +1,68 @@
+<section class="hero">
+  <h1>Simulate a bad network in CI</h1>
+  <p class="lead">The window is optional. The same executable runs as a command-line tool, ends by
+  itself after a set time, and reports what happened in a way a pipeline can read.</p>
+</section>
+
+<section>
+  <h2>The shape of a step</h2>
+  <p>Impair for the length of the test, then let it stop on its own. No cleanup step to forget:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --latency 200 --target myapp.exe --duration 60</code></pre>
+  <p>In a GitHub Actions job, on a self-hosted Windows runner:</p>
+<pre><code>- name: Test the app on a poor connection
+  shell: pwsh
+  run: |
+    Start-Process -FilePath BeanNetworkTester.exe `
+      -ArgumentList '--loss 10 --latency 200 --target myapp.exe --duration 90'
+    npm test</code></pre>
+  <p>Two things about the runner: capturing traffic needs administrator rights, and a hosted runner
+  will not give you those, so this belongs on a self-hosted Windows machine.</p>
+</section>
+
+<section>
+  <h2>Every ending has an exit code</h2>
+  <p>Nothing ends with a traceback. Each way a run can finish has a number, so a pipeline can tell
+  "your app failed" from "the tool could not start":</p>
+  <table>
+    <tr><th>Code</th><th>Meaning</th></tr>
+    <tr><td>0</td><td>Finished as asked.</td></tr>
+    <tr><td>1</td><td>Something failed at runtime.</td></tr>
+    <tr><td>2</td><td>The command line was wrong.</td></tr>
+    <tr><td>3</td><td>The configuration or a value was invalid.</td></tr>
+    <tr><td>4</td><td>A scenario file was rejected.</td></tr>
+    <tr><td>5</td><td>A file could not be read or written.</td></tr>
+    <tr><td>6</td><td>An assertion about the run did not hold.</td></tr>
+    <tr><td>7</td><td>No administrator rights, so the driver cannot load.</td></tr>
+    <tr><td>130 / 143</td><td>Interrupted, or terminated.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Machine-readable output</h2>
+  <p><code>--format json</code> writes one JSON object per line - samples while the run goes, a
+  summary at the end - so a later step can assert on it:</p>
+<pre><code>BeanNetworkTester.exe --loss 5 --duration 30 --format json &gt; run.ndjson</code></pre>
+  <p>Log lines go to standard error and data to standard output, so redirecting the data never mixes
+  the two. <code>--seed</code> makes the run repeatable, which is what a flaky test needs before
+  anybody can argue about it.</p>
+</section>
+
+<section>
+  <h2>A dry run that touches nothing</h2>
+  <p>Two flags make this safe to wire up before you trust it: <code>--dry-run</code> reports what
+  the settings would do and exits, and <code>--simulate</code> runs the whole engine against
+  synthetic traffic, without loading the driver and without touching the network. Both are useful in
+  a build that must not impair the machine it runs on.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/ci/page.json
+++ b/site/pages/ci/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "network-tests-in-ci",
       "link_text": "Network tests in CI",
-      "title": "Simulate a bad network in CI",
+      "title": "Simulate a bad network in CI on Windows",
       "description": "The same executable runs without a window, reports through exit codes and NDJSON, and stops on its own, so a pipeline can test a bad connection."
     },
     "pl": {
       "slug": "testy-sieciowe-w-ci",
       "link_text": "Testy sieciowe w CI",
-      "title": "Symulacja słabej sieci w CI",
+      "title": "Symulacja słabej sieci w CI na Windows",
       "description": "Ten sam plik działa bez okna, raportuje kodami wyjścia i NDJSON, i zatrzymuje się sam, więc pipeline może testować słabe połączenie."
     }
   }

--- a/site/pages/ci/page.json
+++ b/site/pages/ci/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "ci",
+  "order": 60,
+  "languages": {
+    "en": {
+      "slug": "network-tests-in-ci",
+      "link_text": "Network tests in CI",
+      "title": "Simulate a bad network in CI",
+      "description": "The same executable runs without a window, reports through exit codes and NDJSON, and stops on its own, so a pipeline can test a bad connection."
+    },
+    "pl": {
+      "slug": "testy-sieciowe-w-ci",
+      "link_text": "Testy sieciowe w CI",
+      "title": "Symulacja słabej sieci w CI",
+      "description": "Ten sam plik działa bez okna, raportuje kodami wyjścia i NDJSON, i zatrzymuje się sam, więc pipeline może testować słabe połączenie."
+    }
+  }
+}

--- a/site/pages/ci/pl.html
+++ b/site/pages/ci/pl.html
@@ -1,0 +1,69 @@
+<section class="hero">
+  <h1>Symulacja słabej sieci w CI</h1>
+  <p class="lead">Okno jest opcjonalne. Ten sam plik wykonywalny działa jako narzędzie linii komend,
+  kończy się sam po zadanym czasie i raportuje wynik w formie, którą pipeline umie przeczytać.</p>
+</section>
+
+<section>
+  <h2>Kształt kroku</h2>
+  <p>Psuj sieć na czas testu i pozwól narzędziu zatrzymać się samo. Nie ma kroku sprzątającego, o
+  którym można zapomnieć:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --latency 200 --target myapp.exe --duration 60</code></pre>
+  <p>W zadaniu GitHub Actions, na własnym runnerze z Windows:</p>
+<pre><code>- name: Test aplikacji na słabym łączu
+  shell: pwsh
+  run: |
+    Start-Process -FilePath BeanNetworkTester.exe `
+      -ArgumentList '--loss 10 --latency 200 --target myapp.exe --duration 90'
+    npm test</code></pre>
+  <p>Dwie rzeczy o runnerze: przechwytywanie ruchu wymaga praw administratora, a runner hostowany
+  przez GitHuba ich nie da, więc to zadanie należy do własnej maszyny z Windows.</p>
+</section>
+
+<section>
+  <h2>Każde zakończenie ma kod wyjścia</h2>
+  <p>Nic nie kończy się tracebackiem. Każdy sposób zakończenia przebiegu ma numer, więc pipeline
+  rozróżni "Twoja aplikacja padła" od "narzędzie nie mogło wystartować":</p>
+  <table>
+    <tr><th>Kod</th><th>Znaczenie</th></tr>
+    <tr><td>0</td><td>Skończyło się tak, jak zamówiono.</td></tr>
+    <tr><td>1</td><td>Coś padło w trakcie działania.</td></tr>
+    <tr><td>2</td><td>Błąd w linii komend.</td></tr>
+    <tr><td>3</td><td>Nieprawidłowa konfiguracja albo wartość.</td></tr>
+    <tr><td>4</td><td>Plik scenariusza został odrzucony.</td></tr>
+    <tr><td>5</td><td>Nie udało się odczytać albo zapisać pliku.</td></tr>
+    <tr><td>6</td><td>Założenie o przebiegu się nie potwierdziło.</td></tr>
+    <tr><td>7</td><td>Brak praw administratora, więc sterownik się nie wczyta.</td></tr>
+    <tr><td>130 / 143</td><td>Przerwane albo zakończone z zewnątrz.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Wyjście do czytania maszyną</h2>
+  <p><code>--format json</code> wypisuje jeden obiekt JSON na linię - próbki w trakcie przebiegu,
+  podsumowanie na końcu - więc kolejny krok może na tym asertować:</p>
+<pre><code>BeanNetworkTester.exe --loss 5 --duration 30 --format json &gt; run.ndjson</code></pre>
+  <p>Linie logu idą na standardowe wyjście błędu, a dane na standardowe wyjście, więc przekierowanie
+  danych nigdy nie miesza jednego z drugim. <code>--seed</code> czyni przebieg powtarzalnym, a tego
+  potrzebuje niestabilny test, zanim ktokolwiek zacznie się o niego spierać.</p>
+</section>
+
+<section>
+  <h2>Przebieg na próbę, który niczego nie rusza</h2>
+  <p>Dwie flagi pozwalają wpiąć to, zanim zaczniesz temu ufać: <code>--dry-run</code> mówi, co
+  zrobiłyby ustawienia, i kończy pracę, a <code>--simulate</code> uruchamia cały silnik na sztucznym
+  ruchu, bez wczytywania sterownika i bez dotykania sieci. Obie są przydatne w buildzie, który nie
+  może zepsuć maszyny, na której chodzi.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/clumsy-alternative/en.html
+++ b/site/pages/clumsy-alternative/en.html
@@ -1,0 +1,71 @@
+<section class="hero">
+  <h1>A Clumsy alternative for Windows</h1>
+  <p class="lead">Clumsy is the tool most people find first, and it is a good one: free, MIT
+  licensed, interactive, and built on the same WinDivert driver this tool uses. If it does what you
+  need, use it. This page is about the cases where it does not.</p>
+</section>
+
+<section>
+  <h2>What to look for, whichever you pick</h2>
+  <table>
+    <tr><th>Question</th><th>Why it decides the tool</th></tr>
+    <tr><td>Can it hit <strong>one application</strong>?</td><td>Otherwise you impair the machine
+    you are working on, including the remote session and the browser you are reading the docs in.</td></tr>
+    <tr><td>Does it have a <strong>command line</strong>?</td><td>A pipeline cannot click a
+    checkbox. Without one, a network test can never be part of the build.</td></tr>
+    <tr><td>Is a run <strong>repeatable</strong>?</td><td>Random loss that cannot be replayed
+    produces bug reports nobody else can reproduce.</td></tr>
+    <tr><td>Does it <strong>stop by itself</strong>?</td><td>A tool that needs you to remember to
+    switch it off will be left running.</td></tr>
+    <tr><td>Can you tell what it <strong>actually did</strong>?</td><td>Counters and a connection
+    list turn "it felt slow" into numbers.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>What this one brings</h2>
+  <ul>
+    <li><strong>Targeting by process, PID, address or port</strong>, following the process tree, so a
+    browser with thirty child processes is still one target.</li>
+    <li><strong>The same executable is the command line</strong>, with an exit code for every
+    outcome and NDJSON output, so it works in CI.</li>
+    <li><strong>Seeded runs</strong>: the same seed replays the same random loss and jitter.</li>
+    <li><strong>Ready profiles</strong> - 3G, LTE, satellite, a crowded cafe, in-flight WiFi, a 56k
+    modem - so you start from something believable instead of guessing numbers.</li>
+    <li><strong>Timed sessions and scripted scenarios</strong>, so impairment can change on its own
+    while you watch the app.</li>
+    <li><strong>A live view</strong>: chart, counters and a connections table showing which
+    connection was hit.</li>
+    <li><strong>English and Polish</strong> interface, and no telemetry of any kind.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>When to use something else</h2>
+  <p>Being honest about this is cheaper than a disappointed download.</p>
+  <ul>
+    <li><strong>You are on Linux or macOS.</strong> This is Windows only, and it always will be - it
+    is built on a Windows driver. On Linux, <code>tc</code> with <code>netem</code> is the standard
+    answer and needs no extra software.</li>
+    <li><strong>You want permanent bandwidth management</strong> for the whole machine, per
+    application, as a product feature rather than a test. That is what commercial traffic-shaping
+    tools like NetLimiter are for. This one is a test instrument: it is meant to be switched on for a
+    while and then off.</li>
+    <li><strong>You cannot get administrator rights.</strong> Capturing packets needs them. There is
+    no way around that, and a tool claiming otherwise is not capturing your traffic.</li>
+    <li><strong>You need to inspect and rewrite application data</strong> rather than degrade the
+    link. That is a proxy's job.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/clumsy-alternative/page.json
+++ b/site/pages/clumsy-alternative/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "clumsy-alternative",
+  "order": 70,
+  "languages": {
+    "en": {
+      "slug": "clumsy-alternative",
+      "link_text": "A Clumsy alternative",
+      "title": "A Clumsy alternative for Windows",
+      "description": "What to look for in a network impairment tool for Windows, what this one adds over an interactive-only tool, and when to use something else."
+    },
+    "pl": {
+      "slug": "alternatywa-dla-clumsy",
+      "link_text": "Alternatywa dla Clumsy",
+      "title": "Alternatywa dla Clumsy na Windows",
+      "description": "Na co patrzeć w narzędziu do psucia sieci na Windows, co to daje ponad narzędzie tylko z okienkiem, i kiedy wybrać coś innego."
+    }
+  }
+}

--- a/site/pages/clumsy-alternative/page.json
+++ b/site/pages/clumsy-alternative/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "clumsy-alternative",
       "link_text": "A Clumsy alternative",
-      "title": "A Clumsy alternative for Windows",
+      "title": "A Clumsy alternative for Windows with a CLI",
       "description": "What to look for in a network impairment tool for Windows, what this one adds over an interactive-only tool, and when to use something else."
     },
     "pl": {
       "slug": "alternatywa-dla-clumsy",
       "link_text": "Alternatywa dla Clumsy",
-      "title": "Alternatywa dla Clumsy na Windows",
+      "title": "Alternatywa dla Clumsy na Windows z CLI",
       "description": "Na co patrzeć w narzędziu do psucia sieci na Windows, co to daje ponad narzędzie tylko z okienkiem, i kiedy wybrać coś innego."
     }
   }

--- a/site/pages/clumsy-alternative/pl.html
+++ b/site/pages/clumsy-alternative/pl.html
@@ -1,0 +1,73 @@
+<section class="hero">
+  <h1>Alternatywa dla Clumsy na Windows</h1>
+  <p class="lead">Clumsy to narzędzie, które większość ludzi znajduje pierwsze, i jest dobre:
+  darmowe, na licencji MIT, interaktywne i zbudowane na tym samym sterowniku WinDivert, z którego
+  korzysta ten program. Jeśli robi to, czego potrzebujesz - używaj go. Ta strona jest o
+  przypadkach, w których nie wystarcza.</p>
+</section>
+
+<section>
+  <h2>Na co patrzeć, niezależnie od wyboru</h2>
+  <table>
+    <tr><th>Pytanie</th><th>Dlaczego rozstrzyga o narzędziu</th></tr>
+    <tr><td>Czy trafia w <strong>jedną aplikację</strong>?</td><td>Inaczej psujesz komputer, na
+    którym pracujesz, razem z sesją zdalną i przeglądarką, w której czytasz dokumentację.</td></tr>
+    <tr><td>Czy ma <strong>linię komend</strong>?</td><td>Pipeline nie kliknie w checkbox. Bez niej
+    test sieciowy nigdy nie stanie się częścią builda.</td></tr>
+    <tr><td>Czy przebieg jest <strong>powtarzalny</strong>?</td><td>Losowa strata, której nie da się
+    odtworzyć, produkuje zgłoszenia, których nikt inny nie powtórzy.</td></tr>
+    <tr><td>Czy <strong>zatrzymuje się samo</strong>?</td><td>Narzędzie, które wymaga pamiętania o
+    wyłączeniu, zostanie włączone na noc.</td></tr>
+    <tr><td>Czy widać, co <strong>naprawdę zrobiło</strong>?</td><td>Liczniki i lista połączeń
+    zamieniają "wydawało się wolne" w liczby.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Co daje ten program</h2>
+  <ul>
+    <li><strong>Celowanie po procesie, PID-zie, adresie albo porcie</strong>, idące po drzewie
+    procesów, więc przeglądarka z trzydziestoma procesami potomnymi to nadal jeden cel.</li>
+    <li><strong>Ten sam plik wykonywalny jest linią komend</strong>, z kodem wyjścia dla każdego
+    zakończenia i wyjściem NDJSON, więc działa w CI.</li>
+    <li><strong>Przebiegi z ziarnem</strong>: to samo ziarno odtwarza tę samą losową stratę i
+    jitter.</li>
+    <li><strong>Gotowe profile</strong> - 3G, LTE, satelita, zatłoczona kawiarnia, WiFi w samolocie,
+    modem 56k - żeby startować z czegoś wiarygodnego, a nie z wymyślonych liczb.</li>
+    <li><strong>Sesje na czas i scenariusze</strong>, więc zaburzenie może zmieniać się samo, gdy Ty
+    patrzysz na aplikację.</li>
+    <li><strong>Widok na żywo</strong>: wykres, liczniki i tabela połączeń pokazująca, które
+    połączenie zostało trafione.</li>
+    <li><strong>Interfejs polski i angielski</strong>, i zero telemetrii.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Kiedy wybrać coś innego</h2>
+  <p>Uczciwość w tej sprawie jest tańsza niż rozczarowane pobranie.</p>
+  <ul>
+    <li><strong>Jesteś na Linuksie albo macOS.</strong> To narzędzie jest tylko na Windows i zawsze
+    będzie - stoi na sterowniku dla Windows. Na Linuksie standardową odpowiedzią jest
+    <code>tc</code> z <code>netem</code> i nie wymaga instalowania niczego.</li>
+    <li><strong>Chcesz stałego zarządzania przepustowością</strong> całego komputera, per aplikacja,
+    jako funkcji na codzień, a nie jako testu. Do tego są komercyjne narzędzia do kształtowania
+    ruchu, na przykład NetLimiter. To tutaj jest przyrząd testowy: ma być włączony na chwilę i
+    wyłączony.</li>
+    <li><strong>Nie możesz dostać praw administratora.</strong> Przechwytywanie pakietów ich wymaga.
+    Nie da się tego obejść, a narzędzie twierdzące inaczej nie przechwytuje Twojego ruchu.</li>
+    <li><strong>Chcesz oglądać i przepisywać dane aplikacji</strong>, a nie psuć łącze. To zadanie
+    dla proxy.</li>
+  </ul>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/faq/en.html
+++ b/site/pages/faq/en.html
@@ -1,0 +1,71 @@
+<section class="hero">
+  <h1>Questions people ask first</h1>
+  <p class="lead">The ones worth answering before you download rather than after.</p>
+</section>
+
+<section>
+  <h2>Why does it need administrator rights?</h2>
+  <p>Because packets are intercepted by a kernel driver, and Windows does not load one for a normal
+  user. The program asks for the rights itself when it starts. From the command line it refuses with
+  a specific exit code instead of failing halfway through.</p>
+</section>
+
+<section>
+  <h2>Will it break the whole machine or just my app?</h2>
+  <p>Whatever you point it at. Set a target and only that application is affected. Leave the target
+  empty and every connection on the computer is - which the program warns you about, in the window
+  and on the command line, before you can wonder why the video call dropped.</p>
+</section>
+
+<section>
+  <h2>How do I undo it?</h2>
+  <p>STOP. Closing the program does the same, and so does a time limit if you set one. If the tool
+  itself dies mid-session, a watchdog inside it shuts the capture down rather than leaving your
+  network impaired - a session must never outlive the program that started it.</p>
+</section>
+
+<section>
+  <h2>Does it send anything anywhere?</h2>
+  <p>No. There is no analytics, no crash reporting to a service and no update check. The program has
+  no network client at all. The only outgoing connection it can make is opening the support page in
+  your browser, after you click it. It intercepts your traffic, so that traffic must never leave your
+  machine, and this page you are reading loads nothing from anyone else either.</p>
+</section>
+
+<section>
+  <h2>Windows warned me about the download. Why?</h2>
+  <p>Because the executable is new and unsigned, and SmartScreen flags anything it has not seen
+  before. A code-signing certificate is a yearly cost, not a statement about the file. Every release
+  publishes a SHA-256 checksum, a list of components, and a signature tying the two to the build that
+  produced them, so you can verify what you downloaded instead of trusting a green tick.</p>
+</section>
+
+<section>
+  <h2>My download died completely and nothing says why</h2>
+  <p>Check the maximum packet size. Set low enough, it is not a smaller packet, it is a black hole:
+  the network drops what is too big and never reports it. Set it back and the transfer returns.</p>
+</section>
+
+<section>
+  <h2>Does it work on Linux or macOS?</h2>
+  <p>No, and it will not. It stands on a Windows kernel driver. On Linux, <code>tc</code> with
+  <code>netem</code> does this job and is already installed.</p>
+</section>
+
+<section>
+  <h2>Is it really free? Can I use it at work?</h2>
+  <p>Yes. It is free and open source under the GNU GPL v3, including at work, with the source
+  available for anyone to read or change. The download is the same file for everybody.</p>
+</section>
+
+<section>
+  <h2>More</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/faq/page.json
+++ b/site/pages/faq/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "faq",
       "link_text": "Questions and answers",
-      "title": "Questions people ask first",
+      "title": "Common questions about Bean Network Tester",
       "description": "Administrator rights, whether it touches the whole machine, how to undo it, the SmartScreen warning, and what it does with your data."
     },
     "pl": {
       "slug": "najczestsze-pytania",
       "link_text": "Pytania i odpowiedzi",
-      "title": "Pytania, które padają najpierw",
+      "title": "Częste pytania o Bean Network Tester",
       "description": "Prawa administratora, czy rusza cały komputer, jak to cofnąć, ostrzeżenie SmartScreen i co program robi z Twoimi danymi."
     }
   }

--- a/site/pages/faq/page.json
+++ b/site/pages/faq/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "faq",
+  "order": 80,
+  "languages": {
+    "en": {
+      "slug": "faq",
+      "link_text": "Questions and answers",
+      "title": "Questions people ask first",
+      "description": "Administrator rights, whether it touches the whole machine, how to undo it, the SmartScreen warning, and what it does with your data."
+    },
+    "pl": {
+      "slug": "najczestsze-pytania",
+      "link_text": "Pytania i odpowiedzi",
+      "title": "Pytania, które padają najpierw",
+      "description": "Prawa administratora, czy rusza cały komputer, jak to cofnąć, ostrzeżenie SmartScreen i co program robi z Twoimi danymi."
+    }
+  }
+}

--- a/site/pages/faq/pl.html
+++ b/site/pages/faq/pl.html
@@ -1,0 +1,73 @@
+<section class="hero">
+  <h1>Pytania, które padają najpierw</h1>
+  <p class="lead">Te, na które warto odpowiedzieć przed pobraniem, a nie po.</p>
+</section>
+
+<section>
+  <h2>Dlaczego wymaga praw administratora?</h2>
+  <p>Bo pakiety przechwytuje sterownik jądra, a Windows nie wczyta go dla zwykłego użytkownika.
+  Program sam prosi o te prawa przy starcie. Z linii komend odmawia z konkretnym kodem wyjścia,
+  zamiast paść w połowie roboty.</p>
+</section>
+
+<section>
+  <h2>Zepsuje cały komputer czy tylko moją aplikację?</h2>
+  <p>To, na co go skierujesz. Ustaw cel i dotknięta będzie tylko ta aplikacja. Zostaw cel pusty i
+  objęte będzie każde połączenie na komputerze - o czym program ostrzega, w oknie i w linii komend,
+  jeszcze zanim zaczniesz się zastanawiać, dlaczego zerwało rozmowę wideo.</p>
+</section>
+
+<section>
+  <h2>Jak to cofnąć?</h2>
+  <p>STOP. Zamknięcie programu działa tak samo, tak samo limit czasu, jeśli go ustawisz. Jeśli samo
+  narzędzie padnie w środku sesji, jego wewnętrzny nadzorca zamyka przechwyt, zamiast zostawiać
+  zepsutą sieć - sesja nie może przeżyć programu, który ją zaczął.</p>
+</section>
+
+<section>
+  <h2>Czy program cokolwiek gdzieś wysyła?</h2>
+  <p>Nie. Nie ma analityki, nie ma raportowania awarii do usługi, nie ma sprawdzania aktualizacji.
+  Program nie ma w ogóle klienta sieciowego. Jedyne połączenie wychodzące, jakie może wykonać, to
+  otwarcie strony wsparcia w Twojej przeglądarce, po Twoim kliknięciu. Przechwytuje Twój ruch, więc
+  ten ruch nie może opuścić Twojej maszyny - a strona, którą właśnie czytasz, też nie ładuje niczego
+  z obcych serwerów.</p>
+</section>
+
+<section>
+  <h2>Windows ostrzegł mnie przy pobieraniu. Dlaczego?</h2>
+  <p>Bo plik jest nowy i niepodpisany, a SmartScreen oznacza wszystko, czego wcześniej nie widział.
+  Certyfikat do podpisywania kodu to koszt roczny, nie opinia o pliku. Każde wydanie publikuje sumę
+  kontrolną SHA-256, listę komponentów i podpis wiążący jedno z drugim z buildem, który je wytworzył
+  - więc możesz sprawdzić, co pobrałeś, zamiast wierzyć zielonemu znaczkowi.</p>
+</section>
+
+<section>
+  <h2>Pobieranie zdechło całkowicie i nic nie mówi dlaczego</h2>
+  <p>Sprawdź maksymalny rozmiar pakietu. Ustawiony dość nisko nie jest mniejszym pakietem, tylko
+  czarną dziurą: sieć wyrzuca to, co za duże, i nigdy tego nie zgłasza. Przywróć wartość i transfer
+  wraca.</p>
+</section>
+
+<section>
+  <h2>Działa na Linuksie albo macOS?</h2>
+  <p>Nie i nie będzie. Stoi na sterowniku jądra Windows. Na Linuksie tę robotę wykonuje
+  <code>tc</code> z <code>netem</code> i jest już zainstalowany.</p>
+</section>
+
+<section>
+  <h2>Naprawdę darmowy? Mogę używać w pracy?</h2>
+  <p>Tak. Jest darmowy i otwarty na licencji GNU GPL v3, także w pracy, z kodem dostępnym dla
+  każdego do czytania i zmieniania. Pobierany plik jest ten sam dla wszystkich.</p>
+</section>
+
+<section>
+  <h2>Więcej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/home/en.html
+++ b/site/pages/home/en.html
@@ -53,7 +53,7 @@
     <li>Download the zip from the releases page and unpack it anywhere.</li>
     <li>Start <code>BeanNetworkTester.exe</code>. It asks for administrator rights by itself, because
     capturing traffic needs them.</li>
-    <li>Pick a ready profile such as "3G network", press START, and use your app.</li>
+    <li>Pick a ready profile such as "{{app.presets.3g}}", press START, and use your app.</li>
   </ol>
   <p>There is a text mode in the same file, so the whole thing also runs in a pipeline.
   One command is enough to check that your service survives 10 percent packet loss.</p>
@@ -64,6 +64,12 @@
   <p>Testers who have to reproduce "it works on my machine". Developers who need a timeout to
   actually happen. Game developers checking what lag does to their netcode. Anyone who has ever
   been asked whether the app works on a weak connection and had no honest way to find out.</p>
+</section>
+
+<section>
+  <h2>How to do a specific thing</h2>
+  <p>Short guides, each with the numbers worth trying and the command that does it.</p>
+  {{page.guide_links}}
 </section>
 
 <section class="closing">

--- a/site/pages/home/page.json
+++ b/site/pages/home/page.json
@@ -5,12 +5,14 @@
     "en": {
       "slug": "",
       "title": "Bean Network Tester - simulate a bad network on Windows",
-      "description": "Free Windows tool that adds lag, packet loss and speed limits to one app, so you can test how it behaves on a bad connection."
+      "description": "Free Windows tool that adds lag, packet loss and speed limits to one app, so you can test how it behaves on a bad connection.",
+      "link_text": "Home"
     },
     "pl": {
       "slug": "",
       "title": "Bean Network Tester - symulator słabego internetu (Windows)",
-      "description": "Darmowe narzędzie dla Windows. Dodaje opóźnienie, utratę pakietów i limit prędkości wybranej aplikacji, żeby sprawdzić, jak działa przy słabym połączeniu."
+      "description": "Darmowe narzędzie dla Windows. Dodaje opóźnienie, utratę pakietów i limit prędkości wybranej aplikacji, żeby sprawdzić, jak działa przy słabym połączeniu.",
+      "link_text": "Strona główna"
     }
   },
   "schema": "software_application"

--- a/site/pages/home/pl.html
+++ b/site/pages/home/pl.html
@@ -57,7 +57,7 @@
     <li>Pobierz archiwum ze strony wydań i rozpakuj je w dowolnym miejscu.</li>
     <li>Uruchom <code>BeanNetworkTester.exe</code>. Sam poprosi o prawa administratora, bo
     przechwytywanie ruchu ich wymaga.</li>
-    <li>Wybierz gotowy profil, na przykład "Sieć 3G", wciśnij START i korzystaj z aplikacji.</li>
+    <li>Wybierz gotowy profil, na przykład "{{app.presets.3g}}", wciśnij START i korzystaj z aplikacji.</li>
   </ol>
   <p>W tym samym pliku jest tryb tekstowy, więc całość działa też w pipeline. Jedna komenda
   wystarczy, żeby sprawdzić, czy Twoja usługa przetrwa 10 procent utraty pakietów.</p>
@@ -68,6 +68,12 @@
   <p>Testerzy, którzy muszą odtworzyć "u mnie działa". Programiści, którym timeout ma się wreszcie
   wydarzyć. Twórcy gier sprawdzający, co lag robi z ich siecią. Każdy, kto usłyszał pytanie, czy
   aplikacja działa na słabym połączeniu, i nie miał uczciwego sposobu, żeby to stwierdzić.</p>
+</section>
+
+<section>
+  <h2>Jak zrobić konkretną rzecz</h2>
+  <p>Krótkie przewodniki, każdy z wartościami wartymi wypróbowania i komendą, która to robi.</p>
+  {{page.guide_links}}
 </section>
 
 <section class="closing">

--- a/site/pages/latency/en.html
+++ b/site/pages/latency/en.html
@@ -1,0 +1,62 @@
+<section class="hero">
+  <h1>Add latency and jitter to an app</h1>
+  <p class="lead">Everything works on a fast local connection. Give the app 300 ms of ping and you
+  find out which screens were written as if the answer arrives instantly.</p>
+</section>
+
+<section>
+  <h2>Three different things</h2>
+  <table>
+    <tr><th>Setting</th><th>What it does</th><th>Where it comes from in real life</th></tr>
+    <tr><td><strong>{{app.fields.latency}}</strong></td><td>Adds the same delay to every packet, in
+    milliseconds.</td><td>Distance. A server on another continent, or a satellite.</td></tr>
+    <tr><td><strong>{{app.fields.jitter}}</strong></td><td>Adds a random amount on top, so the delay keeps
+    changing.</td><td>Shared WiFi, mobile networks, anything congested.</td></tr>
+    <tr><td><strong>Spikes</strong></td><td>Occasional long stalls, set by how often and how
+    long.</td><td>A handover between cell towers, a router under load.</td></tr>
+  </table>
+  <p>All three are in milliseconds and can run together. Both delay figures accept anything from 0
+  up, so you can go from a believable 40 ms to an absurd 60 seconds.</p>
+</section>
+
+<section>
+  <h2>From the command line</h2>
+  <p>A steady 200 ms with 80 ms of jitter, on one application:</p>
+<pre><code>BeanNetworkTester.exe --latency 200 --jitter 80 --target myapp.exe --duration 60</code></pre>
+  <p>Rare, long stalls instead - roughly one packet in twenty waits an extra second:</p>
+<pre><code>BeanNetworkTester.exe --spike-prob 5 --spike-ms 1000 --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Numbers worth trying</h2>
+  <ul>
+    <li><strong>40 ms</strong> - a server in the same country. Nothing should change.</li>
+    <li><strong>150 ms</strong> - another continent. Anything chatty starts to feel slow, because
+    each round trip costs.</li>
+    <li><strong>600 ms and up</strong> - geostationary satellite or in-flight WiFi. This is where
+    progress bars stall and retry logic finally runs.</li>
+  </ul>
+  <p>The ready profiles carry measured figures: "{{app.presets.distant}}",
+  "{{app.presets.leo}}", "{{app.presets.satellite}}", "{{app.presets.inflight}}", "{{app.presets.lte}}".</p>
+</section>
+
+<section>
+  <h2>Measuring it: look at the worst case, not the average</h2>
+  <p>Jitter barely moves an average, and it barely moves a median. A run with 30 ms of jitter and a
+  run without it can report almost the same "typical" ping while feeling completely different.</p>
+  <p>Compare the <strong>95th percentile against the median</strong> instead. The gap between them
+  is the jitter, and that gap is what makes a voice call choppy or a game unplayable while the
+  average still looks fine.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/latency/page.json
+++ b/site/pages/latency/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "latency",
+  "order": 20,
+  "languages": {
+    "en": {
+      "slug": "latency-and-jitter",
+      "link_text": "Latency and jitter",
+      "title": "Add latency and jitter to an app",
+      "description": "Give one Windows app the ping of a distant server or a train tunnel, with steady delay, random jitter or occasional spikes."
+    },
+    "pl": {
+      "slug": "opoznienie-i-jitter",
+      "link_text": "Opóźnienie i jitter",
+      "title": "Dodawanie opóźnienia i jittera",
+      "description": "Nadaj jednej aplikacji na Windows ping odległego serwera albo tunelu w pociągu: stałe opóźnienie, losowy jitter lub skoki."
+    }
+  }
+}

--- a/site/pages/latency/page.json
+++ b/site/pages/latency/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "latency-and-jitter",
       "link_text": "Latency and jitter",
-      "title": "Add latency and jitter to an app",
+      "title": "Add latency and jitter to an app on Windows",
       "description": "Give one Windows app the ping of a distant server or a train tunnel, with steady delay, random jitter or occasional spikes."
     },
     "pl": {
       "slug": "opoznienie-i-jitter",
       "link_text": "Opóźnienie i jitter",
-      "title": "Dodawanie opóźnienia i jittera",
+      "title": "Dodawanie opóźnienia i jittera na Windows",
       "description": "Nadaj jednej aplikacji na Windows ping odległego serwera albo tunelu w pociągu: stałe opóźnienie, losowy jitter lub skoki."
     }
   }

--- a/site/pages/latency/pl.html
+++ b/site/pages/latency/pl.html
@@ -1,0 +1,62 @@
+<section class="hero">
+  <h1>Dodawanie opóźnienia i jittera</h1>
+  <p class="lead">Na szybkim lokalnym łączu działa wszystko. Daj aplikacji 300 ms pingu i okaże
+  się, które ekrany napisano tak, jakby odpowiedź przychodziła natychmiast.</p>
+</section>
+
+<section>
+  <h2>Trzy różne rzeczy</h2>
+  <table>
+    <tr><th>Ustawienie</th><th>Co robi</th><th>Skąd się bierze w realu</th></tr>
+    <tr><td><strong>{{app.fields.latency}}</strong></td><td>Dokłada to samo opóźnienie każdemu pakietowi, w
+    milisekundach.</td><td>Odległość. Serwer na innym kontynencie albo satelita.</td></tr>
+    <tr><td><strong>{{app.fields.jitter}}</strong></td><td>Dokłada losową wartość na wierzchu, więc opóźnienie
+    cały czas się zmienia.</td><td>Współdzielone WiFi, sieci mobilne, wszystko przeciążone.</td></tr>
+    <tr><td><strong>Skoki</strong></td><td>Sporadyczne długie zacięcia, ustawiane przez to, jak
+    często i jak długo.</td><td>Przełączenie między nadajnikami, router pod obciążeniem.</td></tr>
+  </table>
+  <p>Wszystkie trzy są w milisekundach i mogą działać razem. Obie wartości opóźnienia przyjmują
+  cokolwiek od 0 w górę, więc możesz zejść od wiarygodnych 40 ms do absurdalnych 60 sekund.</p>
+</section>
+
+<section>
+  <h2>Z linii komend</h2>
+  <p>Stałe 200 ms z 80 ms jittera, na jednej aplikacji:</p>
+<pre><code>BeanNetworkTester.exe --latency 200 --jitter 80 --target myapp.exe --duration 60</code></pre>
+  <p>Albo rzadkie, długie zacięcia - mniej więcej co dwudziesty pakiet czeka dodatkową sekundę:</p>
+<pre><code>BeanNetworkTester.exe --spike-prob 5 --spike-ms 1000 --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Wartości warte wypróbowania</h2>
+  <ul>
+    <li><strong>40 ms</strong> - serwer w tym samym kraju. Nic nie powinno się zmienić.</li>
+    <li><strong>150 ms</strong> - inny kontynent. Wszystko, co gada z serwerem często, zaczyna być
+    ślamazarne, bo każda podróż w obie strony kosztuje.</li>
+    <li><strong>600 ms i więcej</strong> - satelita geostacjonarny albo WiFi w samolocie. Tu paski
+    postępu stają, a logika ponawiania wreszcie się uruchamia.</li>
+  </ul>
+  <p>Gotowe profile mają wpisane zmierzone wartości: "{{app.presets.distant}}",
+  "{{app.presets.leo}}", "{{app.presets.satellite}}", "{{app.presets.inflight}}", "{{app.presets.lte}}".</p>
+</section>
+
+<section>
+  <h2>Jak to mierzyć: patrz na najgorszy przypadek, nie na średnią</h2>
+  <p>Jitter prawie nie rusza średniej i prawie nie rusza mediany. Przebieg z 30 ms jittera i
+  przebieg bez niego mogą pokazać niemal ten sam "typowy" ping, a odczucie będzie zupełnie inne.</p>
+  <p>Porównuj zamiast tego <strong>95. percentyl z medianą</strong>. Różnica między nimi to właśnie
+  jitter, i to ona sprawia, że rozmowa się rwie albo gra staje się niegrywalna, gdy średnia dalej
+  wygląda dobrze.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/packet-loss/en.html
+++ b/site/pages/packet-loss/en.html
@@ -1,0 +1,63 @@
+<section class="hero">
+  <h1>Simulate packet loss on Windows</h1>
+  <p class="lead">Packet loss is the fault users describe as "it just hangs". You set a percentage,
+  the tool throws away that share of the packets, and your app has to deal with it.</p>
+</section>
+
+<section>
+  <h2>In the window</h2>
+  <ol class="steps">
+    <li>Fill in <strong>{{app.fields.target_process}}</strong> so only your application is affected, not the whole
+    machine.</li>
+    <li>Set <strong>{{app.fields.loss}}</strong> to a percentage between 0 and 100. Start at 5.</li>
+    <li>Press <strong>{{app.buttons.start}}</strong> and use the app.</li>
+  </ol>
+  <p>The bar at the top of the window summarises what is running, and the
+  <strong>{{app.app.tabs.statistics}}</strong> tab counts the packets that were dropped.</p>
+</section>
+
+<section>
+  <h2>From the command line</h2>
+  <p>The same executable runs without the window. Five percent loss on one browser, for two
+  minutes, then everything back to normal on its own:</p>
+<pre><code>BeanNetworkTester.exe --loss 5 --target chrome.exe --duration 120</code></pre>
+  <p>Add <code>--simulate</code> to rehearse the command without touching real traffic.</p>
+</section>
+
+<section>
+  <h2>What percentage to pick</h2>
+  <table>
+    <tr><th>Loss</th><th>What it feels like</th></tr>
+    <tr><td>1 percent</td><td>A good connection having a bad minute. Most apps hide it.</td></tr>
+    <tr><td>5 percent</td><td>Weak wifi. Slow page loads, video drops quality.</td></tr>
+    <tr><td>20 percent</td><td>A crowded cafe or a train tunnel. Timeouts start appearing.</td></tr>
+    <tr><td>60 percent and up</td><td>Almost unusable. Good for finding the error message nobody
+    ever tested.</td></tr>
+  </table>
+  <p>The ready profiles set this for you. "{{app.presets.weak_wifi}}", "{{app.presets.cafe}}" and "{{app.presets.3g}}" all
+  carry a loss figure along with delay and a speed limit.</p>
+</section>
+
+<section>
+  <h2>Two things that surprise people</h2>
+  <p><strong>On TCP you may see nothing at all.</strong> TCP retransmits what it loses, so a
+  download over HTTPS just gets slower instead of failing. If you want to see loss as loss, test
+  something that runs over UDP: a voice call, a game, a video stream, or DNS.</p>
+  <p><strong>Loss is random, so two runs differ.</strong> Set a seed and the same run repeats
+  exactly, which is what turns "it broke once" into a bug report somebody else can reproduce:</p>
+<pre><code>BeanNetworkTester.exe --loss 20 --target myapp.exe --seed 42 --duration 60</code></pre>
+</section>
+
+<section>
+  <h2>Next</h2>
+  <p>Loss on its own is rare. Real bad connections lose packets <em>and</em> add delay
+  <em>and</em> run out of speed, which is what the profiles reproduce.</p>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/packet-loss/page.json
+++ b/site/pages/packet-loss/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "packet-loss",
       "link_text": "Packet loss",
-      "title": "Simulate packet loss on Windows",
+      "title": "Simulate packet loss on Windows for one app",
       "description": "Drop a set percentage of one app's packets on Windows, watch what breaks, and replay the same run with a seed."
     },
     "pl": {
       "slug": "utrata-pakietow",
       "link_text": "Utrata pakietów",
-      "title": "Symulacja utraty pakietów na Windows",
+      "title": "Jak symulować utratę pakietów na Windows",
       "description": "Odrzucaj ustalony procent pakietów jednej aplikacji na Windows, patrz co się psuje i powtórz ten sam przebieg z ziarnem."
     }
   }

--- a/site/pages/packet-loss/page.json
+++ b/site/pages/packet-loss/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "packet-loss",
+  "order": 10,
+  "languages": {
+    "en": {
+      "slug": "packet-loss",
+      "link_text": "Packet loss",
+      "title": "Simulate packet loss on Windows",
+      "description": "Drop a set percentage of one app's packets on Windows, watch what breaks, and replay the same run with a seed."
+    },
+    "pl": {
+      "slug": "utrata-pakietow",
+      "link_text": "Utrata pakietów",
+      "title": "Symulacja utraty pakietów na Windows",
+      "description": "Odrzucaj ustalony procent pakietów jednej aplikacji na Windows, patrz co się psuje i powtórz ten sam przebieg z ziarnem."
+    }
+  }
+}

--- a/site/pages/packet-loss/pl.html
+++ b/site/pages/packet-loss/pl.html
@@ -1,0 +1,64 @@
+<section class="hero">
+  <h1>Symulacja utraty pakietów na Windows</h1>
+  <p class="lead">Utrata pakietów to ta usterka, którą użytkownicy opisują jako "wisi". Ustawiasz
+  procent, narzędzie wyrzuca tyle pakietów, a Twoja aplikacja musi się z tym uporać.</p>
+</section>
+
+<section>
+  <h2>W oknie programu</h2>
+  <ol class="steps">
+    <li>Wypełnij <strong>{{app.fields.target_process}}</strong>, żeby zaburzenie dotknęło tylko Twojej aplikacji, a
+    nie całego komputera.</li>
+    <li>Ustaw <strong>{{app.fields.loss}}</strong> na procent od 0 do 100. Zacznij od 5.</li>
+    <li>Wciśnij <strong>{{app.buttons.start}}</strong> i korzystaj z aplikacji.</li>
+  </ol>
+  <p>Pasek na górze okna streszcza, co jest włączone, a zakładka <strong>{{app.app.tabs.statistics}}</strong> liczy
+  odrzucone pakiety.</p>
+</section>
+
+<section>
+  <h2>Z linii komend</h2>
+  <p>Ten sam plik wykonywalny działa bez okna. Pięć procent straty na jednej przeglądarce, na dwie
+  minuty, potem wszystko samo wraca do normy:</p>
+<pre><code>BeanNetworkTester.exe --loss 5 --target chrome.exe --duration 120</code></pre>
+  <p>Dodaj <code>--simulate</code>, żeby przećwiczyć komendę bez ruszania prawdziwego ruchu.</p>
+</section>
+
+<section>
+  <h2>Jaki procent wybrać</h2>
+  <table>
+    <tr><th>Utrata</th><th>Jak to wygląda</th></tr>
+    <tr><td>1 procent</td><td>Dobre łącze w słabszej minucie. Większość aplikacji to ukryje.</td></tr>
+    <tr><td>5 procent</td><td>Słabe wifi. Strony wczytują się wolniej, wideo traci jakość.</td></tr>
+    <tr><td>20 procent</td><td>Zatłoczona kawiarnia albo tunel w pociągu. Pojawiają się timeouty.</td></tr>
+    <tr><td>60 procent i więcej</td><td>Prawie nieużywalne. Dobre do znalezienia komunikatu błędu,
+    którego nikt nigdy nie przetestował.</td></tr>
+  </table>
+  <p>Gotowe profile ustawiają to za Ciebie. "{{app.presets.weak_wifi}}", "{{app.presets.cafe}}" i
+  "{{app.presets.3g}}" mają wpisaną stratę razem z opóźnieniem i limitem prędkości.</p>
+</section>
+
+<section>
+  <h2>Dwie rzeczy, które zaskakują</h2>
+  <p><strong>Na TCP możesz nie zobaczyć niczego.</strong> TCP retransmituje to, co zgubi, więc
+  pobieranie po HTTPS po prostu zwalnia, zamiast paść. Jeśli chcesz zobaczyć stratę jako stratę,
+  testuj coś, co idzie po UDP: rozmowę głosową, grę, strumień wideo albo DNS.</p>
+  <p><strong>Strata jest losowa, więc dwa przebiegi się różnią.</strong> Ustaw ziarno, a ten sam
+  przebieg powtórzy się dokładnie - i to zamienia "raz się zepsuło" w zgłoszenie, które ktoś inny
+  odtworzy:</p>
+<pre><code>BeanNetworkTester.exe --loss 20 --target myapp.exe --seed 42 --duration 60</code></pre>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  <p>Sama strata jest rzadka. Prawdziwe słabe łącza gubią pakiety <em>i</em> dokładają opóźnienie
+  <em>i</em> nie mają prędkości - i właśnie to odtwarzają profile.</p>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/target-one-app/en.html
+++ b/site/pages/target-one-app/en.html
@@ -1,0 +1,64 @@
+<section class="hero">
+  <h1>Aim at one app, not the machine</h1>
+  <p class="lead">Without a target, every connection on the computer is affected - including the
+  remote desktop you are using and the download of the fix. With a target, one process gets the bad
+  network and everything else carries on.</p>
+</section>
+
+<section>
+  <h2>By process</h2>
+  <p>Type a name into <strong>{{app.fields.target_process}}</strong>, or pass <code>--target</code>. A bare name
+  matches as a fragment, so <code>chrome</code> covers <code>chrome.exe</code>:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --target chrome.exe</code></pre>
+  <p>It follows the process tree, which matters for anything that spawns children: a browser opens a
+  process per tab, and those are hit too.</p>
+  <p>The field takes more than one name, and more than one kind of thing at once:</p>
+  <table>
+    <tr><th>What you type</th><th>What it means</th></tr>
+    <tr><td><code>chrome.exe,firefox.exe</code></td><td>Two applications.</td></tr>
+    <tr><td><code>chrome,!chromedriver</code></td><td>Chrome, but never the driver. Exclusions
+    win.</td></tr>
+    <tr><td><code>my*.exe</code></td><td>Everything starting with "my".</td></tr>
+    <tr><td><code>re:^node\.exe$</code></td><td>A regular expression, when a wildcard is not
+    enough.</td></tr>
+    <tr><td><code>4812</code></td><td>A single process id.</td></tr>
+    <tr><td><code>&gt;1000</code></td><td>Every process id above 1000.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>By address or port</h2>
+  <p>Sometimes the app is not the unit of interest - one server is. These take the same list,
+  range and exclusion syntax, and understand CIDR and IPv6:</p>
+<pre><code>BeanNetworkTester.exe --latency 300 --dst-ip 10.0.0.0/24 --dst-port 443</code></pre>
+<pre><code>BeanNetworkTester.exe --loss 20 --dst-port "!53"</code></pre>
+  <p>The second one is worth knowing: everything except DNS. Aiming <em>away</em> from a port is
+  often easier than listing the ones you want.</p>
+</section>
+
+<section>
+  <h2>Targeting a process by name survives its restart</h2>
+  <p>Restart the application while a session is running and a target by <strong>name</strong> picks
+  the new process up again. A target by <strong>process id</strong> cannot - the id belonged to the
+  process that exited. If your test restarts the thing under test, target it by name.</p>
+</section>
+
+<section>
+  <h2>The warning you should not ignore</h2>
+  <p>Start with impairment on, nothing to aim at and no time limit, and both the window and the
+  command line say so: this affects every connection on this machine. It is a warning, not a
+  refusal - sometimes that is what you want. If it is not, set a target or a
+  <code>--duration</code>, and STOP always puts everything back.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/target-one-app/page.json
+++ b/site/pages/target-one-app/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "target-one-app",
+  "order": 40,
+  "languages": {
+    "en": {
+      "slug": "target-one-app",
+      "link_text": "Aim at one app",
+      "title": "Aim at one app, not the machine",
+      "description": "Point the impairment at one process, PID, address or port, so your test breaks the app under test and leaves the rest of the machine alone."
+    },
+    "pl": {
+      "slug": "celowanie-w-jedna-aplikacje",
+      "link_text": "Celowanie w aplikację",
+      "title": "Celuj w jedną aplikację, nie w komputer",
+      "description": "Skieruj zaburzenie na jeden proces, PID, adres albo port, żeby test psuł badaną aplikację, a resztę komputera zostawił w spokoju."
+    }
+  }
+}

--- a/site/pages/target-one-app/page.json
+++ b/site/pages/target-one-app/page.json
@@ -5,13 +5,13 @@
     "en": {
       "slug": "target-one-app",
       "link_text": "Aim at one app",
-      "title": "Aim at one app, not the machine",
+      "title": "Target one app on Windows, not the machine",
       "description": "Point the impairment at one process, PID, address or port, so your test breaks the app under test and leaves the rest of the machine alone."
     },
     "pl": {
       "slug": "celowanie-w-jedna-aplikacje",
       "link_text": "Celowanie w aplikację",
-      "title": "Celuj w jedną aplikację, nie w komputer",
+      "title": "Celuj w jedną aplikację, nie w cały komputer",
       "description": "Skieruj zaburzenie na jeden proces, PID, adres albo port, żeby test psuł badaną aplikację, a resztę komputera zostawił w spokoju."
     }
   }

--- a/site/pages/target-one-app/pl.html
+++ b/site/pages/target-one-app/pl.html
@@ -1,0 +1,63 @@
+<section class="hero">
+  <h1>Celuj w jedną aplikację, nie w komputer</h1>
+  <p class="lead">Bez celu zaburzenie dotyka każdego połączenia na komputerze - w tym pulpitu
+  zdalnego, na którym pracujesz, i pobierania poprawki. Z celem złą sieć dostaje jeden proces, a
+  reszta pracuje normalnie.</p>
+</section>
+
+<section>
+  <h2>Po procesie</h2>
+  <p>Wpisz nazwę w <strong>{{app.fields.target_process}}</strong> albo podaj <code>--target</code>. Sama nazwa
+  dopasowuje się jako fragment, więc <code>chrome</code> obejmuje <code>chrome.exe</code>:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --target chrome.exe</code></pre>
+  <p>Celowanie idzie po drzewie procesów, co ma znaczenie dla wszystkiego, co tworzy potomków:
+  przeglądarka otwiera proces na kartę i te też są objęte.</p>
+  <p>Pole przyjmuje więcej niż jedną nazwę i więcej niż jeden rodzaj rzeczy naraz:</p>
+  <table>
+    <tr><th>Co wpisujesz</th><th>Co to znaczy</th></tr>
+    <tr><td><code>chrome.exe,firefox.exe</code></td><td>Dwie aplikacje.</td></tr>
+    <tr><td><code>chrome,!chromedriver</code></td><td>Chrome, ale nigdy driver. Wykluczenia
+    wygrywają.</td></tr>
+    <tr><td><code>my*.exe</code></td><td>Wszystko, co zaczyna się na "my".</td></tr>
+    <tr><td><code>re:^node\.exe$</code></td><td>Wyrażenie regularne, gdy wildcard nie wystarcza.</td></tr>
+    <tr><td><code>4812</code></td><td>Jeden identyfikator procesu.</td></tr>
+    <tr><td><code>&gt;1000</code></td><td>Każdy proces o identyfikatorze powyżej 1000.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Po adresie albo porcie</h2>
+  <p>Czasem jednostką zainteresowania nie jest aplikacja, tylko jeden serwer. Te pola przyjmują tę
+  samą składnię list, zakresów i wykluczeń, rozumieją CIDR i IPv6:</p>
+<pre><code>BeanNetworkTester.exe --latency 300 --dst-ip 10.0.0.0/24 --dst-port 443</code></pre>
+<pre><code>BeanNetworkTester.exe --loss 20 --dst-port "!53"</code></pre>
+  <p>Ta druga komenda jest warta zapamiętania: wszystko poza DNS. Celowanie <em>obok</em> portu
+  bywa łatwiejsze niż wypisywanie tych, które chcesz objąć.</p>
+</section>
+
+<section>
+  <h2>Cel po nazwie przeżywa restart aplikacji</h2>
+  <p>Zrestartuj aplikację w trakcie sesji, a cel po <strong>nazwie</strong> podłapie nowy proces.
+  Cel po <strong>identyfikatorze</strong> nie ma jak - ten numer należał do procesu, który się
+  zakończył. Jeśli Twój test restartuje badaną rzecz, celuj po nazwie.</p>
+</section>
+
+<section>
+  <h2>Ostrzeżenie, którego nie warto ignorować</h2>
+  <p>Wystartuj z włączonym psuciem, bez celu i bez limitu czasu, a i okno, i linia komend powiedzą
+  to wprost: dotyczy to każdego połączenia na tym komputerze. To ostrzeżenie, nie odmowa - czasem
+  właśnie tego chcesz. Jeśli nie, ustaw cel albo <code>--duration</code>, a STOP zawsze przywraca
+  wszystko do normy.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -34,6 +34,9 @@
 </main>
 
 <footer class="foot">
+  <nav aria-label="{{nav.pages}}">
+    {{page.nav_links}}
+  </nav>
   <p>{{footer.license}}</p>
   <p>{{footer.no_telemetry}}</p>
   <p>{{footer.author}} <a href="{{site.issues_url}}">{{footer.issues}}</a></p>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -560,8 +560,15 @@ def test_the_structured_data_invents_neither_a_rating_nor_a_version(tmp_path):
             check(f"{rel}: the block does not close its own script element",
                   "</script>" not in raw)
             data = jsonlib.loads(raw.replace("\\u003c", "<"))
-            check(f"{rel}: it is a SoftwareApplication",
-                  data.get("@type") == "SoftwareApplication", f"({data.get('@type')})")
+            # Two kinds are expected now, and an unexpected third one is a finding:
+            # this test used to assert that EVERY block is a SoftwareApplication, which
+            # was true until the breadcrumbs arrived and then failed for the right
+            # reason. The allow list keeps that signal instead of dropping the check.
+            kind = data.get("@type")
+            check(f"{rel}: {kind} is a kind this site publishes on purpose",
+                  kind in ("SoftwareApplication", "BreadcrumbList"), f"({kind})")
+            if kind != "SoftwareApplication":
+                continue
             for field in ("name", "url", "operatingSystem", "downloadUrl"):
                 check(f"{rel}: {field} is set", data.get(field), "(missing)")
             check(f"{rel}: a free app declares the price Google requires",
@@ -569,6 +576,62 @@ def test_the_structured_data_invents_neither_a_rating_nor_a_version(tmp_path):
             for invented in ("aggregateRating", "review", "ratingValue", "softwareVersion"):
                 check(f"{rel}: no {invented} (nobody gave us one)", invented not in data)
     check("the site carries structured data at all", blocks >= 1, f"({blocks})")
+
+
+def test_every_guide_carries_the_trail_back_to_the_home_page(tmp_path):
+    """A breadcrumb, in the language of the page, generated from the registry.
+
+    Found by measuring the built output rather than by reading the plan: the guides
+    carried no structured data at all, because the idea had been waved off with "flat
+    pages have no hierarchy". Home -> page is the hierarchy, and it is what a search
+    result shows instead of a bare URL.
+
+    The home page must NOT have one (a trail of length one says nothing) and neither
+    must the error page, which asks not to be indexed at all.
+    """
+    import json as jsonlib
+    out, _ = _build(tmp_path, "crumbs")
+    registry = build_site.load_registry(ROOT)
+    base = registry["base_url"]
+    pages = build_site.load_pages(ROOT, registry)
+    home = next(p for p in pages if p["id"] == "home")
+
+    def trails(rel):
+        text = _read(os.path.join(out, rel.replace("/", os.sep)))
+        found = []
+        for raw in re.findall(r'<script type="application/ld\+json">\n(.*?)\n</script>',
+                              text, re.S):
+            data = jsonlib.loads(raw.replace("\\u003c", "<"))
+            if data.get("@type") == "BreadcrumbList":
+                found.append(data["itemListElement"])
+        return found
+
+    check("the home page has no trail",
+          not trails("index.html"), "(a one-step trail says nothing)")
+    check("the error page has no trail", not trails("404.html"), "(it is noindex)")
+
+    seen = 0
+    for page in pages:
+        if page["output"] or page["id"] == "home":
+            continue
+        for code in page["codes"]:
+            rel = posixpath.join(page["languages"][code]["dir_path"], "index.html").lstrip("/")
+            found = trails(rel)
+            check(f"{rel}: exactly one breadcrumb trail", len(found) == 1, f"({len(found)})")
+            steps = found[0]
+            check(f"{rel}: the trail is home then this page", len(steps) == 2, f"({steps})")
+            check(f"{rel}: it starts at the home page of this language",
+                  steps[0]["item"] == "%s/%s" % (
+                      base, home["languages"][code]["dir_path"] + "/"
+                      if home["languages"][code]["dir_path"] else ""),
+                  f"({steps[0]['item']})")
+            check(f"{rel}: it names the page with its own label",
+                  steps[1]["name"] == page["languages"][code]["link_text"],
+                  f"({steps[1]['name']!r})")
+            check(f"{rel}: both steps are absolute",
+                  all(step["item"].startswith(base) for step in steps), f"({steps})")
+            seen += 1
+    check("there were trails to check", seen >= 4, f"({seen})")
 
 
 def test_the_sitemap_lists_exactly_the_pages_that_may_be_indexed(tmp_path):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -17,6 +17,7 @@ on the two failure modes that are invisible:
   the URLs out of one registry, and these check that it stayed that way.
 """
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -47,7 +48,7 @@ def _read(path):
 
 
 def _sandbox(base):
-    """A copy of ``site/`` plus the two files the builder reads outside it.
+    """A copy of ``site/`` plus the files the builder reads outside it.
 
     The listed assets are only copied, never parsed, so a one-byte stand-in keeps a
     sandbox cheap enough to make one per mutation.
@@ -58,6 +59,9 @@ def _sandbox(base):
     gui = os.path.join(root, "beantester", "gui")
     os.makedirs(gui)
     shutil.copyfile(os.path.join(ROOT, build_site.THEME_FILE), os.path.join(gui, "theme.py"))
+    # The pages name field labels and preset names through the program's own language
+    # files, so a sandbox without them is not a copy of the real inputs.
+    shutil.copytree(os.path.join(ROOT, "lang"), os.path.join(root, "lang"))
     for asset in build_site.load_registry(ROOT).get("assets", []):
         target = os.path.join(root, asset["source"].replace("/", os.sep))
         os.makedirs(os.path.dirname(target), exist_ok=True)
@@ -231,6 +235,203 @@ def test_the_builder_runs_as_a_script(tmp_path):
     check("the page is there", os.path.isfile(os.path.join(out, "index.html")))
 
 
+# -- more than one page: reachability, uniqueness, links ------------------------ #
+
+def test_no_page_is_an_orphan(tmp_path):
+    """Every page is linked from every other page, in its own language.
+
+    A page nothing links to is reachable through the sitemap and nowhere else: a
+    reader never finds it, and a crawler treats it as an afterthought. The footer
+    list is generated from the page registry precisely so that adding a page cannot
+    forget to link it, and this is the check that the generation really happened.
+    """
+    out, written = _build(tmp_path)
+    registry = build_site.load_registry(ROOT)
+    pages = build_site.load_pages(ROOT, registry)
+    indexable = [p for p in pages if not p["output"]]
+    check("there is more than one page to link", len(indexable) > 1, f"({len(indexable)})")
+
+    for code in build_site.language_codes(registry):
+        for page in indexable:
+            rel = posixpath.join(page["languages"][code]["dir_path"], "index.html").lstrip("/")
+            text = _read(os.path.join(out, rel.replace("/", os.sep)))
+            for other in indexable:
+                if other["id"] == page["id"]:
+                    continue
+                label = other["languages"][code]["link_text"]
+                check(f"{rel} links to {other['id']} ({label})",
+                      f">{label}</a>" in text, "(missing from the footer list)")
+
+
+def test_no_two_pages_claim_the_same_title_or_description(tmp_path):
+    """Duplicate titles and descriptions are a real defect, not untidiness.
+
+    Two pages with one title compete for the same result, and a search engine picks
+    one and quietly discounts the other. It is also the most likely mistake when a
+    page is created by copying its neighbour, which is exactly how these were made.
+    """
+    registry = build_site.load_registry(ROOT)
+    pages = build_site.load_pages(ROOT, registry)
+    for code in build_site.language_codes(registry):
+        for field in ("title", "description", "link_text"):
+            values = [p["languages"][code][field] for p in pages if code in p["languages"]]
+            duplicates = sorted({v for v in values if values.count(v) > 1})
+            check(f"{code}: every page has its own {field}", not duplicates,
+                  f"({duplicates})")
+
+
+def test_the_polish_pages_have_polish_addresses(tmp_path):
+    """A localised page with an English address is a half-translated page.
+
+    Not cosmetic: the words in a URL are read by both a person deciding whether to
+    click and a search engine deciding what the page is about. The home page is
+    exempt - its slug is empty in every language by design.
+    """
+    registry = build_site.load_registry(ROOT)
+    pages = build_site.load_pages(ROOT, registry)
+    default = registry["default_language"]
+    for page in pages:
+        if page["output"] or page["id"] == "home":
+            continue
+        for code in page["codes"]:
+            if code == default:
+                continue
+            own = page["languages"][code]["slug"]
+            english = page["languages"][default]["slug"]
+            check(f"{page['id']} [{code}]: the address is translated, not copied",
+                  own and own != english, f"({own!r} vs {english!r})")
+
+
+def test_every_internal_link_reaches_a_page_that_exists(tmp_path):
+    """A broken internal link is invisible from the source and obvious to a visitor.
+
+    Resolved against the built tree the way a browser would: relative to the
+    directory the page sits in, with a directory link meaning its index.html. This is
+    the guard that makes localised slugs safe to hand-write - get one wrong and the
+    link that names it fails here instead of in production.
+    """
+    out, written = _build(tmp_path)
+    pages = [p for p in written if p.endswith(".html")]
+    checked = 0
+    for rel in pages:
+        text = _read(os.path.join(out, rel.replace("/", os.sep)))
+        here = posixpath.dirname(rel)
+        for href in re.findall(r'(?:href|src)="([^"]+)"', text):
+            if href.startswith(("http://", "https://", "mailto:", "#", "data:")):
+                continue
+            target = href.split("#")[0].split("?")[0]
+            if not target:
+                continue
+            full = posixpath.normpath(posixpath.join(here, target.lstrip("/"))
+                                      if target.startswith("/")
+                                      else posixpath.join(here, target))
+            if target.startswith("/"):
+                full = posixpath.normpath(target.lstrip("/"))
+            candidates = [full, posixpath.join(full, "index.html")]
+            exists = any(os.path.exists(os.path.join(out, c.replace("/", os.sep)))
+                         for c in candidates)
+            check(f"{rel}: {href} reaches something", exists, f"(looked for {candidates})")
+            checked += 1
+    check("the link scan actually followed links", checked >= 20, f"({checked})")
+
+
+def test_the_pages_never_write_a_name_from_the_program_by_hand(tmp_path):
+    """A preset name in the prose must come from ``lang/<code>.json``, not from memory.
+
+    Measured, not feared: the first draft of these guides invented three Polish preset
+    names and two field labels. The prose read perfectly and no test could see it,
+    because a guide that tells somebody to fill in a field nobody can find is wrong in
+    the same way a correct sentence is right. The pages now name them through
+    ``{{app.<key>}}``, so a rename in the program either follows or fails the build.
+
+    Preset names are checked strictly - they are distinctive phrases and cannot appear
+    by accident. Field labels are not: "Buffer" and "Jitter" are ordinary words that
+    start sentences, so the placeholder mechanism carries them and the test below only
+    proves the wiring works. That half is deliberately not airtight, and saying so is
+    better than a guard with false alarms nobody trusts.
+    """
+    import json as jsonlib
+    from beantester import presets
+    registry = build_site.load_registry(ROOT)
+    for code in build_site.language_codes(registry):
+        strings = jsonlib.load(open(os.path.join(ROOT, "lang", "%s.json" % code),
+                                    encoding="utf-8"))
+        names = [strings[key] for key in presets.PRESETS if key in strings]
+        check(f"{code}: there are preset names to look for", len(names) > 10, f"({len(names)})")
+        for path in sorted(glob_pages(code)):
+            text = _read(path)
+            for name in names:
+                check(f"{os.path.basename(os.path.dirname(path))} [{code}]: "
+                      f"{name!r} is written by hand instead of {{{{app.presets.*}}}}",
+                      name not in text, "(use the placeholder)")
+
+
+def glob_pages(code):
+    import glob
+    return glob.glob(os.path.join(SITE, "pages", "*", "%s.html" % code))
+
+
+def test_the_program_strings_really_reach_the_built_pages(tmp_path):
+    """The other half: every ``{{app.*}}`` a page uses resolves to the program's text.
+
+    Proves the wiring rather than the absence of hand-written copies - so a renamed
+    field label shows up on the site, and a key that stops existing fails the build.
+    """
+    out, _ = _build(tmp_path, "appstrings")
+    registry = build_site.load_registry(ROOT)
+    pages = build_site.load_pages(ROOT, registry)
+    used = 0
+    for code in build_site.language_codes(registry):
+        strings = build_site.load_app_strings(ROOT, code)
+        for page in pages:
+            if code not in page["languages"]:
+                continue
+            body = page["languages"][code]["body"]
+            keys = re.findall(r"\{\{(app\.[a-z0-9_.]+)\}\}", body)
+            if not keys:
+                continue
+            rel = posixpath.join(page["languages"][code]["dir_path"], "index.html").lstrip("/")
+            target = page["output"] or rel
+            text = _read(os.path.join(out, target.replace("/", os.sep)))
+            for key in keys:
+                check(f"{target}: {key} is a real key in lang/{code}.json", key in strings,
+                      "(missing)")
+                check(f"{target}: the page shows {strings[key]!r} for {key}",
+                      strings[key] in text, "(not in the built page)")
+                used += 1
+    check("the pages use the program's strings at all", used >= 10, f"({used})")
+
+
+def test_the_exit_codes_on_the_page_are_the_programs_exit_codes(tmp_path):
+    """A hand-written table of exit codes is a second copy of ``exitcodes.py``.
+
+    It is on the site because a pipeline author needs it, and it is guarded because
+    the whole point of that table is that a build can trust the numbers. Until the
+    table is generated (which is the honest fix), this is what stands between it and
+    a silent divergence.
+    """
+    from beantester import exitcodes
+    out, written = _build(tmp_path, "codes")
+    codes = {value for name, value in vars(exitcodes).items()
+             if name.isupper() and isinstance(value, int)}
+    check("there are exit codes to look for", len(codes) >= 8, f"({sorted(codes)})")
+    # Selected through the registry, not by substring: the first version matched
+    # "limit-predkosci" because it contains "ci", and then asserted that a page about
+    # speed limits lists every exit code.
+    registry = build_site.load_registry(ROOT)
+    ci = [p for p in build_site.load_pages(ROOT, registry) if p["id"] == "ci"]
+    check("the CI page is in the registry", len(ci) == 1, f"({[p['id'] for p in ci]})")
+    pages = [posixpath.join(ci[0]["languages"][code]["dir_path"], "index.html").lstrip("/")
+             for code in ci[0]["codes"]]
+    for rel in pages:
+        text = _read(os.path.join(out, rel.replace("/", os.sep)))
+        listed = {int(n) for n in re.findall(r"<td>(\d+)(?:\s*/\s*\d+)?</td>", text)}
+        listed |= {int(n) for n in re.findall(r"<td>\d+\s*/\s*(\d+)</td>", text)}
+        missing = sorted(codes - listed)
+        check(f"{rel}: every exit code the program can return is on the page", not missing,
+              f"(missing {missing}, found {sorted(listed)})")
+
+
 # -- the layer search engines read ---------------------------------------------- #
 
 def test_every_indexable_page_declares_itself_canonical(tmp_path):
@@ -259,23 +460,31 @@ def test_the_language_annotations_are_reciprocal_with_one_x_default(tmp_path):
     that one generator wrote them all the same way. And exactly one ``x-default``,
     because two is undefined behaviour dressed as thoroughness.
     """
-    out, written = _build(tmp_path)
+    out, _ = _build(tmp_path)
     registry = build_site.load_registry(ROOT)
     base = registry["base_url"]
-    pages = [p for p in written if p.endswith("index.html")]
-    expected = {lang["code"]: "%s/%s" % (base, lang["dir"] + "/" if lang["dir"] else "")
-                for lang in registry["languages"]}
-    for rel in pages:
-        page = _read(os.path.join(out, rel.replace("/", os.sep)))
-        pairs = dict(re.findall(r'<link rel="alternate" hreflang="([^"]+)" href="([^"]+)">',
-                                page))
-        for code, url in expected.items():
-            check(f"{rel}: lists {code} (including itself)", pairs.get(code) == url,
-                  f"(got {pairs.get(code)}, expected {url})")
-        x_default = re.findall(r'hreflang="x-default" href="([^"]+)"', page)
-        check(f"{rel}: exactly one x-default", len(x_default) == 1, f"({x_default})")
-        check(f"{rel}: x-default is the default language",
-              x_default[0] == expected[registry["default_language"]], f"({x_default[0]})")
+    default = registry["default_language"]
+    # Derived per PAGE, not per language: every page has its own localised address in
+    # each language, so a set of expectations built from the language directories
+    # alone would only ever have described the home page. The first version of this
+    # test did exactly that and passed until a second page existed.
+    pages = [p for p in build_site.load_pages(ROOT, registry) if not p["output"]]
+    check("there are pages to compare", len(pages) >= 2, f"({len(pages)})")
+    for page in pages:
+        expected = {code: "%s/%s" % (base, entry["dir_path"] + "/" if entry["dir_path"] else "")
+                    for code, entry in page["languages"].items()}
+        for code in page["codes"]:
+            rel = posixpath.join(page["languages"][code]["dir_path"], "index.html").lstrip("/")
+            text = _read(os.path.join(out, rel.replace("/", os.sep)))
+            pairs = dict(re.findall(
+                r'<link rel="alternate" hreflang="([^"]+)" href="([^"]+)">', text))
+            for other, url in expected.items():
+                check(f"{rel}: lists {other} (including itself)", pairs.get(other) == url,
+                      f"(got {pairs.get(other)}, expected {url})")
+            x_default = re.findall(r'hreflang="x-default" href="([^"]+)"', text)
+            check(f"{rel}: exactly one x-default", len(x_default) == 1, f"({x_default})")
+            check(f"{rel}: x-default is the default language",
+                  x_default[0] == expected[default], f"({x_default[0]})")
 
 
 def test_the_social_card_says_the_same_thing_as_the_page(tmp_path):

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -442,7 +442,7 @@ def _png_size(path):
     return struct.unpack(">II", head[16:24])
 
 
-def head_meta(page, code, registry, texts, description, root):
+def head_meta(page, code, registry, texts, description, root, home):
     """Canonical, hreflang, social cards and structured data, as HTML.
 
     Composed here and not in the template because the set differs per page and the
@@ -498,7 +498,38 @@ def head_meta(page, code, registry, texts, description, root):
 
     if page.get("schema") == "software_application":
         lines.append(_software_json_ld(registry, texts[code], canonical, description, code))
+    if page["id"] != home["id"]:
+        lines.append(_breadcrumb_json_ld(registry, page, home, code, canonical))
     return Raw("\n".join(lines))
+
+
+def _breadcrumb_json_ld(registry, page, home, code, canonical):
+    """The trail from the home page to this one.
+
+    Added after MEASURING the built output, which found every guide carrying no
+    structured data at all. The idea had been dismissed once with "nine flat pages
+    have no hierarchy", and that was wrong: home -> page IS the hierarchy, it is the
+    trail a search result shows in place of a raw URL, and it costs one generated
+    block per page.
+
+    Built from the registry, so the names are the same labels the navigation uses and
+    a renamed page cannot leave a stale trail behind.
+    """
+    base = registry["base_url"]
+    data = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1,
+             "name": home["languages"][code]["link_text"],
+             "item": _absolute(base, home["languages"][code]["dir_path"])},
+            {"@type": "ListItem", "position": 2,
+             "name": page["languages"][code]["link_text"],
+             "item": canonical},
+        ],
+    }
+    body = json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)
+    return '<script type="application/ld+json">\n%s\n</script>' % body.replace("<", "\\u003c")
 
 
 def _software_json_ld(registry, texts, canonical, description, code):
@@ -672,7 +703,7 @@ def language_switcher(page, current_code, registry, label):
                % (html.escape(label, quote=True), "".join(parts)))
 
 
-def page_context(page, code, registry, texts, home_dir, colours, root, pages):
+def page_context(page, code, registry, texts, home, colours, root, pages):
     """Everything a page's template and body may refer to, for one language."""
     entry = page["languages"][code]
     lang = _language(registry, code)
@@ -694,7 +725,8 @@ def page_context(page, code, registry, texts, home_dir, colours, root, pages):
         "page.asset_prefix": (_root_prefix(registry) if page["output"]
                               else _asset_prefix(entry["dir_path"])),
         "page.home_url": (_root_prefix(registry) if page["output"]
-                          else _relative_url(entry["dir_path"], home_dir)),
+                          else _relative_url(entry["dir_path"],
+                                             home["languages"][code]["dir_path"])),
         "page.language_switcher": language_switcher(page, code, registry,
                                                     texts[code]["nav.language"]),
         "page.nav_links": page_links(pages, page, code, "foot-nav",
@@ -703,7 +735,8 @@ def page_context(page, code, registry, texts, home_dir, colours, root, pages):
         "page.guide_links": page_links(pages, page, code, "guides", skip_home=True,
                                        root_prefix=_root_prefix(registry) if page["output"]
                                        else None),
-        "page.head_meta": head_meta(page, code, registry, texts, entry["description"], root),
+        "page.head_meta": head_meta(page, code, registry, texts, entry["description"], root,
+                                    home),
     }, "page %s [%s]" % (page["id"], code))
     return context
 
@@ -762,8 +795,7 @@ def build(root=ROOT, out=None):
     for page in pages:
         for code in page["codes"]:
             entry = page["languages"][code]
-            home_dir = home["languages"][code]["dir_path"]
-            context = page_context(page, code, registry, texts, home_dir, colours,
+            context = page_context(page, code, registry, texts, home, colours,
                                    root, pages)
             body = render(entry["body"], context,
                           "pages/%s/%s.html" % (page["id"], code))

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -63,9 +63,12 @@ THEME_FILE = os.path.join("beantester", "gui", "theme.py")
 # invisible from the source.
 TITLE_LEN = (15, 65)
 DESC_LEN = (50, 160)
+# A nav label, not a title: long enough to say what the page is, short enough that
+# nine of them fit in a footer without wrapping into a wall.
+LINK_LEN = (4, 42)
 
 SLUG_RE = re.compile(r"^$|^[a-z0-9]+(?:-[a-z0-9]+)*(?:/[a-z0-9]+(?:-[a-z0-9]+)*)*$")
-PLACEHOLDER_RE = re.compile(r"\{\{([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)*)\}\}")
+PLACEHOLDER_RE = re.compile(r"\{\{([a-z][a-z0-9_]*(?:\.[a-z0-9_]+)*)\}\}")
 
 
 class SiteError(Exception):
@@ -213,6 +216,35 @@ def load_i18n(root, codes, default_code):
     return texts
 
 
+def load_app_strings(root, code):
+    """The PROGRAM's own language file, exposed to the pages as ``app.<key>``.
+
+    The site names things the reader will see on screen - field labels, preset names -
+    and those strings live in ``lang/<code>.json``, which is where the program itself
+    reads them. Writing them out by hand got three preset names and two field labels
+    wrong on the first attempt, in a way nothing could catch: the prose read
+    perfectly, and only a comparison against the language file found it. A guide that
+    tells somebody to fill in a field that does not exist under that name is worse
+    than no guide.
+
+    Trailing colons are stripped for the same reason ``i18n.field_name`` strips them:
+    a label is written to sit in front of an input, and a sentence quoting it is not a
+    form (convention 17a).
+
+    A missing key raises through ``render``, so a renamed string breaks the build
+    instead of quietly publishing yesterday's name.
+    """
+    data = _read_json(os.path.join(root, "lang", "%s.json" % code))
+    out = {}
+    for key, value in data.items():
+        if key == "_meta" or not isinstance(value, str):
+            continue
+        out["app." + key] = value[:-1] if value.endswith(":") else value
+    if not out:
+        raise SiteError("lang/%s.json holds no strings" % code)
+    return out
+
+
 def load_pages(root, registry):
     """Every page directory under ``site/pages/``, with its metadata and bodies.
 
@@ -264,6 +296,7 @@ def load_pages(root, registry):
             slug = entry.get("slug", None)
             title = (entry.get("title") or "").strip()
             description = (entry.get("description") or "").strip()
+            link_text = (entry.get("link_text") or "").strip()
             if slug is None or not SLUG_RE.match(slug):
                 raise SiteError("pages/%s [%s]: %r is not a valid slug "
                                 "(lower case, digits and '-', '/' between segments)"
@@ -274,6 +307,10 @@ def load_pages(root, registry):
             if not DESC_LEN[0] <= len(description) <= DESC_LEN[1]:
                 raise SiteError("pages/%s [%s]: the description is %d characters, allowed %d..%d"
                                 % (page_id, code, len(description), *DESC_LEN))
+            if not LINK_LEN[0] <= len(link_text) <= LINK_LEN[1]:
+                raise SiteError("pages/%s [%s]: link_text is %d characters, allowed %d..%d "
+                                "(it is a nav label, not a title)"
+                                % (page_id, code, len(link_text), *LINK_LEN))
 
             lang = _language(registry, code)
             if page["output"]:
@@ -289,6 +326,7 @@ def load_pages(root, registry):
 
             page["languages"][code] = {
                 "slug": slug, "title": title, "description": description,
+                "link_text": link_text,
                 "dir_path": dir_path,
                 "body": _read_text(os.path.join(page_dir, "%s.html" % code)),
             }
@@ -563,6 +601,44 @@ def _relative_url(from_dir, to_dir):
     return rel if rel.endswith("/") else rel + "/"
 
 
+def page_links(pages, current, code, css_class, skip_home=False, root_prefix=None):
+    """Links to the site's other pages, as HTML.
+
+    Generated from the page registry for the same reason the language row is: a
+    hand-written list is a list that forgets the page added after it. This is also
+    what keeps a page from becoming an orphan - a page nothing links to is a page a
+    crawler reaches only through the sitemap, and a reader never.
+
+    ``skip_home`` is for the landing page's own list of guides, where a link back to
+    the page you are standing on is noise.
+
+    ``root_prefix`` exists for the error document, and it is not a detail: 404.html is
+    served AT the address that missed, so a relative link from it resolves against a
+    path that does not exist. The stylesheet was fixed for this once already, and this
+    list reintroduced the same bug by another route until the guard from that fix
+    caught it. Anything that can be served from an unknown address addresses the site
+    from its root.
+    """
+    here = current["languages"][code]["dir_path"]
+    items = []
+    for page in pages:
+        if page["output"] or page["id"] == current["id"]:
+            continue
+        if skip_home and page["id"] == "home":
+            continue
+        entry = page["languages"][code]
+        if root_prefix is not None:
+            href = root_prefix + (entry["dir_path"] + "/" if entry["dir_path"] else "")
+        else:
+            href = _relative_url(here, entry["dir_path"])
+        items.append('<li><a href="%s">%s</a></li>'
+                     % (html.escape(href, quote=True),
+                        html.escape(entry["link_text"], quote=True)))
+    if not items:
+        return Raw("")
+    return Raw('<ul class="%s">%s</ul>' % (css_class, "".join(items)))
+
+
 def language_switcher(page, current_code, registry, label):
     """The language row in the header, as HTML.
 
@@ -596,12 +672,13 @@ def language_switcher(page, current_code, registry, label):
                % (html.escape(label, quote=True), "".join(parts)))
 
 
-def page_context(page, code, registry, texts, home_dir, colours, root):
+def page_context(page, code, registry, texts, home_dir, colours, root, pages):
     """Everything a page's template and body may refer to, for one language."""
     entry = page["languages"][code]
     lang = _language(registry, code)
     repo = registry["repo_url"].rstrip("/")
     context = dict(texts[code])
+    _merge(context, load_app_strings(root, code), "program strings [%s]" % code)
     _merge(context, {
         "site.base_url": registry["base_url"],
         "site.repo_url": repo,
@@ -620,6 +697,12 @@ def page_context(page, code, registry, texts, home_dir, colours, root):
                           else _relative_url(entry["dir_path"], home_dir)),
         "page.language_switcher": language_switcher(page, code, registry,
                                                     texts[code]["nav.language"]),
+        "page.nav_links": page_links(pages, page, code, "foot-nav",
+                                     root_prefix=_root_prefix(registry) if page["output"]
+                                     else None),
+        "page.guide_links": page_links(pages, page, code, "guides", skip_home=True,
+                                       root_prefix=_root_prefix(registry) if page["output"]
+                                       else None),
         "page.head_meta": head_meta(page, code, registry, texts, entry["description"], root),
     }, "page %s [%s]" % (page["id"], code))
     return context
@@ -680,7 +763,8 @@ def build(root=ROOT, out=None):
         for code in page["codes"]:
             entry = page["languages"][code]
             home_dir = home["languages"][code]["dir_path"]
-            context = page_context(page, code, registry, texts, home_dir, colours, root)
+            context = page_context(page, code, registry, texts, home_dir, colours,
+                                   root, pages)
             body = render(entry["body"], context,
                           "pages/%s/%s.html" % (page["id"], code))
             context["page.body"] = Raw(body)


### PR DESCRIPTION
The landing page from #120 ranks for a product name nobody searches for yet. These are the pages
that answer what people type: how to simulate packet loss, how to add latency and jitter, how to cap
a speed, how to break connections, how to aim at one application, how to run this in a pipeline, how
it compares with other Windows tools, and the questions people ask before downloading.

Eight pages, each in English and Polish, with localised addresses (`/packet-loss/` and
`/pl/utrata-pakietow/`). Each one names the numbers worth trying and gives the command that does it.

## Machinery that nine pages need and one did not

- `link_text` per language, because a title written for a search result is far too long to sit in a
  list of nine.
- A footer list of every page, and a list of guides on the landing page, both **generated from the
  page registry** - adding a page cannot forget to link it, and a page nothing links to is reachable
  through the sitemap and nowhere else.
- Styles for tables and command blocks. Still no hex colour anywhere under `site/`.

## 🔴 The pages are no longer allowed to write screen names by hand

Field labels, preset names, tab and button names now come from `lang/<code>.json` - the file the
program itself reads - through `{{app.<key>}}`, with trailing colons stripped the way
`i18n.field_name` strips them.

That is not tidiness. The first draft of these guides **invented three Polish preset names and two
field labels**: the field is labelled "Process:", not "Target process", and the Polish setting is
"Latencja", not "Opoznienie". Every one of them read perfectly as prose. A guide that tells somebody
to fill in a field they cannot find is wrong in exactly the way a correct sentence is right, and only
a comparison against the language file found it - so the comparison is the mechanism now, and a
rename in the program either follows onto the site or fails the build.

## Seven guards, three of which caught something as they were written

No page is an orphan, no two pages share a title, description or nav label, Polish pages have Polish
addresses, every internal link resolves the way a browser resolves it, no preset name is hand-written,
every `{{app.*}}` reaches the built page, and the CI page's exit-code table lists every code
`exitcodes.py` defines.

What they found immediately, which is the argument for writing them at all:

- **The generated footer list reintroduced relative links on `404.html`** - the exact bug the
  stylesheet fix in #120 removed, arriving by a different route. The guard from that fix went red.
  Links from a single-output page are rooted now.
- **The hreflang test had been passing vacuously.** It built its expectations from the language
  directories, which only ever described the home page. A second page broke it; it derives them per
  page now.
- **The exit-code test selected its page with a substring** that also matches `limit-predkosci`, so
  it was asserting that a page about speed limits lists every exit code. It selects through the
  registry now.

## What is deliberately still missing

- The **download page** and the **generated reference tables** (presets, CLI flags, exit codes) are
  the next step. The exit-code table on the CI page is hand-written prose today, which is why it got
  a guard rather than a promise.
- **No breadcrumbs and no dates on the guides.** Breadcrumbs need a hierarchy that nine flat pages do
  not have, and a date would need a clock in the build, which would end byte-identical rebuilds.
- The competitor page states only what can be checked at the source about the other tool (Windows,
  WinDivert, MIT, interactive) and otherwise says what this one does, plus four cases where something
  else is the right answer. No unverified claims about somebody else's software.

## Verification

- `python -m pytest tests` - **1083 passed**, run bare and last.
- `python smoke_gui.py` - green. Both Stop hooks green.
- `python tools/build_site.py` twice into the same directory - **byte-identical**, 19 pages, 18
  sitemap entries.
- Both languages opened in a browser, desktop width, including a guide at depth two so the relative
  asset paths and the localised language switcher were seen working.
- The three new guards mutation-checked by breaking each on purpose: a hand-written preset name, a
  drifted exit code, and a dead internal link each redden their own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
