### PR TITLE
Four measured ceilings and the dead code they found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   # between the runners. Kept out of the `tests` matrix for exactly that reason -
   # in there it would run twice and say the same thing.
   lint:
-    name: ruff (F and B block, S and ASYNC report)
+    name: ruff (F, B, C90 and PLR0913 block, S and ASYNC report)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -98,8 +98,14 @@ jobs:
       # pyproject.toml and nothing else: the per-file ignores and the target
       # version still come from there, so the two runs below cannot drift apart
       # from what a developer sees locally.
-      - name: Bugs, dead code and the complexity ceiling (blocking)
-        run: ruff check --select F,B,C90 --output-format github
+      # 🔴 Every blocking rule has to be named HERE as well. `--select` on the
+      # command line REPLACES the list in pyproject.toml, so a rule added there
+      # and forgotten here is configured, visible to a developer running plain
+      # `ruff check`, and absent from the only place that can block a merge.
+      # tests/test_code_shape.py::test_the_selected_rules_only_ever_grow holds the
+      # two lists to each other so this cannot drift in silence.
+      - name: Bugs, dead code, complexity and argument count (blocking)
+        run: ruff check --select F,B,C90,PLR0913 --output-format github
       # The report. S is 306 findings on this repository and 287 of them are
       # things a test suite for a packet mangler does on purpose - so it
       # annotates the diff and never fails the run. `ruff check` exits 1 on any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,16 @@ jobs:
         run: |
           pip install --require-hashes -r requirements.txt
           pip install -r requirements-dev.txt
+          # 🔴 The linter too, and it is not decoration here. Three guards in
+          # tests/test_code_shape.py read a threshold out of pyproject.toml and
+          # ask ruff whether anything crosses it. Without ruff on PATH they skip,
+          # a skip is not a failure, and the runner reports SURVIVED for a
+          # mutation the guard would have caught anywhere else. Measured on this
+          # very branch (2026-08-21): two entries came back SURVIVED with no
+          # defect behind either - the job simply could not run the checks it was
+          # asked to break. The whole file, never a single package picked out of
+          # it by grep: a hash cannot travel through `$(grep ...)`.
+          pip install --require-hashes -r requirements-lint.txt
       # A pull request pays for what it touched; the weekly run pays for
       # everything. The full pass is minutes (~13 for 117 entries on a developer
       # machine), which is fine once a week and absurd on every push.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ pip install --require-hashes -r requirements-lint.txt   # ruff, mypy and diff-co
 pip install -r requirements-scan.txt   # semgrep (Linux and macOS) and pip-audit
 python -m pytest tests            # full suite - no Windows, no driver, no admin rights
 python smoke_gui.py               # GUI smoke with a fake tkinter
-ruff check                        # F and B fail a pull request, S and ASYNC are a report
+ruff check                        # F, B, C90 and PLR0913 fail a PR; S and ASYNC are a report
 mypy                              # types, over the package
 python bean_network_tester.py --simulate --loss 10 --duration 3   # CLI demo
 python bean_network_tester.py --doctor                            # environment report
