### PR TITLE
fix(gui): give paired checkboxes the gap every other pair already had

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **The two LAN checkboxes were touching.** "Internet only" started right where the "LAN mode"
+  label ended, with nothing between them, so the pair read as one control. They now have the same
+  gap as any other two settings sharing a row.
 - The right-click copy menu on the Statistics page opened with a white background instead of the
   dark one used everywhere else. It now looks like the menu in the Connections table, on both
   Live and Session.

--- a/beantester/gui/form.py
+++ b/beantester/gui/form.py
@@ -48,6 +48,20 @@ def _takes_a_row(field):
     neighbour. Only the registry may say so - the caller reads the answer.
     """
     return field.kind in SPAN_KINDS if field.span is None else field.span
+
+
+def _gap_after(field):
+    """How much room to leave to the RIGHT of a field inside its row.
+
+    A field that owns its row only has to clear the card's edge. Two that SHARE
+    one need a real gap between them, or they read as a single control: the pair
+    of LAN switches shipped touching, the second one's box hard against the end
+    of the first one's label, because the checkbox branch packed with no padding
+    at all while every other kind went through a cell that had some.
+
+    One place, so the two paths cannot drift apart again.
+    """
+    return scaled(6) if _takes_a_row(field) else scaled(22)
 VALIDATED_KINDS = (F.NUMBER, F.EXPR, F.SCHEDULE, F.SEED)
 
 # Below this width a second column of sections would squeeze the wider rows
@@ -216,7 +230,7 @@ class ControlForm:
             widget = ttk.Checkbutton(row, text=T(field.label),
                                      variable=app.vars[field.key],
                                      command=app.on_form_changed)
-            widget.pack(side="left", anchor="w")
+            widget.pack(side="left", anchor="w", padx=(0, _gap_after(field)))
             add_tooltip(widget, field.tip)
             self.entries[field.key] = widget
             return
@@ -240,8 +254,7 @@ class ControlForm:
 
         span = _takes_a_row(field)
         cell = ttk.Frame(row, style="Card.TFrame")
-        cell.pack(side="left", fill="x", expand=span,
-                  padx=(0, scaled(6) if span else scaled(22)))
+        cell.pack(side="left", fill="x", expand=span, padx=(0, _gap_after(field)))
 
         label = ttk.Label(cell, text=T(field.label), style="Card.TLabel")
         label.pack(side="left", padx=(0, scaled(6)))

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -932,4 +932,12 @@ def test_the_two_lan_switches_share_one_row():
         assert lan.master is net.master, "the LAN switches are not in one row"
         assert app.form.entries["filter"].master is not lan.master, (
             "the traffic dropdown was pulled into the checkbox row")
+
+        # ...and they must not TOUCH. They shipped with the second one's box hard
+        # against the end of the first one's label, because the checkbox branch
+        # packed with no padding while every other kind went through a cell that
+        # had some. Two controls with nothing between them read as one.
+        gap = (lan.pack_info or {}).get("padx")
+        gap = gap[1] if isinstance(gap, (tuple, list)) else gap
+        assert gap, "no room to the right of the first switch: %r" % (lan.pack_info,)
     """)

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1346,6 +1346,16 @@ MUTATIONS = [
         "test": "test_the_two_lan_switches_share_one_row",
     },
     {
+        # How they shipped touching: the checkbox branch packed with no padding
+        # while every other kind went through a cell that had some, so the pair
+        # only looked wrong once two of them ended up in one row.
+        "label": "gui: paired checkboxes lose the gap between them",
+        "file": "beantester/gui/form.py",
+        "old": '            widget.pack(side="left", anchor="w", padx=(0, _gap_after(field)))',
+        "new": '            widget.pack(side="left", anchor="w")',
+        "test": "test_the_two_lan_switches_share_one_row",
+    },
+    {
         # Without the idle hint the row is one cluster in a band of nothing -
         # the shape that has now been reported twice.
         "label": "gui: the search bar loses its idle right-hand anchor",


### PR DESCRIPTION
Reported from the running build the day after the two LAN switches landed side by side:
"Internet only" started exactly where the "LAN mode" label ended, with nothing between them, so the
pair read as one control rather than two.

## Why it happened

The BOOL branch of `form._place_one` packs its Checkbutton straight into the row:

```python
widget.pack(side="left", anchor="w")        # no padx at all
```

Every other kind goes through a cell that carries `padx=(0, scaled(22))`. That difference had no
visible consequence for as long as no two checkboxes ever shared a row - a state that lasted exactly
one day, since the registry only learned to pair them yesterday.

## The fix

Both paths ask `_gap_after(field)` now, so the two cannot drift apart again: a field that owns its
row only has to clear the card's edge, two that share one get a real gap. One rule, one constant, in
the place that already decides whether a field takes a row to itself.

## Measured

On real Tk at 1366x768, in both languages:

| | gap | `lan_mode` | `internet_only` | spare to the right |
|---|---|---|---|---|
| English | 22 px | asks 254, gets 254 | asks 191, gets 191 | 59 px |
| Polish | 22 px | asks 249, gets 249 | asks 195, gets 195 | 63 px |

22 px is the same gap any other pair of fields in a row gets. Nothing is clipped, and the row still
has room to spare at the minimum supported resolution.

## Guard

The test that already asserts the two share a row now also asserts they do not touch, and a
`MUTATIONS` entry reddens it by putting the padding-free `pack` call back. The render check
(buttons and checkboxes since yesterday) passes in both languages, and the fix was looked at on the
live window as well, since "they touch" is a question about pixels.
