### PR TITLE
feat(site): pages for offline, timed scenarios, game lag and chaos testing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,10 @@ on:
       - "tools/build_site.py"
       - "tests/test_site.py"
       - "beantester/gui/theme.py"
+      # The site reads the shipped scenario corpus for the table on the scenarios
+      # page, so editing a scenario changes the site. Without this line the page would
+      # keep serving the previous list and look like a page nobody edited.
+      - "scenarios/**"
       - "beantester/appinfo.py"
       - "bean.png"
       - "docs/demo.gif"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   "Apply changes" to put them into a running session.
 
 ### Docs
+- **Four more guides on the website: no internet, timed scenarios, game lag and chaos testing.**
+  How to take the internet away from one app while the local network keeps working, how a scenario
+  file changes conditions on a timeline (with the seven that ship listed straight from the folder),
+  what to set when testing a game client, and how to inject network faults repeatably in a pipeline.
+  Each one also says what it cannot do.
 - **The comparison page now answers "I came from another tool".** A table putting this next to
   netem on Linux, Clumsy, NetLimiter and proxies like Fiddler, with what each one is for and what to
   expect here - including the cases where one of them is the better answer.

--- a/site/i18n/en.json
+++ b/site/i18n/en.json
@@ -37,9 +37,15 @@
   "site.tagline": "Simulate a bad network on Windows",
   "table.code": "Code",
   "table.flag": "Flag",
+  "table.length": "Length",
   "table.meaning": "What it means",
+  "table.no": "no",
   "table.preset": "Profile",
   "table.range": "Range",
+  "table.repeats": "Repeats",
+  "table.scenario": "File",
   "table.setting": "Setting",
-  "table.unit": "Unit"
+  "table.steps": "Steps",
+  "table.unit": "Unit",
+  "table.yes": "yes"
 }

--- a/site/i18n/pl.json
+++ b/site/i18n/pl.json
@@ -37,9 +37,15 @@
   "site.tagline": "Symulator słabego internetu dla Windows",
   "table.code": "Kod",
   "table.flag": "Flaga",
+  "table.length": "Długość",
   "table.meaning": "Co znaczy",
+  "table.no": "nie",
   "table.preset": "Profil",
   "table.range": "Zakres",
+  "table.repeats": "Powtarza się",
+  "table.scenario": "Plik",
   "table.setting": "Ustawienie",
-  "table.unit": "Jednostka"
+  "table.steps": "Kroków",
+  "table.unit": "Jednostka",
+  "table.yes": "tak"
 }

--- a/site/pages/chaos/en.html
+++ b/site/pages/chaos/en.html
@@ -1,0 +1,69 @@
+<section class="hero">
+  <h1>Network chaos testing on Windows</h1>
+  <p class="lead">Chaos testing means breaking something on purpose, while you are watching, to find
+  out what your software does about it. At the network layer that is exactly what this tool is: a way
+  to inject a fault into one application and see whether it survives.</p>
+</section>
+
+<section>
+  <h2>The faults you can inject</h2>
+  <table>
+    <tr><th>Fault</th><th>What it models</th></tr>
+    <tr><td>Loss, corruption, duplication</td><td>A degraded path. Packets vanish, arrive damaged, or
+    arrive twice.</td></tr>
+    <tr><td>Latency, jitter, spikes</td><td>A slow or unstable path, including the multi-second stall
+    that breaks timeouts.</td></tr>
+    <tr><td>Connection resets</td><td>A firewall or a load balancer killing connections
+    mid-transfer.</td></tr>
+    <tr><td>Link outages</td><td>The path disappearing and coming back, on a cycle.</td></tr>
+    <tr><td>Blocked address or port</td><td>One dependency unreachable while everything else
+    works.</td></tr>
+    <tr><td>Internet gone, LAN alive</td><td>The captive-portal shape: local works, the world does
+    not.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>What separates chaos from noise: repeatability</h2>
+  <p>A random failure that cannot be replayed produces a story, not a bug report. Every random
+  decision here comes from a seed, so the same command reproduces the same run - the same packets
+  lost, the same jitter, in the same order:</p>
+<pre><code>BeanNetworkTester.exe --loss 15 --rst-prob 5 --seed 42 --target myapp.exe --duration 120</code></pre>
+  <p>That is the difference between "it fell over once last Tuesday" and a failing test somebody else
+  can run.</p>
+</section>
+
+<section>
+  <h2>In a pipeline</h2>
+  <p>The command line reports through exit codes, so a build can tell "the application failed" from
+  "the tool could not start", and the session ends by itself - there is no cleanup step to forget:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --rst-prob 5 --target myapp.exe --duration 90 --format json &gt; chaos.ndjson</code></pre>
+  <p>A sequence of faults instead of one is a scenario file, and those are also repeatable. See
+  <a href="../scenarios-over-time/">timed scenarios</a> and
+  <a href="../network-tests-in-ci/">network tests in CI</a> for the exit codes and the runner it
+  needs.</p>
+</section>
+
+<section>
+  <h2>Where the blast radius stops</h2>
+  <p>Two limits, and both are deliberate. The impairment reaches one process, PID, address or port
+  when you aim it, so the machine you are working on keeps working. And it is one machine: this is
+  fault injection for a client and its connection, not for a cluster. If you are looking for chaos
+  across services and nodes, that is a different kind of tool, and this one is the piece that breaks
+  the network under a single Windows application.</p>
+  <p>Everything is reversible on the spot. STOP restores the network, a time limit does the same, and
+  a watchdog inside the tool shuts the capture down if the tool itself dies - a fault you injected
+  must never outlive the run that injected it.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/chaos/page.json
+++ b/site/pages/chaos/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "chaos",
+  "order": 75,
+  "languages": {
+    "en": {
+      "slug": "network-chaos-testing",
+      "link_text": "Chaos testing",
+      "title": "Network chaos testing on Windows",
+      "description": "Inject network faults on purpose, repeat them exactly with a seed, and let a pipeline decide from the exit code whether the application survived."
+    },
+    "pl": {
+      "slug": "chaos-testing-sieci",
+      "link_text": "Chaos testing",
+      "title": "Chaos testing sieci na Windows",
+      "description": "Wstrzykuj awarie sieci celowo, powtarzaj je dokładnie z ziarnem i pozwól pipeline'owi ocenić z kodu wyjścia, czy aplikacja przeżyła."
+    }
+  }
+}