@@ -69,5 +69,10 @@ onedir, `asInvoker`. Do not reintroduce `--noconsole` / `--onefile` / `--uac-adm
 2. Run `ruff check` and `mypy` - both are gates on the pull request.
    Semgrep runs in CI and needs no local setup. On Windows it installs but does not
    scan, so run it from WSL if you want it locally.
+   Two of the ruff rules are ceilings pinned to the widest thing in the tree today
+   (`C90` complexity, `PLR0913` argument count), so they are green until something
+   grows past what already exists. If one fires, split the function - raising the
+   number in `pyproject.toml` is a decision for the maintainer, not a way to get a
+   build green.
 3. Add tests for new behavior (see `tests/` for the style).
 4. Update both `lang/en.json` and `lang/pl.json` when adding UI texts.

--- a/README.md
+++ b/README.md
@@ -1184,7 +1184,7 @@ Every job in that workflow, and what a red one means:
 | job | what it does |
 |---|---|
 | `public-text` | commit messages and the pull-request description: English, plain hyphens, nothing private to a machine |
-| `lint` | **ruff**. Dead code, bug shapes and the complexity ceiling fail the run. The security family is reported and never blocks |
+| `lint` | **ruff**. Dead code, bug shapes, the complexity ceiling and the argument ceiling fail the run. The security family is reported and never blocks |
 | `types` | **mypy** over the package |
 | `semgrep` | the default registry ruleset. ERROR, HIGH and CRITICAL fail the run, the rest is printed |
 | `mutations` | breaks each guarded behaviour and proves its test reddens. A pull request runs the entries it touched, the weekly run does all of them |
@@ -1195,7 +1195,10 @@ Every job in that workflow, and what a red one means:
 
 **Three static checks run beside the tests**, on Linux only, because they read the source rather
 than run it. **ruff** fails a pull request on a dead-code or bug-shape finding (`F` and `B`) and
-reports the security family (`S`, `ASYNC`) as annotations that never block. **mypy** type-checks
+reports the security family (`S`, `ASYNC`) as annotations that never block. Two of its
+rules are ceilings rather than opinions: `C90` for how many ways there are through a
+function and `PLR0913` for how many arguments it takes, both set to the widest thing
+that exists today, so they are silent until something grows past it. **mypy** type-checks
 the package. **semgrep** scans with its default registry ruleset and a finding at ERROR, HIGH or
 CRITICAL fails the run, while everything below that is printed in full. All three tool versions are
 pinned, so a new release of a linter cannot redden a pull request that changed nothing: ruff and

--- a/README.pl.md
+++ b/README.pl.md
@@ -1031,7 +1031,7 @@ Wszystkie joby tego workflow i co znaczy czerwony:
 | job | co robi |
 |---|---|
 | `public-text` | treść commitów i opisu PR-a: po angielsku, płaskie łączniki, nic prywatnego z maszyny |
-| `lint` | **ruff**. Martwy kod, kształty błędów i sufit złożoności wywracają przebieg. Rodzina bezpieczeństwa tylko raportuje |
+| `lint` | **ruff**. Martwy kod, kształty błędów, sufit złożoności i sufit liczby argumentów wywracają przebieg. Rodzina bezpieczeństwa tylko raportuje |
 | `types` | **mypy** na pakiecie |
 | `semgrep` | domyślny zestaw reguł z rejestru. ERROR, HIGH i CRITICAL wywracają przebieg, reszta ląduje w logu |
 | `mutations` | psuje każde pilnowane zachowanie i dowodzi, że jego test się czerwieni. PR odpala wpisy, których dotknął, cotygodniowy przebieg wszystkie |
@@ -1042,7 +1042,10 @@ Wszystkie joby tego workflow i co znaczy czerwony:
 
 **Obok testów chodzą trzy analizy statyczne**, wyłącznie na Linuksie, bo czytają kod, a nie go
 uruchamiają. **ruff** wywraca pull requesta na martwym kodzie i na kształtach błędów (`F` i `B`),
-a rodzinę bezpieczeństwa (`S`, `ASYNC`) tylko wypisuje w diffie i nigdy nie blokuje. **mypy**
+a rodzinę bezpieczeństwa (`S`, `ASYNC`) tylko wypisuje w diffie i nigdy nie blokuje.
+Dwie z jego reguł to sufity, a nie opinie: `C90` mierzy, iloma drogami można przejść
+przez funkcję, a `PLR0913` ile bierze argumentów. Obie stoją na najszerszej rzeczy,
+jaka dziś istnieje, więc milczą, dopóki coś jej nie przerośnie. **mypy**
 sprawdza typy w pakiecie. **semgrep** skanuje domyślnym zestawem reguł z rejestru, przy czym
 znalezisko na poziomie ERROR, HIGH albo CRITICAL wywraca przebieg, a wszystko niżej ląduje w logu.
 Wersje wszystkich trzech narzędzi są przypięte, więc nowe wydanie lintera nie zaczerwieni pull

--- a/beantester/core.py
+++ b/beantester/core.py
@@ -519,25 +519,6 @@ class BeanCore:
         self._flow_last.maybe_rotate(now)
         self._reset_until.maybe_rotate(now)
 
-    def in_scope(self, local_port, remote_ip=None, remote_port=None):
-        """Whether a flow is in targeting scope RIGHT NOW (read-only, no effects).
-
-        Mirrors the targeting gates of ``decide`` (steps 1-2) without touching any
-        flow table or bucket. The connections view uses it to colour a row by the
-        target as it stands now, not by the last packet the flow happened to send:
-        an idle flow otherwise kept a stale flag, so a firefox row stayed marked
-        "in scope" after the target had been narrowed to chrome.
-        """
-        with self._lock:
-            if self.target_active and local_port not in self.target_ports:
-                return False
-            if self.dst_active:
-                if self.dst_ip_matcher and not self.dst_ip_matcher.matches(remote_ip):
-                    return False
-                if self.dst_port_matcher and not self.dst_port_matcher.matches(remote_port):
-                    return False
-            return True
-
     def targeting_active(self):
         """True when any targeting (process or destination) is narrowing traffic."""
         with self._lock:

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -470,10 +470,6 @@ class BeanEngine:
     def set_dest(self, *a):
         self.core.set_dest(*a)
 
-    def in_scope_now(self, local_port, remote_ip=None, remote_port=None):
-        """Whether a flow is in targeting scope right now (see BeanCore.in_scope)."""
-        return self.core.in_scope(local_port, remote_ip, remote_port)
-
     def targeting_active(self):
         """True when process or destination targeting is narrowing traffic."""
         return self.core.targeting_active()
@@ -728,10 +724,9 @@ class BeanEngine:
             # a browser closes hundreds a minute. A live check flipped every
             # finished flow to "not impaired" the moment it closed (its ephemeral
             # port left the socket table), so a run that impaired all of chrome read
-            # as a table full of "no". The LIVE "in scope now" signal still exists -
-            # it is the row highlight (gui/pages/conns.py::_tag_of, via in_scope) -
-            # so narrowing chrome->firefox drops the highlight without erasing the
-            # record that the chrome flow WAS impaired.
+            # as a table full of "no". The row highlight
+            # (gui/pages/conns.py::_tag_of) reads this same stored record, so the
+            # colour and the "impaired?" column can never disagree.
             c["scoped"] = c["scoped"] or bool(scoped)
             c["last"] = now
             c["dir"] = "out" if is_out else "in"

--- a/beantester/gui/scrollable.py
+++ b/beantester/gui/scrollable.py
@@ -285,18 +285,6 @@ class ScrollableFrame:
         except Exception as _exc:
             crashlog.note(_exc, "gui.scrollable")
 
-    def yview_fraction(self):
-        try:
-            return float(self.canvas.yview()[0])
-        except Exception:
-            return 0.0
-
-    def set_yview_fraction(self, fraction):
-        try:
-            self.canvas.yview_moveto(max(0.0, min(1.0, float(fraction or 0.0))))
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.scrollable")
-
 
 def make_scrollable(parent):
     """Backwards-compatible helper: returns the inner frame."""

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -751,9 +751,6 @@ class PortTable:
             return None
         return self._ports.get(int(port))
 
-    def age(self, now=None):
-        return (self.clock() if now is None else now) - self._last
-
     # -- process info ----------------------------------------------------------- #
     def _expire_info(self, now):
         """Drop entries older than ``INFO_TTL_S``, counted from when they were WRITTEN.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,28 @@ testpaths = ["tests"]
 addopts = "-q"
 
 [tool.ruff]
-# Ruff: four rule families and no more, decided 2026-08-19.
+# Ruff: a NAMED list, and nothing joins it without a reason written down. Four
+# families were chosen on 2026-08-19; C90 arrived with the gates in #133 and
+# PLR0913 on 2026-08-21, each for a measurement nothing else here takes.
 #
-#   F      pyflakes      - dead imports, dead variables, redefinitions
-#   B      bugbear       - the bug shapes a reader misses (late binding, zip truncation)
-#   S      bandit        - security patterns
-#   ASYNC  flake8-async  - blocking calls in async code (zero findings here: there is
-#                          no async code, and this keeps it that way)
+#   F        pyflakes      - dead imports, dead variables, redefinitions
+#   B        bugbear       - the bug shapes a reader misses (late binding, zip truncation)
+#   S        bandit        - security patterns
+#   ASYNC    flake8-async  - blocking calls in async code (zero findings here: there is
+#                            no async code, and this keeps it that way)
+#   C90      mccabe        - the complexity ceiling (see max-complexity below)
+#   PLR0913  pylint        - how many arguments a function takes
+#
+# 🔴 Why PLR0913 ALONE out of the pylint refactor rules, and why not the obvious
+# three next to it. PLR0912 (branches) scores `core.decide` at 30 where C90 scores
+# it 29 - the same function, the same axis, a second number that moves at a
+# different rate. PLR0915 (statements) is FUNCTION_CEILING measured worse, because
+# the ratchet in tests/test_code_shape.py counts LOGIC lines and therefore leaves
+# comments free, which this repository is built on. PLR0911 (returns) needs a
+# branch per return, so C90 has already counted them. Argument count is the one
+# thing on that list nothing else here measures, so it is the one that joined.
+# The same test applied to `lizard` on 2026-08-21 is why that tool was not adopted:
+# five of the six things it measures are measured here already.
 #
 # F and B BLOCK a pull request. S is a report, and the difference is not
 # softness - it is what the two measure. Measured 2026-08-19: S raises 306
@@ -61,7 +76,24 @@ addopts = "-q"
 target-version = "py310"        # matches requires-python; ruff reads it anyway, said out loud
 
 [tool.ruff.lint]
-select = ["F", "B", "S", "ASYNC", "C90"]
+select = ["F", "B", "S", "ASYNC", "C90", "PLR0913"]
+
+[tool.ruff.lint.pylint]
+# 🔴 THE CEILING IS THE MEASUREMENT, like max-complexity above it and FILE_CEILING
+# in tests/test_code_shape.py. 14 is `gui/widgets/sortable_tree.py::__init__`
+# today, which is the widest signature in the tree; `engine._log_conn` is next at
+# 10. Ruff does not count `self`.
+#
+# Ruff's own default is 5, and setting it there would raise 25 findings across the
+# repository on day one - a gate that is red before it has caught anything teaches
+# people to switch it off. This one is a ratchet instead: nothing may get wider
+# than the widest thing today, down is routine, up is a decision.
+#
+# What this measures that nothing else here does: how many things a caller must
+# line up correctly to use a function. Complexity and length do not see it - a
+# fifteen-argument constructor can be four lines of straight-line assignment and
+# sail past both.
+max-args = 14
 
 [tool.ruff.lint.mccabe]
 # 🔴 THE CEILING IS THE MEASUREMENT, like FILE_CEILING in tests/test_code_shape.py.

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -15,6 +15,7 @@ Two invariants, both true today, both cheap to keep true:
 import ast
 import glob
 import os
+import re
 
 from fakes import ROOT, check
 
@@ -119,3 +120,182 @@ def test_the_decision_core_never_swallows_an_exception_silently():
             offenders.append(f"core.py:{node.lineno}")
     check("core.py routes every broad except to crashlog or re-raises (never silent)",
           not offenders, f"({offenders})")
+
+
+# -- code nothing calls any more ------------------------------------------------- #
+#
+# 🔴 An ALLOW-list of trees, never a deny-list, and that is the whole safety
+# argument. `internal_tools/`, `.claude/` and `crashes/` exist on the maintainer's
+# machine and in no checkout, so a scan that walked ROOT would find a name USED
+# here (a rig names it) and DEAD in CI - green locally, red on the pull request,
+# over a difference nobody can see from the diff. Naming the trees that are
+# actually in the repository makes that impossible instead of merely guarded
+# against. Measured 2026-08-21: no name in the package is used only from a rig
+# today, so this costs nothing now and stops costing something later.
+USAGE_TREES = ("beantester", "tests", "tools", "lang", "scenarios")
+USAGE_FILES = ("bean_network_tester.py", "smoke_gui.py", "build.py",
+               "BeanNetworkTester.spec")
+USAGE_EXTS = (".py", ".json", ".spec")
+WALK_SKIP = {"__pycache__", "build", "dist"}
+
+# 🔴 EVERY WORD COUNTS, including one inside a comment or a string, and that is a
+# MEASUREMENT rather than a preference. Counting only code tokens finds six more
+# names here and five of them are alive: `reset_ui_layout`, `_settle_transition`,
+# `show_info` and `sync` are called from inside `run_gui("""...""")` blocks - the
+# GUI tests are Python source in a string, executed in a subprocess, and the suite
+# holds 204 of those calls - while `on_pref_changed` is reached through
+# `getattr(page, "on_pref_changed", None)`. A guard that accuses living code is a
+# guard people learn to ignore, so this one errs the other way.
+#
+# The price is real and is named here rather than discovered later: a definition
+# whose name is an ordinary English word survives on prose alone. `PortTable.age`
+# did exactly that and had to be found by hand. What this catches is an abandoned
+# helper with a distinctive name; it is not a substitute for reading.
+#
+# Same trade in the other direction: names are matched as WORDS, not resolved, so
+# two classes with a `close()` share one answer. Fewer false alarms, more misses.
+_WORD = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# A decorator that hands the object to a registry IS a call site, just not a
+# visible one. Written as the exact names rather than a substring match, so a
+# future `@register_anything` cannot quietly become a way out of this guard.
+REGISTERED_BY = {"register_window"}
+
+# 🔴 Unreferenced ON PURPOSE, each with the reason it stays. A RATCHET: it may
+# shrink and may not grow without somebody deciding that it should - a list that
+# absorbs whatever the scan finds is not a guard, it is a place to put things.
+KNOWN_UNUSED = {
+    "ui_scale": "the getter paired with set_scale(), which IS used (init_scaling); "
+                "PROJECT_NOTES lists it as part of the scaling surface",
+    "make_scrollable": "the compatibility alias the notes say stays. Deleting it is "
+                       "a decision about that promise, not about this scan",
+}
+
+
+def _package_definitions():
+    """Every function and class in the package: name, file, line, end, decorators."""
+    out = []
+    for path in _pkg_files():
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        for node in ast.walk(ast.parse(open(path, encoding="utf-8").read())):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                out.append((node.name, rel, node.lineno, node.end_lineno or node.lineno,
+                            [ast.unparse(d) for d in node.decorator_list]))
+    return out
+
+
+def _usage_files():
+    """Every file in the repository that could legitimately name a symbol.
+
+    🔴 EXCEPT THIS ONE, and it is not an optimisation: `KNOWN_UNUSED` lives here,
+    so a name written into the exception list would be a mention of itself and the
+    scan would report it as used. The guard would disarm itself in the act of
+    recording an exception - and the two entries in that list are exactly the
+    names it would stop watching. Measured: removing this file from the scan
+    changes nothing else, the same 1003 definitions minus those two.
+    """
+    mine = os.path.abspath(__file__)
+    out = []
+    for tree in USAGE_TREES:
+        for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, tree)):
+            dirnames[:] = [d for d in dirnames if d not in WALK_SKIP]
+            out += [os.path.join(dirpath, n) for n in filenames
+                    if n.endswith(USAGE_EXTS)]
+    out += [os.path.join(ROOT, n) for n in USAGE_FILES]
+    return [p for p in out
+            if os.path.isfile(p) and os.path.abspath(p) != mine]
+
+
+def _unreferenced():
+    """(unreferenced definitions, files read, definitions seen), to a FIXED POINT.
+
+    Iterated rather than counted once, because a dead caller keeps its callee
+    looking alive: `BeanCore.in_scope` had exactly one caller in the whole tree and
+    that caller was `BeanEngine.in_scope_now`, which nothing called either. One
+    pass sees a name mentioned twice and calls it used.
+    """
+    definitions = _package_definitions()
+    names = {name for name, *_ in definitions}
+    spans = {}
+    for name, rel, line, end, _decorators in definitions:
+        spans.setdefault(rel, []).append((line, end, (name, rel, line)))
+
+    def enclosing(rel, number):
+        """The innermost definition containing this line, or None."""
+        best = None
+        for start, end, key in spans.get(rel, ()):
+            if start <= number <= end and (best is None or start >= best[2]):
+                best = key
+        return best
+
+    mentions, files = {}, 0
+    for path in _usage_files():
+        files += 1
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        in_package = rel.startswith("beantester/")
+        try:
+            text = open(path, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for number, line in enumerate(text.splitlines(), 1):
+            found = [w for w in _WORD.findall(line) if w in names]
+            if not found:
+                continue
+            site = enclosing(rel, number) if in_package else None
+            for word in found:
+                mentions.setdefault(word, set()).add(site or "EXTERNAL")
+
+    dead = set()
+    while True:
+        grew = False
+        for name, rel, line, _end, decorators in definitions:
+            key = (name, rel, line)
+            if key in dead or (name.startswith("__") and name.endswith("__")):
+                continue
+            if any(d in REGISTERED_BY for d in decorators):
+                continue
+            # A mention from a dead site is not life, and neither is a function
+            # naming itself - recursion keeps nothing alive.
+            living = [s for s in mentions.get(name, ())
+                      if s == "EXTERNAL" or (s not in dead and s != key)]
+            if not living:
+                dead.add(key)
+                grew = True
+        if not grew:
+            return sorted(dead), files, len(definitions)
+
+
+def test_no_definition_in_the_package_is_unreferenced():
+    """Nothing in the package is left over from a change that moved on without it.
+
+    Nobody reads this code line by line. A helper written in one session and
+    superseded in the next keeps compiling, keeps passing, keeps being read as
+    something that matters - and the only thing that notices is a scan.
+    """
+    dead, files, definitions = _unreferenced()
+
+    # The canary this file's neighbours all carry: a scan that reads nothing finds
+    # no dead code and looks exactly like a scan that works.
+    check("the dead-code scan actually read the repository",
+          files >= 100 and definitions >= 500,
+          f"({files} files, {definitions} definitions)")
+
+    unexpected = [f"{name} ({rel}:{line})" for name, rel, line in dead
+                  if name not in KNOWN_UNUSED]
+    check("every definition in the package is named from somewhere that is alive",
+          not unexpected,
+          f"({unexpected} - delete it, or add it to KNOWN_UNUSED with the reason)")
+
+
+def test_the_known_unused_list_only_ever_shrinks():
+    """A name that got a caller back must LEAVE the list, or the list rots.
+
+    Without this, an exception written once outlives its reason and the next
+    session reads it as a rule. Same shape as every other ratchet here: the cheap
+    direction is free, the other one is a decision.
+    """
+    dead, _files, _definitions = _unreferenced()
+    still_dead = {name for name, _rel, _line in dead}
+    revived = sorted(name for name in KNOWN_UNUSED if name not in still_dead)
+    check("no name on the exception list has quietly gained a caller", not revived,
+          f"({revived} - it is used again, so take it out of KNOWN_UNUSED)")

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -32,8 +32,12 @@ What this does NOT check
 Whether a function does one thing (a tidy twenty-line function doing three things
 passes exactly like a good one), whether its name is honest, or whether splitting it
 scattered the logic across ten places - that last one has its own cost and no metric.
-Nesting depth is not measured either. This guard buys one thing only: nothing grows
-past what a person can follow without somebody deciding that it should.
+This guard buys one thing only: nothing grows past what a person can follow without
+somebody deciding that it should.
+
+Nesting depth USED to be on that list and was taken off it on 2026-08-21 - see
+DEPTH_CEILING. Length, branch count and indent depth are three different questions,
+and a function can be quiet in two of them while failing the third.
 """
 import ast
 import os
@@ -82,6 +86,36 @@ CROWD_BAND = 0.70
 FILES_NEAR_CEILING = 1          # beantester/gui/app.py
 FUNCTIONS_NEAR_CEILING = 3      # _run_session, _build_ui, build_arg_parser
 
+# 🔴 THE THIRD AXIS, added 2026-08-21 - and this file used to say, in the paragraph
+# above, that nesting depth was not measured. It is now, because nothing else can
+# see it: ruff has no rule for it (SIM102 and SIM117 collapse joinable statements,
+# they do not measure depth), the size ceiling is blind to it by construction, and
+# `max-complexity` scores a flat chain of eight `elif` exactly like eight nested
+# `if` while a reader does not.
+#
+# Today, over 942 functions: one reaches 5 and it earns it - `gui/icon.py::
+# make_gear_icon` is a supersampling rasteriser, four loops over pixel and sub-pixel
+# with the coverage test inside. Eleven sit at 4, 70 at 3, and 860 at 2 or less. So
+# this ceiling buys nothing today and is bought for the same reason as the ones
+# above it: it costs nothing while nothing grows.
+#
+# 🔴 These numbers are the SECOND measurement. The first put the band at 3
+# functions, and it was wrong: `_nesting_depth` walked an `if` body without adding
+# the level the body sits at, so anything nested inside an `if` measured one short.
+# `test_the_depth_metric_still_counts_real_nesting` caught it - four nested blocks
+# came back as three - which is the entire reason the three metric tests below were
+# written before the constants were filled in rather than after.
+#
+# The band here is ABSOLUTE, not the 70% the size counts use, and that is measured
+# rather than lazy: 70% of 5 is 3.5, so the band would be "4 or more" today - the
+# same as below - but the moment the ceiling dropped to 4 it would become "3 or
+# more" and the count would jump from 3 to 38. A band that reshapes itself under
+# the thing it is watching says nothing. Percentages need a range to be a
+# percentage OF, and depth here runs 0 to 5.
+DEPTH_CEILING = 5               # beantester/gui/icon.py::make_gear_icon
+DEPTH_BAND = 4                  # absolute: see above
+DEPTHS_NEAR_CEILING = 12        # make_gear_icon at 5, eleven more at 4
+
 
 def _logic_lines(source):
     """Line numbers that carry executable code: no blanks, comments or docstrings.
@@ -103,6 +137,51 @@ def _logic_lines(source):
         if text and not text.startswith("#") and number not in doc:
             live.add(number)
     return tree, live
+
+
+def _nesting_depth(node):
+    """How deep the deepest block inside one function is INDENTED ON SCREEN.
+
+    Two corrections, and both were paid for: the first draft of this metric put
+    ``legal.py::component_rows`` at depth 7 when the function is two levels deep to
+    a reader. A ceiling standing on a wrong metric is worse than no ceiling, because
+    it looks guarded.
+
+    * **An ``elif`` chain is ONE level.** In the AST each ``elif`` is an ``If``
+      nested in the ``orelse`` of the one before it, so a flat six-branch chain
+      measures six deep unless the whole chain is walked at a single depth.
+    * **An ``except`` handler is not a level of its own.** The AST makes it a child
+      of the ``Try``; on screen the two bodies sit at the same indent.
+
+    A nested function is skipped and measured on its own, like everywhere else here.
+    """
+    blocks = (ast.If, ast.For, ast.AsyncFor, ast.While, ast.With, ast.AsyncWith,
+              ast.Try, ast.Match, ast.match_case)
+
+    def step(child, depth):
+        """A child that opens a block sits one level in; anything else does not."""
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return depth                             # measured on its own, not here
+        return walk(child, depth + (1 if isinstance(child, blocks) else 0))
+
+    def walk(current, depth):
+        deepest = depth
+        if isinstance(current, ast.If):
+            chain = current
+            while True:
+                for child in chain.body:
+                    deepest = max(deepest, step(child, depth))
+                if len(chain.orelse) == 1 and isinstance(chain.orelse[0], ast.If):
+                    chain = chain.orelse[0]          # elif: same indent, keep going
+                    continue
+                for child in chain.orelse:           # a real else, same indent again
+                    deepest = max(deepest, step(child, depth))
+                return deepest
+        for child in ast.iter_child_nodes(current):
+            deepest = max(deepest, step(child, depth))
+        return deepest
+
+    return walk(node, 0)
 
 
 def _package_files():
@@ -129,6 +208,19 @@ def _sizes():
     files.sort(reverse=True)
     functions.sort(reverse=True)
     return files, functions, len(paths)
+
+
+def _depths():
+    """Every function in the package with its indent depth, deepest first."""
+    out = []
+    for path in _package_files():
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        tree = ast.parse(open(path, encoding="utf-8").read())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out.append((_nesting_depth(node), f"{rel}::{node.name}"))
+    out.sort(reverse=True)
+    return out
 
 
 def _measure():
@@ -162,6 +254,114 @@ def test_no_function_or_file_has_grown_past_the_ratchet():
           worst_file[1] <= FILE_CEILING,
           f"(worst: {worst_file[0]} at {worst_file[1]}, "
           f"{FILE_CEILING - worst_file[1]} lines of headroom left)")
+
+
+def test_no_function_nests_deeper_than_the_ratchet():
+    """The third axis - see DEPTH_CEILING for what it buys and what it costs.
+
+    A function can be short, have few branches and still be unreadable because
+    every one of them is inside the last. Neither ceiling above sees that.
+    """
+    depths = _depths()
+    check("the depth scan actually read the package "
+          "(an empty scan satisfies every ceiling ever set)",
+          len(depths) >= 300, f"({len(depths)} functions)")
+
+    deepest = depths[0]
+    check(f"no function nests deeper than {DEPTH_CEILING} "
+          f"(pull a block out into its own function - do not raise the ceiling)",
+          deepest[0] <= DEPTH_CEILING, f"(deepest: {deepest[1]} at {deepest[0]})")
+
+    crowded = [f"{name} ({d})" for d, name in depths if d >= DEPTH_BAND]
+    check(f"at most {DEPTHS_NEAR_CEILING} function(s) nested {DEPTH_BAND} deep or "
+          f"more - flatten one before adding another",
+          len(crowded) <= DEPTHS_NEAR_CEILING, f"({crowded})")
+
+
+def test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire():
+    """Both numbers are today's measurement, exactly - the rule the file lives by.
+
+    Frozen one above the truth, either would grant headroom nobody decided to grant
+    and the next arrival would slip in silently.
+    """
+    depths = _depths()
+    check("the depth ceiling IS the deepest function, not a number above it",
+          depths[0][0] == DEPTH_CEILING,
+          f"({depths[0][1]} is {depths[0][0]}, ceiling is {DEPTH_CEILING} - "
+          f"move the ceiling to {depths[0][0]})")
+    actual = sum(1 for d, _ in depths if d >= DEPTH_BAND)
+    check("the depth crowd count is today's measurement, not a looser number",
+          actual == DEPTHS_NEAR_CEILING,
+          f"(measured {actual}, frozen at {DEPTHS_NEAR_CEILING} - lower it)")
+
+
+# The three tests below measure the METRIC, not the code, and they are not
+# decoration: the first draft of `_nesting_depth` reported a flat six-branch `elif`
+# chain as six levels deep and put `legal.py::component_rows` at 7 when a reader
+# sees 2. A ceiling standing on a metric that lies is worse than no ceiling,
+# because the suite is green and somebody believes it.
+def test_an_elif_chain_is_one_level_not_one_per_branch():
+    source = ("def f(x):\n"
+              "    if x == 1:\n"
+              "        return 'a'\n"
+              "    elif x == 2:\n"
+              "        return 'b'\n"
+              "    elif x == 3:\n"
+              "        return 'c'\n"
+              "    else:\n"
+              "        return 'd'\n")
+    node = ast.parse(source).body[0]
+    check("a four-branch if/elif/else measures one level deep",
+          _nesting_depth(node) == 1, f"(measured {_nesting_depth(node)})")
+
+
+def test_an_except_handler_is_not_a_level_of_its_own():
+    """``try`` and ``except`` bodies share an indent, whatever the AST shape says."""
+    plain = ast.parse("def f():\n"
+                      "    try:\n"
+                      "        g()\n"
+                      "    except OSError:\n"
+                      "        h()\n").body[0]
+    check("try/except is one level, not two",
+          _nesting_depth(plain) == 1, f"(measured {_nesting_depth(plain)})")
+
+    nested = ast.parse("def f():\n"
+                       "    try:\n"
+                       "        g()\n"
+                       "    except OSError:\n"
+                       "        for item in items:\n"
+                       "            h(item)\n").body[0]
+    check("a loop inside the handler is the second level, not the third",
+          _nesting_depth(nested) == 2, f"(measured {_nesting_depth(nested)})")
+
+
+def test_the_depth_metric_still_counts_real_nesting():
+    """The other half, and the one that keeps the two above honest.
+
+    "An elif chain is flat" is satisfied perfectly by a metric that returns zero for
+    everything - and a ceiling standing on a metric stuck at zero passes for ever
+    while the code nests deeper underneath it.
+    """
+    flat = ast.parse("def f():\n    a = 1\n    b = 2\n").body[0]
+    check("a function with no blocks is zero deep",
+          _nesting_depth(flat) == 0, f"(measured {_nesting_depth(flat)})")
+
+    deep = ast.parse("def f():\n"
+                     "    for a in x:\n"
+                     "        for b in a:\n"
+                     "            if b:\n"
+                     "                with open(b) as fh:\n"
+                     "                    fh.read()\n").body[0]
+    check("four genuinely nested blocks measure four",
+          _nesting_depth(deep) == 4, f"(measured {_nesting_depth(deep)})")
+
+    sibling = ast.parse("def f():\n"
+                        "    for a in x:\n"
+                        "        pass\n"
+                        "    for b in y:\n"
+                        "        pass\n").body[0]
+    check("two loops side by side are one level, not two",
+          _nesting_depth(sibling) == 1, f"(measured {_nesting_depth(sibling)})")
 
 
 def test_the_ratchet_measures_logic_and_not_explanation():

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -299,20 +299,28 @@ COMPLEX_NEAR_CEILING = 3        # decide, _run_session, settings_summary
 # than fail in that case - the same choice the admin-only tests make, and for the
 # same reason: a red that means "you did not install a tool" teaches people to
 # ignore red.
-def _ruff_complexity_findings(limit):
-    """How many functions ruff reports above ``limit``, or None if ruff is absent."""
+def _ruff_findings(rule, setting, limit):
+    """How many findings ``rule`` raises with ``setting`` at ``limit``.
+
+    None when ruff is not installed here, so every caller skips rather than fails.
+    """
     import subprocess
     try:
         proc = subprocess.run(
-            [sys.executable, "-m", "ruff", "check", "--select", "C901",
-             "--config", f"lint.mccabe.max-complexity = {limit}",
+            [sys.executable, "-m", "ruff", "check", "--select", rule,
+             "--config", f"{setting} = {limit}",
              "--output-format", "concise", "--no-cache", "."],
             cwd=ROOT, capture_output=True, text=True)
     except OSError:
         return None
     if "No module named" in proc.stderr or proc.returncode not in (0, 1):
         return None
-    return len([ln for ln in proc.stdout.splitlines() if "C901" in ln])
+    return len([ln for ln in proc.stdout.splitlines() if rule in ln])
+
+
+def _ruff_complexity_findings(limit):
+    """How many functions ruff reports above ``limit``, or None if ruff is absent."""
+    return _ruff_findings("C901", "lint.mccabe.max-complexity", limit)
 
 
 def test_the_complexity_ceiling_is_the_measurement_not_a_number_above_it():
@@ -369,6 +377,87 @@ def test_nothing_else_is_creeping_up_on_the_complexity_ceiling():
     check("the complexity crowd count is today's measurement, not a looser number",
           crowded == COMPLEX_NEAR_CEILING,
           f"(measured {crowded}, frozen at {COMPLEX_NEAR_CEILING} - lower it)")
+
+
+def test_the_argument_ceiling_is_the_measurement_not_a_number_above_it():
+    """`max-args` on the third axis: how many things a caller must line up.
+
+    Complexity and length are both blind to it - a fifteen-argument constructor
+    can be four lines of straight-line assignment and pass them both. The rule at
+    ruff's own default of 5 would be red on 25 signatures on day one, so it is
+    pinned to the widest one instead and ratchets down from there.
+    """
+    import tomllib
+    with open(os.path.join(ROOT, "pyproject.toml"), "rb") as handle:
+        ceiling = tomllib.load(handle)["tool"]["ruff"]["lint"]["pylint"]["max-args"]
+
+    over = _ruff_findings("PLR0913", "lint.pylint.max-args", ceiling)
+    if over is None:
+        return                      # ruff not installed here: nothing to measure
+    check(f"no signature takes more than {ceiling} arguments "
+          f"(split the call - do not raise the ceiling)",
+          over == 0, f"({over} signature(s) over the ceiling)")
+
+    below = _ruff_findings("PLR0913", "lint.pylint.max-args", ceiling - 1)
+    check(f"the ceiling {ceiling} IS a real measurement, not headroom",
+          below and below > 0,
+          f"(nothing reaches {ceiling} - lower max-args to the real maximum)")
+
+
+# 🔴 The rule list is a RATCHET, and it is recorded in two places for the reason
+# every other double record here exists: nothing stopped a future change from
+# deleting a family out of `select` to make a red build green, and a check that
+# has vanished cannot fail to announce itself.
+#
+# `BLOCKING` is the subset the pull request actually stands on. It is written down
+# separately because `--select` on the ci.yml command line REPLACES the list in
+# pyproject.toml - so a rule can be configured, visible to anyone running plain
+# `ruff check`, and yet absent from the only run that can block a merge. That is
+# not hypothetical: it is the exact mistake this test was written to make
+# impossible, on the day PLR0913 was added.
+SELECTED_RULES = {"F", "B", "S", "ASYNC", "C90", "PLR0913"}
+BLOCKING_RULES = {"F", "B", "C90", "PLR0913"}
+
+
+def test_the_selected_rules_only_ever_grow():
+    """Growing the list is free (add it in both places); shrinking it reddens."""
+    import tomllib
+    with open(os.path.join(ROOT, "pyproject.toml"), "rb") as handle:
+        selected = set(tomllib.load(handle)["tool"]["ruff"]["lint"]["select"])
+
+    lost = sorted(SELECTED_RULES - selected)
+    check("no rule family has quietly left the ruff configuration", not lost,
+          f"({lost} - dropping one is a decision, so change SELECTED_RULES too)")
+    gained = sorted(selected - SELECTED_RULES)
+    check("a newly selected rule is recorded here as well", not gained,
+          f"({gained} - add it to SELECTED_RULES, that is what makes it stick)")
+
+
+def test_every_blocking_rule_is_named_in_the_workflow_that_blocks():
+    """The configured list and the list CI runs are two different things.
+
+    ci.yml runs ruff twice: once blocking, once reporting with --exit-zero. Between
+    them they must account for every selected rule - a rule in neither is a gate
+    nobody runs, and a blocking rule missing from the first command is a gate that
+    exists only on a developer machine.
+    """
+    import re
+    path = os.path.join(ROOT, ".github", "workflows", "ci.yml")
+    with open(path, encoding="utf-8") as handle:
+        workflow = handle.read()
+    runs = re.findall(r"ruff check --select ([A-Z0-9,]+)", workflow)
+    check("ci.yml still runs ruff twice (one blocking, one report)",
+          len(runs) == 2, f"(found {len(runs)} ruff invocations)")
+    if len(runs) != 2:
+        return
+    blocking, reporting = (set(r.split(",")) for r in runs)
+    check("the blocking run names exactly the rules that must block",
+          blocking == BLOCKING_RULES,
+          f"(workflow blocks on {sorted(blocking)}, expected {sorted(BLOCKING_RULES)})")
+    check("every selected rule is either blocking or reported, none is unrun",
+          blocking | reporting == SELECTED_RULES,
+          f"(workflow runs {sorted(blocking | reporting)}, "
+          f"configured {sorted(SELECTED_RULES)})")
 
 
 # The modules mypy is strict about, recorded here so the list in pyproject.toml

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -273,6 +273,27 @@ def test_the_ceilings_are_not_set_so_loosely_that_they_never_fire():
           f"{FUNCTION_CEILING} - move the ceiling to {biggest_function[0]})")
 
 
+# 🔴 THE SECOND KNOB, on the complexity axis - the counterpart of
+# FILES_NEAR_CEILING and FUNCTIONS_NEAR_CEILING, and it was missing until
+# 2026-08-21. `max-complexity` watches ONE function: the most branching one in the
+# tree. It is blind to the shape the size ratchet already grew a knob for - the
+# runners-up climbing together, none of them a record. With the ceiling at 29,
+# `cli._run_session` could go from 27 to 29 across three sessions and every gate in
+# this repository would stay green the whole way.
+#
+# Today's measurement, same 70% band as the size counts (CROWD_BAND): three
+# functions reach 21 or more - `core.decide` (29), `cli._run_session` (27) and
+# `summary.settings_summary` (25). `engine._capture_loop` is next at 20, roughly
+# one branch of headroom, which is what makes this band a real one rather than a
+# number that can never fire.
+#
+# Measured over the WHOLE tree, like the ceiling above it and unlike the size
+# counts, which walk the package only. That is deliberate: the ceiling this band
+# hangs from is repo-wide, so a band scoped to the package would be measuring a
+# different thing from the number it is a percentage of.
+COMPLEX_NEAR_CEILING = 3        # decide, _run_session, settings_summary
+
+
 # Ruff is not in requirements-dev.txt: it lives in requirements-lint.txt, which a
 # contributor may not have installed. The two checks below skip themselves rather
 # than fail in that case - the same choice the admin-only tests make, and for the
@@ -320,6 +341,34 @@ def test_the_complexity_ceiling_is_the_measurement_not_a_number_above_it():
     check(f"the ceiling {ceiling} IS a real measurement, not headroom",
           below and below > 0,
           f"(nothing reaches {ceiling} - lower max-complexity to the real maximum)")
+
+
+def test_nothing_else_is_creeping_up_on_the_complexity_ceiling():
+    """The crowd count, one axis over - see COMPLEX_NEAR_CEILING for why.
+
+    Both halves live in ONE test on purpose, which is a deviation from the size
+    ratchet above and it is about cost, not tidiness: every reading here is a ruff
+    subprocess over the whole tree (measured 0.6 s warm, 2.4 s cold), and splitting
+    the two questions would pay for the same measurement twice to print two
+    sentences. `check` gives each half its own wording, which is what the split was
+    ever for.
+    """
+    import tomllib
+    with open(os.path.join(ROOT, "pyproject.toml"), "rb") as handle:
+        ceiling = tomllib.load(handle)["tool"]["ruff"]["lint"]["mccabe"]["max-complexity"]
+
+    band = int(ceiling * CROWD_BAND)
+    crowded = _ruff_complexity_findings(band)
+    if crowded is None:
+        return                      # ruff not installed here: nothing to measure
+
+    check(f"at most {COMPLEX_NEAR_CEILING} function(s) within {CROWD_BAND:.0%} of "
+          f"max-complexity ({band + 1} or more) - simplify one before adding another",
+          crowded <= COMPLEX_NEAR_CEILING,
+          f"({crowded} in the band, COMPLEX_NEAR_CEILING is {COMPLEX_NEAR_CEILING})")
+    check("the complexity crowd count is today's measurement, not a looser number",
+          crowded == COMPLEX_NEAR_CEILING,
+          f"(measured {crowded}, frozen at {COMPLEX_NEAR_CEILING} - lower it)")
 
 
 # The modules mypy is strict about, recorded here so the list in pyproject.toml

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -43,6 +43,8 @@ import ast
 import os
 import sys
 
+import pytest
+
 from fakes import ROOT, check
 
 # Today's maxima, measured 2026-08-02. Ratchet: down is routine, up is a decision.
@@ -109,7 +111,7 @@ FUNCTIONS_NEAR_CEILING = 3      # _run_session, _build_ui, build_arg_parser
 # The band here is ABSOLUTE, not the 70% the size counts use, and that is measured
 # rather than lazy: 70% of 5 is 3.5, so the band would be "4 or more" today - the
 # same as below - but the moment the ceiling dropped to 4 it would become "3 or
-# more" and the count would jump from 3 to 38. A band that reshapes itself under
+# more" and the count would jump from 12 to 82. A band that reshapes itself under
 # the thing it is watching says nothing. Percentages need a range to be a
 # percentage OF, and depth here runs 0 to 5.
 DEPTH_CEILING = 5               # beantester/gui/icon.py::make_gear_icon
@@ -541,7 +543,7 @@ def test_the_complexity_ceiling_is_the_measurement_not_a_number_above_it():
 
     at_ceiling = _ruff_complexity_findings(ceiling)
     if at_ceiling is None:
-        return                      # ruff not installed here: nothing to measure
+        pytest.skip("ruff is not installed here, so this guard measured nothing")
     check(f"nothing in the tree is more complex than {ceiling}",
           at_ceiling == 0, f"({at_ceiling} function(s) over the ceiling)")
 
@@ -568,7 +570,7 @@ def test_nothing_else_is_creeping_up_on_the_complexity_ceiling():
     band = int(ceiling * CROWD_BAND)
     crowded = _ruff_complexity_findings(band)
     if crowded is None:
-        return                      # ruff not installed here: nothing to measure
+        pytest.skip("ruff is not installed here, so this guard measured nothing")
 
     check(f"at most {COMPLEX_NEAR_CEILING} function(s) within {CROWD_BAND:.0%} of "
           f"max-complexity ({band + 1} or more) - simplify one before adding another",
@@ -593,7 +595,7 @@ def test_the_argument_ceiling_is_the_measurement_not_a_number_above_it():
 
     over = _ruff_findings("PLR0913", "lint.pylint.max-args", ceiling)
     if over is None:
-        return                      # ruff not installed here: nothing to measure
+        pytest.skip("ruff is not installed here, so this guard measured nothing")
     check(f"no signature takes more than {ceiling} arguments "
           f"(split the call - do not raise the ceiling)",
           over == 0, f"({over} signature(s) over the ceiling)")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -315,8 +315,8 @@ def test_scoped_is_a_sticky_session_record():
     socket closed. A browser closes hundreds of connections a minute; if the flag
     tracked only the latest packet (or a live port lookup) every finished flow would
     read "not impaired" the instant it closed, so a run that impaired all of chrome
-    looked like it had caught nothing. The LIVE "in scope now" signal is a separate
-    thing (the connections page highlights the row via BeanCore.in_scope).
+    looked like it had caught nothing. The row highlight reads this same stored
+    record (gui/pages/conns.py::_tag_of), so colour and column cannot disagree.
 
     Driven straight through ``_log_conn`` so the stickiness is asserted without any
     thread timing: three packets on one flow (in scope, then twice out), plus a flow

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -258,6 +258,34 @@ MUTATIONS = [
         "test": "test_nothing_else_is_creeping_up_on_the_complexity_ceiling",
     },
     {
+        # A rule deleted from `select` to turn a red build green is a check that
+        # vanished - and a check that has vanished cannot fail to announce itself.
+        "label": "ruff: a selected rule quietly leaves the configuration",
+        "file": "pyproject.toml",
+        "old": 'select = ["F", "B", "S", "ASYNC", "C90", "PLR0913"]',
+        "new": 'select = ["F", "B", "S", "ASYNC", "C90"]',
+        "test": "test_the_selected_rules_only_ever_grow",
+    },
+    {
+        # The gap the pairing exists for: `--select` on the command line REPLACES
+        # the list in pyproject.toml, so a rule can stay configured, stay visible
+        # to `ruff check` on a developer machine, and stop blocking anything.
+        "label": "ci: a blocking ruff rule drops out of the workflow command",
+        "file": ".github/workflows/ci.yml",
+        "old": "        run: ruff check --select F,B,C90,PLR0913 --output-format github",
+        "new": "        run: ruff check --select F,B,C90 --output-format github",
+        "test": "test_every_blocking_rule_is_named_in_the_workflow_that_blocks",
+    },
+    {
+        # A ceiling standing above the truth grants headroom nobody decided to
+        # grant - the same defect the file and function ceilings are guarded for.
+        "label": "ratchet: the argument ceiling is raised above the widest signature",
+        "file": "pyproject.toml",
+        "old": "max-args = 14",
+        "new": "max-args = 20",
+        "test": "test_the_argument_ceiling_is_the_measurement_not_a_number_above_it",
+    },
+    {
         # The leak guard's newest half. It runs in CI and had never been shown
         # able to fail - the canary that finally did found it blind to exactly
         # the class the convention names first.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1067,11 +1067,19 @@ MUTATIONS = [
         # from the index a line before it is asked to verify our hashes. Additive on
         # purpose - it puts the line back without taking anything away, so exactly
         # one test answers.
+        # 🔴 RE-ANCHORED 2026-08-21, and the reason is the trap itself: this used to
+        # aim at the bare `pip install --require-hashes -r requirements-lint.txt`
+        # line, which was unique only while ONE job installed the linter. The
+        # moment the mutation job needed ruff too, the pattern matched twice and
+        # the entry stopped proving anything - the suite said so the same day.
+        # The anchor now names two requirement files in one command, which is
+        # unique for a reason that has nothing to do with the property guarded
+        # here, so extending the linter install again cannot break it.
         "label": "supply chain: a workflow upgrades pip from the index again",
         "file": ".github/workflows/ci.yml",
-        "old": "          pip install --require-hashes -r requirements-lint.txt",
+        "old": "          pip install --require-hashes -r requirements.txt -r requirements-build.txt",
         "new": "          python -m pip install --upgrade pip\n"
-               "          pip install --require-hashes -r requirements-lint.txt",
+               "          pip install --require-hashes -r requirements.txt -r requirements-build.txt",
         "test": "test_no_workflow_bootstraps_pip_from_the_index",
     },
     {

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -286,6 +286,17 @@ MUTATIONS = [
         "test": "test_the_argument_ceiling_is_the_measurement_not_a_number_above_it",
     },
     {
+        # The third axis, added the same day. Aimed at the COUNT rather than at
+        # `_nesting_depth` itself for the reason written next to the depth metric
+        # tests in PROVEN_BY_HAND: any patch to the metric reddens three tests at
+        # once, and an entry that fells a crowd proves nothing about any one of them.
+        "label": "ratchet: the nesting crowd count is frozen looser than the measurement",
+        "file": "tests/test_code_shape.py",
+        "old": "DEPTHS_NEAR_CEILING = 12        # make_gear_icon at 5, eleven more at 4",
+        "new": "DEPTHS_NEAR_CEILING = 20        # make_gear_icon at 5, eleven more at 4",
+        "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
+    },
+    {
         # The leak guard's newest half. It runs in CI and had never been shown
         # able to fail - the canary that finally did found it blind to exactly
         # the class the convention names first.
@@ -1459,6 +1470,26 @@ PROVEN_BY_HAND = {
     "test_the_language_files_stay_sorted":
         "2026-08-17, swapped two adjacent keys back out of order in both lang "
         "files (byte-level, so LF survived), saw it go red, restored it, saw green",
+    # 🔴 These three cannot become MUTATIONS entries, and the reason is a property
+    # of what they guard rather than laziness. Every patch to `_nesting_depth`
+    # moves the measurement of the whole package, so it reddens the two ratchet
+    # tests pinned to that measurement as well as the metric test being aimed at -
+    # measured on 2026-08-21: making an `elif` count as a level again turned three
+    # tests red at once, and rule 3 of this registry is that an entry names ONE.
+    # An entry that fells a crowd proves nothing about any single guard in it.
+    #
+    # All three were red for real during the session that wrote them, which is
+    # better evidence than usual for this list: the metric was WRONG when the tests
+    # went in - it walked an `if` body without adding the level that body sits at -
+    # and `test_the_depth_metric_still_counts_real_nesting` is what found it, before
+    # any constant had been filled in.
+    "test_an_elif_chain_is_one_level_not_one_per_branch":
+        "2026-08-21, made elif count per branch again, saw red, restored, saw green",
+    "test_an_except_handler_is_not_a_level_of_its_own":
+        "2026-08-21, same patch run: the handler counted as its own level",
+    "test_the_depth_metric_still_counts_real_nesting":
+        "2026-08-21, it failed on the first draft of the metric (four nested blocks "
+        "measured three) and passed once the missing level was added",
 }
 
 # No mutation at all. Naming them is the point: an unproven guard and a guard nobody

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -248,6 +248,16 @@ MUTATIONS = [
         "test": "test_the_crowd_counts_are_not_set_so_loosely_that_they_never_fire",
     },
     {
+        # The same knob on the complexity axis, which had no crowd count at all
+        # until 2026-08-21: `max-complexity` watches the single most branching
+        # function and cannot see the runners-up climbing together underneath it.
+        "label": "ratchet: the complexity crowd count is frozen looser than the measurement",
+        "file": "tests/test_code_shape.py",
+        "old": "COMPLEX_NEAR_CEILING = 3        # decide, _run_session, settings_summary",
+        "new": "COMPLEX_NEAR_CEILING = 5        # decide, _run_session, settings_summary",
+        "test": "test_nothing_else_is_creeping_up_on_the_complexity_ceiling",
+    },
+    {
         # The leak guard's newest half. It runs in CI and had never been shown
         # able to fail - the canary that finally did found it blind to exactly
         # the class the convention names first.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -297,6 +297,28 @@ MUTATIONS = [
         "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
     },
     {
+        # Half the package is only ever named from the suite, so a scan that stops
+        # reading tests/ calls a live helper dead. This is the noisy direction and
+        # the one that gets a guard switched off.
+        "label": "dead code: the usage scan stops reading the test suite",
+        "file": "tests/test_code_hygiene.py",
+        "old": 'USAGE_TREES = ("beantester", "tests", "tools", "lang", "scenarios")',
+        "new": 'USAGE_TREES = ("beantester", "tools", "lang", "scenarios")',
+        "test": "test_no_definition_in_the_package_is_unreferenced",
+    },
+    {
+        # The quiet direction, and the reason the exception list is a ratchet
+        # rather than a note: a scan blinded here finds NOTHING and reads exactly
+        # like a clean package. What catches it is the list of names that are
+        # supposed to still be unreferenced - they stop being reported, and the
+        # second test says so.
+        "label": "dead code: the scan stops recognising an unreferenced definition",
+        "file": "tests/test_code_hygiene.py",
+        "old": "            if not living:\n                dead.add(key)",
+        "new": "            if False:\n                dead.add(key)",
+        "test": "test_the_known_unused_list_only_ever_shrinks",
+    },
+    {
         # The leak guard's newest half. It runs in CI and had never been shown
         # able to fail - the canary that finally did found it blind to exactly
         # the class the convention names first.


### PR DESCRIPTION
## What this is

Four ceilings and one clean-up, all measured on this tree rather than taken from a
textbook. Every number pinned here is today's maximum, so the whole set is green
from the first run and only fires when something grows past what already exists.

This started as a question about adopting an external complexity analyser. The
measurement said no: five of the six things that tool takes are taken here already,
often better, and its duplicate detector finds nothing in this tree - 168 files
scanned, zero logic clones, nine cross-file groups that are all data tables. Its
Python reader also counts `and` / `or`, which scores `driver.doctor` at 27 where
ruff scores the same function 6 - a ranking inversion on a flat table of ternaries.
A second, disagreeing number on an axis that already has one is two ceilings over
one head. So the gaps it did point at were closed with what is already installed.

## The five commits

**Remove five definitions nothing calls.** `BeanEngine.in_scope_now` and the
`BeanCore.in_scope` behind it were recorded as unused when the connections page
moved its row highlight onto the stored `scoped` record; the follow-up the entry
promised never came. `ScrollableFrame.yview_fraction`, `.set_yview_fraction` and
`PortTable.age` have no caller anywhere and no mention in any document. Two comments
that described the deleted path were corrected - they claimed the highlight asks the
engine live, which it has not done for two releases.

**A complexity crowd count.** `max-complexity` watches one function and is blind to
the drift the size ratchet grew a second knob for: the runners-up climbing together,
none of them a record. At a ceiling of 29, `cli._run_session` could reach 29 from 27
with every gate green the whole way. Three functions are in the 70% band today and
the next one sits one branch below it.

**PLR0913, and both rule lists held to each other.** Argument count is the one
measurement on ruff's pylint-refactor list that nothing here already takes -
PLR0912 is C90 on the same function, PLR0915 is FUNCTION_CEILING measured worse
because the ratchet counts logic lines and leaves comments free, PLR0911 needs a
branch per return. Pinned to the widest signature that exists (14), not to ruff's
default of 5, which would be red on 25 signatures before catching anything.
`--select` on the workflow command line replaces the list in `pyproject.toml`, so a
rule could be configured, visible to `ruff check` locally, and absent from the only
run that can block a merge. Both lists are recorded in the suite now, and a third
check refuses a rule that is neither blocking nor reported.

**A nesting-depth ceiling.** The axis `test_code_shape.py` said out loud it did not
measure. Nothing else can see it: ruff has no depth rule, the size ceiling is blind
to it, and complexity scores a flat chain of eight `elif` exactly like eight nested
`if`. The band is absolute rather than a percentage - 70% of 5 lands on the same
line today, but at a ceiling of 4 it would mean "3 or more" and the count would jump
from 12 to 82.

**A dead-code guard, resolved to a fixed point.** A dead caller keeps its callee
looking alive, which is exactly how `BeanCore.in_scope` stayed invisible. The scan
reads an allow-list of trees and never walks the repository root, so it cannot reach
directories that exist on a maintainer machine and in no checkout - one that did
would call a name used locally and dead in CI.

## Two things were wrong on the first attempt

Both were caught by measurement rather than review, and both are written down where
the next reader will hit them.

The depth metric walked an `if` body without adding the level that body sits at, so
four nested blocks measured three. Its own test found it - which is why the three
metric tests went in before any constant was filled in. The first pinned band (3)
was the wrong measurement and became 12 once the metric was fixed.

The dead-code guard scanned its own file, where the exception list lives, so writing
a name into that list was a mention of itself and the scan reported it as used. The
guard disarmed itself in the act of recording an exception, and the two entries on
that list were exactly the names it would have stopped watching.

## Two measured decisions worth knowing about

The dead-code scan counts every word, comments and strings included. Counting only
code tokens finds six more names and five of them are alive: four are called from
inside `run_gui("""...""")` blocks - the GUI tests are Python source in a string, run
in a subprocess, and the suite holds 204 of those calls - and one is reached through
`getattr`. A guard that accuses living code is a guard people switch off. The price
is named in the file: a definition whose name is an ordinary English word survives on
prose alone, which is how `PortTable.age` had to be found by hand.

The three depth-metric tests are in `PROVEN_BY_HAND`, not `MUTATIONS`. Any patch to
the metric moves the measurement of the whole package, so it reddens the two ratchet
tests pinned to it as well - measured, three tests red at once - and a registry entry
names one test.

## Verification

* `ruff check --select F,B,C90,PLR0913 .` clean, `mypy` clean over 66 modules.
* Guards for the touched code: 335 passed. Meta guards (shape, hygiene, registry,
  conventions, README, release, packaging): 97 passed. `smoke_gui.py` OK.
* `tools/mutate.py --changed` for this branch: 29 entries, 29 caught, none survived.
  Six of those entries are new and each was run on its own as well.
* End to end: a function nothing calls was planted in the package, the guard caught
  it by name, and the file was restored byte for byte.
* Every pinned number was re-measured independently of the test that asserts it.

The full suite, the real-Tk render check, semgrep, diff-cover and the executable
build were deliberately left to this pull request - they need the platforms CI has.