--- a/site/pages/chaos/pl.html
+++ b/site/pages/chaos/pl.html
@@ -1,0 +1,70 @@
+<section class="hero">
+  <h1>Chaos testing sieci na Windows</h1>
+  <p class="lead">Chaos testing to psucie czegoś celowo, gdy patrzysz, żeby dowiedzieć się, co Twoje
+  oprogramowanie z tym zrobi. Na warstwie sieci to dokładnie to, czym jest ten program: sposób na
+  wstrzyknięcie awarii jednej aplikacji i sprawdzenie, czy przeżyje.</p>
+</section>
+
+<section>
+  <h2>Awarie, które można wstrzyknąć</h2>
+  <table>
+    <tr><th>Awaria</th><th>Co odwzorowuje</th></tr>
+    <tr><td>Strata, uszkodzenie, duplikacja</td><td>Zdegradowaną ścieżkę. Pakiety znikają, docierają
+    popsute albo docierają dwa razy.</td></tr>
+    <tr><td>Opóźnienie, jitter, skoki</td><td>Wolną albo niestabilną ścieżkę, razem z
+    wielosekundowym zacięciem, które psuje timeouty.</td></tr>
+    <tr><td>Zrywanie połączeń</td><td>Firewall albo load balancer zabijający połączenia w środku
+    transferu.</td></tr>
+    <tr><td>Przerwy w łączu</td><td>Ścieżkę, która znika i wraca, cyklicznie.</td></tr>
+    <tr><td>Zablokowany adres albo port</td><td>Jedną zależność nieosiągalną, gdy wszystko inne
+    działa.</td></tr>
+    <tr><td>Brak internetu przy żywym LAN-ie</td><td>Kształt portalu logowania: lokalnie działa,
+    świat nie.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Co odróżnia chaos od szumu: powtarzalność</h2>
+  <p>Losowa awaria, której nie da się odtworzyć, produkuje opowieść, nie zgłoszenie błędu. Każda
+  losowa decyzja pochodzi tu z ziarna, więc ta sama komenda odtwarza ten sam przebieg - te same
+  zgubione pakiety, ten sam jitter, w tej samej kolejności:</p>
+<pre><code>BeanNetworkTester.exe --loss 15 --rst-prob 5 --seed 42 --target myapp.exe --duration 120</code></pre>
+  <p>To jest różnica między "wywaliło się raz w zeszły wtorek" a czerwonym testem, który ktoś inny
+  potrafi uruchomić.</p>
+</section>
+
+<section>
+  <h2>W pipeline</h2>
+  <p>Linia komend raportuje kodami wyjścia, więc build rozróżni "aplikacja padła" od "narzędzie nie
+  mogło wystartować", a sesja kończy się sama - nie ma kroku sprzątającego, o którym można
+  zapomnieć:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --rst-prob 5 --target myapp.exe --duration 90 --format json &gt; chaos.ndjson</code></pre>
+  <p>Ciąg awarii zamiast jednej to plik scenariusza, i on też jest powtarzalny. Zobacz
+  <a href="../scenariusze-w-czasie/">scenariusze w czasie</a> oraz
+  <a href="../testy-sieciowe-w-ci/">testy sieciowe w CI</a> po kody wyjścia i po to, jakiego runnera
+  to wymaga.</p>
+</section>
+
+<section>
+  <h2>Gdzie kończy się promień rażenia</h2>
+  <p>Dwa ograniczenia i oba są zamierzone. Zaburzenie sięga jednego procesu, PID-u, adresu albo
+  portu, gdy je wycelujesz, więc maszyna, na której pracujesz, dalej działa. I jest to jedna maszyna:
+  to jest wstrzykiwanie awarii klientowi i jego łączu, nie klastrowi. Jeśli szukasz chaosu w wielu
+  usługach i węzłach, to inny rodzaj narzędzia, a to tutaj jest elementem, który psuje sieć pod
+  jedną aplikacją na Windows.</p>
+  <p>Wszystko jest odwracalne na miejscu. STOP przywraca sieć, limit czasu robi to samo, a wewnętrzny
+  nadzorca zamyka przechwyt, jeśli samo narzędzie padnie - awaria, którą wstrzyknąłeś, nie może
+  przeżyć przebiegu, który ją wstrzyknął.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/game-lag/en.html
+++ b/site/pages/game-lag/en.html
@@ -1,0 +1,72 @@
+<section class="hero">
+  <h1>Simulate game lag and packet loss</h1>
+  <p class="lead">Netcode is written on a local connection with 1 ms of ping and tested by players on
+  hotel WiFi. This closes that gap on your own machine, on the game process only, while the rest of
+  the computer stays usable.</p>
+</section>
+
+<section>
+  <h2>Start here</h2>
+  <p>Aim at the game client, give it a realistic bad connection, and let it stop itself after five
+  minutes:</p>
+<pre><code>BeanNetworkTester.exe --latency 120 --jitter 60 --loss 3 --target mygame.exe --duration 300</code></pre>
+  <p>There is a ready timeline for this too - <code>overloaded-game-server.json</code> in the
+  <code>scenarios</code> folder walks a connection into congestion and back out, so you can watch
+  the client handle both directions of the change. See
+  <a href="../scenarios-over-time/">timed scenarios</a>.</p>
+</section>
+
+<section>
+  <h2>Why a game shows loss when a browser does not</h2>
+  <p>Most game traffic is UDP, and UDP has nothing to hide loss behind. A web page over TCP quietly
+  retransmits and just takes longer, which is why a browser can feel fine at 5 percent loss while a
+  match at the same 5 percent stutters, rubber-bands and desynchronises.</p>
+  <p>That makes a game the honest place to test loss: what you set is what the client actually
+  experiences.</p>
+</section>
+
+<section>
+  <h2>What to set, and what it looks for</h2>
+  <table>
+    <tr><th>Setting</th><th>Try</th><th>What it exposes</th></tr>
+    <tr><td>Latency</td><td>80 to 250 ms</td><td>Prediction and interpolation. Does your character
+    slide back after a shot?</td></tr>
+    <tr><td>Jitter</td><td>40 to 100 ms</td><td>Buffering. A steady 200 ms is easier to hide than a
+    ping that keeps moving.</td></tr>
+    <tr><td>Loss</td><td>2 to 10 percent</td><td>Missing state updates, and whether the client
+    recovers or drifts.</td></tr>
+    <tr><td>Spikes</td><td>1 second, rarely</td><td>The stall a tower handover causes. Usually the
+    ugliest one.</td></tr>
+    <tr><td>Link on and off</td><td>10 s cycle, 30 percent down</td><td>Reconnect and rejoin.</td></tr>
+  </table>
+  <p>Measure jitter as the gap between the 95th percentile and the median rather than as an average -
+  jitter barely moves an average, which is why a run can look identical on paper and play
+  differently.</p>
+</section>
+
+<section>
+  <h2>Comparing two builds needs a seed</h2>
+  <p>Random loss makes two runs different, so "the new build feels worse" is not evidence. The same
+  seed replays the same loss and the same jitter, which turns a feeling into a comparison:</p>
+<pre><code>BeanNetworkTester.exe --latency 120 --jitter 60 --loss 5 --seed 42 --target mygame.exe --duration 180</code></pre>
+</section>
+
+<section>
+  <h2>What it cannot do</h2>
+  <p>This shapes the traffic of <em>your</em> machine. It does not slow the server down, it does not
+  change its tick rate, and it does not put other players on a bad connection - so it tests your
+  client against a bad link, not your server under load. For the server side you want load testing,
+  and for a lobby full of bad connections you want more than one machine.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/game-lag/page.json
+++ b/site/pages/game-lag/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "game-lag",
+  "order": 65,
+  "languages": {
+    "en": {
+      "slug": "game-lag-simulator",
+      "link_text": "Game lag",
+      "title": "Simulate game lag and packet loss",
+      "description": "Give a game client the ping, jitter and packet loss of a bad connection, aimed at that process only, and replay the same run with a seed."
+    },
+    "pl": {
+      "slug": "symulator-lagow-w-grach",
+      "link_text": "Lagi w grach",
+      "title": "Symulator lagów i utraty pakietów w grach",
+      "description": "Daj klientowi gry ping, jitter i utratę pakietów słabego łącza, celując tylko w ten proces, i powtórz ten sam przebieg z ziarnem."
+    }
+  }
+}

--- a/site/pages/game-lag/pl.html
+++ b/site/pages/game-lag/pl.html
@@ -1,0 +1,74 @@
+<section class="hero">
+  <h1>Symulator lagów i utraty pakietów w grach</h1>
+  <p class="lead">Kod sieciowy pisze się na lokalnym łączu z pingiem 1 ms, a testują go gracze na
+  hotelowym WiFi. To zamyka tę różnicę na Twojej maszynie, tylko na procesie gry, gdy reszta
+  komputera zostaje używalna.</p>
+</section>
+
+<section>
+  <h2>Zacznij tutaj</h2>
+  <p>Wyceluj w klienta gry, daj mu wiarygodnie słabe łącze i pozwól zatrzymać się samo po pięciu
+  minutach:</p>
+<pre><code>BeanNetworkTester.exe --latency 120 --jitter 60 --loss 3 --target mygame.exe --duration 300</code></pre>
+  <p>Jest też gotowa linia czasu - <code>overloaded-game-server.json</code> w katalogu
+  <code>scenarios</code> wprowadza łącze w przeciążenie i z niego wyprowadza, więc widzisz, jak
+  klient radzi sobie z oboma kierunkami zmiany. Zobacz
+  <a href="../scenariusze-w-czasie/">scenariusze w czasie</a>.</p>
+</section>
+
+<section>
+  <h2>Dlaczego gra pokazuje stratę, a przeglądarka nie</h2>
+  <p>Większość ruchu gier to UDP, a UDP nie ma czym zasłonić straty. Strona po TCP po cichu
+  retransmituje i po prostu ładuje się dłużej - dlatego przeglądarka może działać znośnie przy 5
+  procentach straty, gdy mecz przy tych samych 5 procentach się tnie, cofa postacie i traci
+  synchronizację.</p>
+  <p>To czyni grę uczciwym miejscem do testowania straty: to, co ustawisz, jest tym, czego klient
+  naprawdę doświadcza.</p>
+</section>
+
+<section>
+  <h2>Co ustawić i czego to szuka</h2>
+  <table>
+    <tr><th>Ustawienie</th><th>Spróbuj</th><th>Co obnaża</th></tr>
+    <tr><td>Latencja</td><td>80 do 250 ms</td><td>Predykcję i interpolację. Czy postać cofa się po
+    strzale?</td></tr>
+    <tr><td>Jitter</td><td>40 do 100 ms</td><td>Buforowanie. Stałe 200 ms łatwiej ukryć niż ping,
+    który ciągle się rusza.</td></tr>
+    <tr><td>Utrata</td><td>2 do 10 procent</td><td>Gubione aktualizacje stanu i to, czy klient wraca,
+    czy odjeżdża.</td></tr>
+    <tr><td>Skoki</td><td>1 sekunda, rzadko</td><td>Zacięcie przy przełączeniu nadajnika. Zwykle
+    najbrzydsze.</td></tr>
+    <tr><td>Łącze na przemian</td><td>cykl 10 s, 30 procent przerwy</td><td>Ponowne łączenie i powrót
+    do rozgrywki.</td></tr>
+  </table>
+  <p>Jitter mierz jako różnicę między 95. percentylem a medianą, nie jako średnią - jitter prawie nie
+  rusza średniej, dlatego przebieg może wyglądać identycznie na papierze i grać się inaczej.</p>
+</section>
+
+<section>
+  <h2>Porównanie dwóch buildów wymaga ziarna</h2>
+  <p>Losowa strata sprawia, że dwa przebiegi się różnią, więc "nowy build wydaje się gorszy" nie jest
+  dowodem. To samo ziarno odtwarza tę samą stratę i ten sam jitter, co zamienia wrażenie w
+  porównanie:</p>
+<pre><code>BeanNetworkTester.exe --latency 120 --jitter 60 --loss 5 --seed 42 --target mygame.exe --duration 180</code></pre>
+</section>
+
+<section>
+  <h2>Czego to nie potrafi</h2>
+  <p>To kształtuje ruch <em>Twojej</em> maszyny. Nie zwalnia serwera, nie zmienia jego tick rate i
+  nie wsadza innych graczy na słabe łącze - więc testuje Twojego klienta przy złym łączu, a nie
+  serwer pod obciążeniem. Do strony serwerowej służą testy obciążeniowe, a do lobby pełnego słabych
+  łączy potrzebujesz więcej niż jednej maszyny.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/offline/en.html
+++ b/site/pages/offline/en.html
@@ -1,0 +1,70 @@
+<section class="hero">
+  <h1>Test an app with no internet</h1>
+  <p class="lead">Pulling the network cable tests one thing: a machine with no network. Most offline
+  bugs are not that. They happen when the adapter is up, the WiFi icon looks fine, and the thing the
+  app needs is simply not reachable.</p>
+</section>
+
+<section>
+  <h2>Three different kinds of "offline"</h2>
+  <table>
+    <tr><th>What you switch on</th><th>What the app sees</th><th>The bug it finds</th></tr>
+    <tr><td><strong>LAN mode</strong></td><td>The local network works. Anything beyond it does
+    not.</td><td>Hotel WiFi before you log in, a dead uplink, a company network with no route
+    out.</td></tr>
+    <tr><td><strong>Block an address</strong></td><td>One server is unreachable. Everything else
+    works.</td><td>One dependency down while the app itself is fine - the case a health check
+    usually misses.</td></tr>
+    <tr><td><strong>Block port 53</strong></td><td>Names stop resolving, connections by address
+    still work.</td><td>Broken DNS, which looks like "the internet is down" to a user and like
+    something else entirely in the logs.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>From the command line</h2>
+  <p>Internet gone for one application, local network untouched, for two minutes:</p>
+<pre><code>BeanNetworkTester.exe --lan-mode --target myapp.exe --duration 120</code></pre>
+  <p>One service unreachable, everything else normal:</p>
+<pre><code>BeanNetworkTester.exe --block-ip 203.0.113.10</code></pre>
+  <p>Names stop resolving:</p>
+<pre><code>BeanNetworkTester.exe --block-port 53 --target myapp.exe</code></pre>
+  <p>There is also a ready timeline that breaks DNS and puts it back on its own -
+  <code>failing-dns.json</code> in the <code>scenarios</code> folder next to the program. See
+  <a href="../scenarios-over-time/">timed scenarios</a>.</p>
+</section>
+
+<section>
+  <h2>What to actually look for</h2>
+  <ul>
+    <li><strong>The message.</strong> Does the app say what happened, or show a spinner for
+    ever?</li>
+    <li><strong>The retry.</strong> Does it back off, or hammer the same address in a loop?</li>
+    <li><strong>The queue.</strong> Is work the user did while offline kept and sent later, or
+    lost?</li>
+    <li><strong>The recovery.</strong> STOP puts the network back. Does the app notice on its own,
+    or does it need a restart?</li>
+  </ul>
+  <p>That last one is where most of the value is. Going offline is easy to handle badly and easy to
+  test. Coming back is where the state gets wrong.</p>
+</section>
+
+<section>
+  <h2>What this is not</h2>
+  <p>The adapter stays up and the machine keeps its address, so an application that only asks
+  Windows "is there a network" still gets yes. That is deliberate, and it is the more interesting
+  test: real users are rarely disconnected, they are connected to something that cannot reach what
+  they need. If you specifically want the "no adapter" case, disable the adapter - no tool needed.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/offline/page.json
+++ b/site/pages/offline/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "offline",
+  "order": 45,
+  "languages": {
+    "en": {
+      "slug": "test-app-offline",
+      "link_text": "No internet",
+      "title": "Test an app with no internet on Windows",
+      "description": "Take the internet away from one app while the local network keeps working, make a single service unreachable, or break DNS - without unplugging anything."
+    },
+    "pl": {
+      "slug": "test-bez-internetu",
+      "link_text": "Bez internetu",
+      "title": "Test aplikacji bez internetu na Windows",
+      "description": "Zabierz internet jednej aplikacji, zostawiając sieć lokalną, uczyń jedną usługę nieosiągalną albo zepsuj DNS - bez wyciągania żadnej wtyczki."
+    }
+  }
+}

--- a/site/pages/offline/pl.html
+++ b/site/pages/offline/pl.html
@@ -1,0 +1,72 @@
+<section class="hero">
+  <h1>Test aplikacji bez internetu</h1>
+  <p class="lead">Wyciągnięcie kabla testuje jedną rzecz: komputer bez sieci. Większość błędów
+  offline nie jest tym przypadkiem. Zdarzają się, gdy karta sieciowa działa, ikona WiFi wygląda
+  normalnie, a to, czego aplikacja potrzebuje, jest po prostu nieosiągalne.</p>
+</section>
+
+<section>
+  <h2>Trzy różne rodzaje "offline"</h2>
+  <table>
+    <tr><th>Co włączasz</th><th>Co widzi aplikacja</th><th>Jaki błąd to znajduje</th></tr>
+    <tr><td><strong>Tryb LAN</strong></td><td>Sieć lokalna działa. Cokolwiek poza nią - nie.</td>
+    <td>Hotelowe WiFi przed zalogowaniem, padnięte łącze operatora, firmowa sieć bez wyjścia na
+    świat.</td></tr>
+    <tr><td><strong>Blokada adresu</strong></td><td>Jeden serwer jest nieosiągalny. Wszystko inne
+    działa.</td><td>Jedna zależność padła, gdy sama aplikacja jest zdrowa - przypadek, który
+    health check zwykle przegapia.</td></tr>
+    <tr><td><strong>Blokada portu 53</strong></td><td>Nazwy przestają się rozwiązywać, połączenia po
+    adresie nadal działają.</td><td>Zepsuty DNS, który dla użytkownika wygląda jak "nie ma
+    internetu", a w logach jak coś zupełnie innego.</td></tr>
+  </table>
+</section>
+
+<section>
+  <h2>Z linii komend</h2>
+  <p>Internet znika dla jednej aplikacji, sieć lokalna nietknięta, na dwie minuty:</p>
+<pre><code>BeanNetworkTester.exe --lan-mode --target myapp.exe --duration 120</code></pre>
+  <p>Jedna usługa nieosiągalna, wszystko inne normalnie:</p>
+<pre><code>BeanNetworkTester.exe --block-ip 203.0.113.10</code></pre>
+  <p>Nazwy przestają się rozwiązywać:</p>
+<pre><code>BeanNetworkTester.exe --block-port 53 --target myapp.exe</code></pre>
+  <p>Jest też gotowa linia czasu, która psuje DNS i sama go przywraca -
+  <code>failing-dns.json</code> w katalogu <code>scenarios</code> obok programu. Zobacz
+  <a href="../scenariusze-w-czasie/">scenariusze w czasie</a>.</p>
+</section>
+
+<section>
+  <h2>Na co naprawdę patrzeć</h2>
+  <ul>
+    <li><strong>Komunikat.</strong> Czy aplikacja mówi, co się stało, czy kręci kółkiem bez
+    końca?</li>
+    <li><strong>Ponowienie.</strong> Czy odpuszcza coraz rzadziej, czy wali w ten sam adres w
+    pętli?</li>
+    <li><strong>Kolejka.</strong> Czy praca wykonana bez łącza zostaje zachowana i wysłana potem, czy
+    przepada?</li>
+    <li><strong>Powrót.</strong> STOP przywraca sieć. Czy aplikacja zauważy to sama, czy trzeba ją
+    zrestartować?</li>
+  </ul>
+  <p>To ostatnie jest najcenniejsze. Zniknięcie łącza łatwo obsłużyć źle i łatwo przetestować.
+  Dopiero powrót jest miejscem, w którym stan robi się nieprawdziwy.</p>
+</section>
+
+<section>
+  <h2>Czym to nie jest</h2>
+  <p>Karta sieciowa zostaje włączona i komputer trzyma swój adres, więc aplikacja, która pyta
+  Windows tylko "czy jest sieć", dostaje tak. To jest zamierzone i jest ciekawszym testem: prawdziwi
+  użytkownicy rzadko są rozłączeni, oni są połączeni z czymś, co nie umie dosięgnąć tego, czego
+  potrzebują. Jeśli chcesz właśnie przypadku "nie ma karty", wyłącz kartę - do tego nie trzeba
+  narzędzia.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/scenarios/en.html
+++ b/site/pages/scenarios/en.html
@@ -1,0 +1,68 @@
+<section class="hero">
+  <h1>Change network conditions over time</h1>
+  <p class="lead">A fixed 10 percent loss is a lab condition. Real connections get worse, recover,
+  stall for four seconds and come back - and the bug you are chasing usually lives in the change,
+  not in the steady state.</p>
+</section>
+
+<section>
+  <h2>A scenario is a timeline</h2>
+  <p>One JSON file. Each step says <em>at this second, these settings</em>, and anything you do not
+  mention keeps its value:</p>
+<pre><code>{
+  "loop": true,
+  "steps": [
+    {"at": 0,  "settings": {"latency": 20, "jitter": 15, "down": 4096}},
+    {"at": 20, "settings": {"loss": 8, "latency": 180}},
+    {"at": 45, "settings": {"block_ip": "203.0.113.0/24"}},
+    {"at": 65, "settings": {"block_ip": "", "loss": 0, "latency": 20}}
+  ]
+}</code></pre>
+  <p>Times are seconds from the start of the run, not gaps between steps. With
+  <code>"loop": true</code> the timeline starts over when it ends, which is what you want for a long
+  soak: leave it running and use the app.</p>
+<pre><code>BeanNetworkTester.exe --scenario cafe-wifi.json --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Seven of them ship with the program</h2>
+  <p>In the <code>scenarios</code> folder next to the executable. Read from those files, so this is
+  what you actually have:</p>
+  {{page.scenario_table}}
+  <p>They are ordinary text - open one, change a number, save. The names say what they reproduce:
+  a crowded cafe, a mobile connection dropping from LTE to 3G, an upload that dies half way, a
+  server that gets overloaded, DNS that stops answering.</p>
+</section>
+
+<section>
+  <h2>Two simpler ways to get change</h2>
+  <p>A scenario is worth writing when the sequence matters. When it does not, two settings vary on
+  their own:</p>
+  <ul>
+    <li><strong>Link on and off</strong> - a cycle length and how much of it is downtime. Ten second
+    cycles, four seconds down, forever.</li>
+    <li><strong>A speed schedule</strong> - a series of speeds the limit walks through, so the
+    connection degrades and recovers without a file.</li>
+  </ul>
+<pre><code>BeanNetworkTester.exe --flap-period 10 --flap-down 40 --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Why it works while the app is running</h2>
+  <p>Every setting a scenario touches is applied live, to the session already in progress - the app
+  does not need restarting and neither does the tool. The event log records each step as it happens,
+  so when something breaks you can see which change it followed. Pair that with a seed and the whole
+  sequence, including the random loss inside it, repeats exactly.</p>
+</section>
+
+<section>
+  <h2>Next</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/site/pages/scenarios/page.json
+++ b/site/pages/scenarios/page.json
@@ -1,0 +1,18 @@
+{
+  "id": "scenarios",
+  "order": 55,
+  "languages": {
+    "en": {
+      "slug": "scenarios-over-time",
+      "link_text": "Timed scenarios",
+      "title": "Change network conditions over time",
+      "description": "A scenario file is a timeline: at these seconds, these settings. Seven ready ones ship with the program, and it repeats them for as long as you watch."
+    },
+    "pl": {
+      "slug": "scenariusze-w-czasie",
+      "link_text": "Scenariusze w czasie",
+      "title": "Zmieniaj warunki sieci w czasie",
+      "description": "Plik scenariusza to linia czasu: w tych sekundach takie ustawienia. Siedem gotowych jest z programem, a on powtarza je tak długo, jak patrzysz."
+    }
+  }
+}

--- a/site/pages/scenarios/pl.html
+++ b/site/pages/scenarios/pl.html
@@ -1,0 +1,67 @@
+<section class="hero">
+  <h1>Zmieniaj warunki sieci w czasie</h1>
+  <p class="lead">Stałe 10 procent straty to warunek laboratoryjny. Prawdziwe łącza pogarszają się,
+  wracają, stają na cztery sekundy i znów działają - a błąd, którego szukasz, zwykle siedzi w
+  zmianie, nie w stanie ustalonym.</p>
+</section>
+
+<section>
+  <h2>Scenariusz to linia czasu</h2>
+  <p>Jeden plik JSON. Każdy krok mówi <em>w tej sekundzie takie ustawienia</em>, a wszystko, czego
+  nie wymienisz, zachowuje swoją wartość:</p>
+<pre><code>{
+  "loop": true,
+  "steps": [
+    {"at": 0,  "settings": {"latency": 20, "jitter": 15, "down": 4096}},
+    {"at": 20, "settings": {"loss": 8, "latency": 180}},
+    {"at": 45, "settings": {"block_ip": "203.0.113.0/24"}},
+    {"at": 65, "settings": {"block_ip": "", "loss": 0, "latency": 20}}
+  ]
+}</code></pre>
+  <p>Czasy są sekundami od startu przebiegu, nie odstępami między krokami. Przy
+  <code>"loop": true</code> linia czasu zaczyna się od nowa, gdy się skończy - i tego właśnie chcesz
+  przy długim wygrzewaniu: zostaw to włączone i korzystaj z aplikacji.</p>
+<pre><code>BeanNetworkTester.exe --scenario cafe-wifi.json --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Siedem jest dostarczanych z programem</h2>
+  <p>W katalogu <code>scenarios</code> obok pliku wykonywalnego. Odczytane z tych plików, więc to
+  jest to, co naprawdę masz:</p>
+  {{page.scenario_table}}
+  <p>To zwykły tekst - otwórz jeden, zmień liczbę, zapisz. Nazwy mówią, co odtwarzają: zatłoczoną
+  kawiarnię, łącze mobilne spadające z LTE na 3G, wysyłanie, które umiera w połowie, przeciążony
+  serwer, DNS, który przestaje odpowiadać.</p>
+</section>
+
+<section>
+  <h2>Dwa prostsze sposoby na zmienność</h2>
+  <p>Scenariusz warto pisać, gdy liczy się kolejność. Gdy nie, dwa ustawienia zmieniają się same:</p>
+  <ul>
+    <li><strong>Łącze na przemian</strong> - długość cyklu i jaka jego część to przestój. Cykle
+    dziesięciosekundowe, cztery sekundy przerwy, bez końca.</li>
+    <li><strong>Harmonogram prędkości</strong> - ciąg prędkości, po których chodzi limit, więc łącze
+    pogarsza się i wraca bez żadnego pliku.</li>
+  </ul>
+<pre><code>BeanNetworkTester.exe --flap-period 10 --flap-down 40 --target myapp.exe</code></pre>
+</section>
+
+<section>
+  <h2>Dlaczego to działa na żywo</h2>
+  <p>Każde ustawienie, którego dotyka scenariusz, stosuje się do trwającej już sesji - aplikacji nie
+  trzeba restartować i narzędzia też nie. Dziennik zdarzeń zapisuje każdy krok w chwili, gdy
+  następuje, więc gdy coś pęknie, widzisz, po której zmianie. Dołóż do tego ziarno losowości i cała
+  sekwencja, razem z losową stratą w środku, powtórzy się dokładnie.</p>
+</section>
+
+<section>
+  <h2>Dalej</h2>
+  {{page.guide_links}}
+</section>
+
+<section class="closing">
+  <h2>{{cta.closing}}</h2>
+  <p class="actions">
+    <a class="btn btn-primary" href="{{site.download_url}}">{{cta.download}}</a>
+  </p>
+</section>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -62,6 +62,9 @@ def _sandbox(base):
     # The pages name field labels and preset names through the program's own language
     # files, so a sandbox without them is not a copy of the real inputs.
     shutil.copytree(os.path.join(ROOT, "lang"), os.path.join(root, "lang"))
+    # The scenarios page reads the shipped corpus, so a sandbox without it is not a
+    # copy of the real inputs.
+    shutil.copytree(os.path.join(ROOT, "scenarios"), os.path.join(root, "scenarios"))
     for asset in build_site.load_registry(ROOT).get("assets", []):
         target = os.path.join(root, asset["source"].replace("/", os.sep))
         os.makedirs(os.path.dirname(target), exist_ok=True)
@@ -764,6 +767,29 @@ def test_the_reference_tables_are_generated_from_the_registries(tmp_path):
                       "(missing row)")
 
 
+def test_the_scenario_table_lists_exactly_what_ships(tmp_path):
+    """Every scenario file appears, and nothing that is not a file does.
+
+    The numbers - steps, length, whether it repeats - are read out of the JSON rather
+    than described, because a sentence about a timeline is exactly the kind of prose
+    that survives the timeline being edited. Both directions: a new scenario has to show
+    up, and a row cannot name a file that is gone.
+    """
+    import glob
+    out, _ = _build(tmp_path, "scenarios")
+    registry = build_site.load_registry(ROOT)
+    page = next(p for p in build_site.load_pages(ROOT, registry) if p["id"] == "scenarios")
+    shipped = sorted(os.path.basename(p) for p in
+                     glob.glob(os.path.join(ROOT, "scenarios", "*.json")))
+    check("the program ships scenarios to list", len(shipped) >= 5, f"({shipped})")
+    for code in page["codes"]:
+        rel = posixpath.join(page["languages"][code]["dir_path"], "index.html").lstrip("/")
+        text = _read(os.path.join(out, rel.replace("/", os.sep)))
+        listed = re.findall(r"<td><code>([^<]+\.json)</code></td>", text)
+        check(f"{rel}: every shipped scenario is in the table", sorted(listed) == shipped,
+              f"(only in one: {set(listed) ^ set(shipped)})")
+
+
 def test_no_page_writes_its_own_table_of_exit_codes(tmp_path):
     """The CI page used to carry a hand-typed copy. It uses the generated one now.
 
@@ -979,6 +1005,12 @@ def test_the_workflow_rebuilds_when_any_source_of_the_page_changes(tmp_path):
     registry = build_site.load_registry(ROOT)
     needed = ["site/**", "tools/build_site.py", build_site.THEME_FILE.replace(os.sep, "/")]
     needed += [asset["source"] for asset in registry.get("assets", [])]
+    # Derived, not typed: if the generator reads the scenario corpus - and it does, for
+    # the table on the scenarios page - then editing a scenario changes the site, so the
+    # filter has to fire on it. Without this the page would keep serving the previous
+    # list and look like a page nobody edited.
+    if "scenarios" in _read(os.path.join(ROOT, "tools", "build_site.py")):
+        needed.append("scenarios/**")
     for path in needed:
         check(f"the paths filter covers {path}", f'"{path}"' in text, "(missing)")
 
@@ -1189,6 +1221,15 @@ def test_the_build_refuses_a_source_that_would_publish_a_broken_page(tmp_path):
     _edit_json(os.path.join(root, "site", "site.json"),
                lambda d: d.update({"og_image": "assets/nothing-makes-this.png"}))
     _fails(root, out, "the social card names an image the build does not produce")
+
+    root = _sandbox(tmp_path / "scenario_without_steps")
+    _edit_json(os.path.join(root, "scenarios", "cafe-wifi.json"),
+               lambda d: d.update({"steps": []}))
+    _fails(root, out, "a shipped scenario has no steps")
+
+    root = _sandbox(tmp_path / "no_scenarios_at_all")
+    shutil.rmtree(os.path.join(root, "scenarios"))
+    _fails(root, out, "the scenario corpus is missing entirely")
 
     root = _sandbox(tmp_path / "unknown_schema")
     _edit_json(os.path.join(root, "site", "pages", "home", "page.json"),

--- a/tools/build_site.py
+++ b/tools/build_site.py
@@ -823,6 +823,41 @@ def exit_code_table(texts):
     return Raw("<table>%s</table>" % "".join(rows))
 
 
+def scenario_table(root, texts):
+    """The scenario files that ship next to the program, read from ``scenarios/``.
+
+    A scenario is a timeline: ``{"loop": bool, "steps": [{"at": seconds, "settings":
+    {...}}]}``. What a reader wants before opening one is how long it runs, how many
+    times conditions change and whether it repeats - and those are facts in the file,
+    so they are read rather than described.
+
+    This is the point where the SITE starts depending on the scenario corpus, which is
+    why ``pages.yml`` had to gain ``scenarios/**`` in its paths filter: without it,
+    editing a scenario would change this table and never redeploy, which looks exactly
+    like a page nobody edited.
+    """
+    folder = os.path.join(root, "scenarios")
+    files = sorted(f for f in os.listdir(folder) if f.endswith(".json")) \
+        if os.path.isdir(folder) else []
+    if not files:
+        raise SiteError("no scenario files in %s (the table would be empty and the page "
+                        "would claim the program ships none)" % folder)
+    heads = [texts["table.scenario"], texts["table.steps"], texts["table.length"],
+             texts["table.repeats"]]
+    rows = ["<tr>%s</tr>" % "".join("<th>%s</th>" % html.escape(h, quote=True) for h in heads)]
+    for name in files:
+        data = _read_json(os.path.join(folder, name))
+        steps = data.get("steps") or []
+        if not steps:
+            raise SiteError("scenarios/%s has no steps" % name)
+        last = max(int(step.get("at", 0)) for step in steps)
+        rows.append("<tr><td><code>%s</code></td><td>%d</td><td>%d s</td><td>%s</td></tr>"
+                    % (html.escape(name, quote=True), len(steps), last,
+                       html.escape(texts["table.yes"] if data.get("loop") else texts["table.no"],
+                                   quote=True)))
+    return Raw("<table>%s</table>" % "".join(rows))
+
+
 def social_links(registry, texts):
     """The owner's accounts, as text with a drawn glyph - never a brand mark.
 
@@ -887,6 +922,7 @@ def page_context(page, code, registry, texts, home, colours, root, pages):
         "page.preset_table": preset_table(load_app_strings(root, code), texts[code]),
         "page.settings_table": settings_table(load_app_strings(root, code), texts[code]),
         "page.exit_code_table": exit_code_table(texts[code]),
+        "page.scenario_table": scenario_table(root, texts[code]),
         "page.social_links": social_links(registry, texts[code]),
         "page.source_glyph": Raw(SOURCE_GLYPH),
         "page.nav_links": page_links(pages, page, code, "foot-nav",


### PR DESCRIPTION
The keyword pass in #123 named four topics that needed a page rather than a synonym, and said so
instead of quietly skipping them. These are those four. Fifteen pages in two languages now, thirty
addresses in the sitemap.

## The pages

- **No internet** (`/test-app-offline/`). Three different shapes of offline, because pulling a cable
  tests only one of them: LAN mode leaves the local network working and takes the world away,
  blocking one address makes a single dependency unreachable, and blocking port 53 breaks names while
  addresses still resolve. Each row says which bug it finds. It also says what this is *not*: the
  adapter stays up on purpose, since real users are rarely disconnected - they are connected to
  something that cannot reach what they need.
- **Timed scenarios** (`/scenarios-over-time/`). The file format, the fact that steps apply to a
  session already running, the two simpler ways to get change (flapping, a speed schedule), and the
  seven shipped timelines listed straight from the folder.
- **Game lag** (`/game-lag-simulator/`). Why a game shows loss where a browser hides it, what to set
  and what each setting exposes, why jitter is measured as a percentile rather than an average, and
  why comparing two builds needs a seed. Plus what it cannot do: it shapes this machine's traffic, not
  the server's tick rate.
- **Chaos testing** (`/network-chaos-testing/`). The faults available, repeatability as the difference
  between chaos and noise, the pipeline wiring, and where the blast radius stops - one process when
  aimed, and one machine either way.

## The scenario table is read, not written

`scenario_table()` builds the shipped-scenario list from `scenarios/*.json`: how many steps, how long,
whether it loops. A sentence describing a timeline is exactly the prose that survives the timeline
being edited, so the numbers come from the files. Seven files, 4 to 7 steps, 65 to 85 seconds, six
loop and `upload-drop-midway` does not.

## 🔴 A regression the analysis caught before the code did

Making the site read `scenarios/` means the site now depends on that corpus - and `pages.yml`
filtered on `site/**` and friends, **not** on `scenarios/**`. Editing a scenario would have changed
the table and never triggered a deployment, which looks exactly like a page nobody edited.

The filter covers it, and the test **derives** the requirement from the generator reading the folder
rather than from a typed list, so the next input the site starts reading has to be added in one place
only. Both directions mutation-checked: dropping a scenario from the generator, and removing the line
from the workflow.

## The i18n guard fired, and was right

`"yes": "yes"` in `en.json` is refused, because English text may never equal its own key (convention
9) - that rule exists so a key cannot leak into an interface unnoticed. Hence `table.yes` and
`table.no`.

## Verification

- 49 site tests, plus the repository-convention, mutation-registry, release and shipped-scenario
  guards: **80 passed**.
- The full suite was **deliberately not run locally**: no program code is touched here, and this pull
  request runs it on Linux and Windows. Said out loud because it is a departure from the usual
  definition of done.
- 30 pages: no duplicate title or description, none over the length a result shows, structured data on
  every one, sitemap and `llms.txt` regenerated from the registry.
- Four new guards mutation-checked by breaking each on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
