### PR TITLE
Audit the pins when they move, when a release ships them, and say when a cron goes red

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Who owns this repository, and who GitHub asks to review a change to it.
+#
+# One owner, one line. Finer-grained rules would be fiction here: every path
+# below has the same owner, and a list that pretends otherwise ages into a claim
+# nobody checks.
+#
+# What this file DOES do
+# ----------------------
+# A pull request opened by anyone else automatically requests a review from the
+# owner. That is the whole reason it exists: an outside contribution should not
+# sit unnoticed because nobody was asked.
+#
+# What it does NOT do
+# -------------------
+# GitHub never requests a review from the person who opened the pull request, and
+# nobody can approve their own. So on a change written by the owner this file is
+# silent by design - and a branch rule that demands a code-owner approval would,
+# on such a change, demand one from somebody who does not exist. That combination
+# freezes the repository: no pull request can ever be merged.
+#
+# This project therefore protects the default branch with STATUS CHECKS rather
+# than with reviews (see CONTRIBUTING.md and the CI workflow). A gate that runs is
+# worth more here than an approval nobody can give.
+#
+# Syntax note: gitignore-style patterns, with three exceptions - a pattern may not
+# start with `#`, `!` does not negate, and `[ ]` character ranges do not work.
+
+*       @donislawdev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,20 @@ on:
   # machine. It is pinned in requirements-build.txt now, so what this cron watches
   # on the build side is the runner and the interpreter, not the freezer.
   #
-  # 🔴 A red cron is only worth the minutes if somebody reads it. The owner
-  # decided against opening an issue automatically (2026-08-17), so this run is
-  # checked by hand - `gh run list --workflow CI --branch master`.
+  # 🔴 A red cron is only worth the minutes if somebody reads it - and the way
+  # this repository made sure of that CHANGED on 2026-08-21.
+  #
+  # The owner decided on 2026-08-17 that a red weekly run would be read by hand
+  # (`gh run list --workflow CI --branch master`) rather than announced, and
+  # reversed that on 2026-08-21 for one reason: **a cron is very easy to miss.**
+  # Nothing arrives when it goes red, the run hangs off no pull request anybody
+  # is looking at, and a week later it is off the first page. The narrow
+  # exception carved out for advisories (the `audit` job below) had already made
+  # the same argument for a smaller case.
+  #
+  # So the `cron-issue` job at the end of this file opens one, deduplicated by
+  # the set of jobs that failed. It never closes anything: a later green run
+  # means those jobs passed once, not that the cause is gone.
   schedule:
     - cron: "0 6 * * 1"
   # Allow running the pipeline by hand from the Actions tab.
@@ -172,33 +183,85 @@ jobs:
   # `pydivert` carries a `sys_platform == "win32"` marker, so a Linux runner would
   # skip the one dependency that puts a kernel driver on a user's machine.
   audit:
+    # 🔴 A CONTRACT with the branch ruleset, like every other job name here: the
+    # rule requires a status check by this exact string. Do not edit it without
+    # editing the ruleset first.
     name: pip-audit (advisories against the pinned set)
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Three triggers, two different questions.
+    #
+    #   schedule / workflow_dispatch - "did the WORLD move under versions that
+    #     did not?" The set is hash-pinned, so only a newly published advisory
+    #     can change the answer, and that is a clock event.
+    #   pull_request - "did the SET move?" A pull request that edits a
+    #     requirements file changes what is installed, and waiting until Monday
+    #     to find out means a merge and possibly a release in between.
+    #
+    # A pull request that touches no requirements file cannot change the answer,
+    # so the job starts, asks that question cheaply, and stops. It runs rather
+    # than being skipped by a job-level `if:` on purpose: a job that reports
+    # "skipped" is an awkward thing for a required check to be, while one that
+    # reports success after finding nothing to do is not.
+    if: >-
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'pull_request'
     runs-on: windows-latest
     timeout-minutes: 15
     permissions:
       contents: read
       # Raised on THIS job only, and only because it opens an issue when it finds
-      # something. Nothing else in this workflow may write anything.
+      # something on the SCHEDULED path. Nothing else in this workflow may write
+      # anything, and the pull-request path never uses it - it fails the run
+      # instead, which is what a pull request can act on.
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # The pull-request path diffs against the base branch, and a shallow
+          # clone has no base branch to diff against.
+          fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.14"
+      # 🔴 The cheap question, and the one place this job can go quietly wrong.
+      # If the base cannot be fetched, `git diff` fails and so does this step -
+      # deliberately. The alternative shape ("could not tell, so assume nothing
+      # changed") is the worst failure mode a gate has: green because it could
+      # not look.
+      - name: Is there anything to audit
+        id: scope
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "$BASE_REF"
+          changed="$(git diff --name-only "origin/$BASE_REF...HEAD" -- 'requirements*.txt')"
+          if [ -n "$changed" ]; then
+            echo "the pinned set moved:"; echo "$changed"
+            echo "audit=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "no requirements file changed - the answer cannot have moved"
+            echo "audit=no" >> "$GITHUB_OUTPUT"
+          fi
+      # Every step below is skipped on a pull request that moved no requirements
+      # file. The condition is repeated rather than shared because GitHub Actions
+      # has no way to name one - there are no YAML anchors here.
       - name: Install the auditor
+        if: github.event_name != 'pull_request' || steps.scope.outputs.audit == 'yes'
         run: pip install -r requirements-scan.txt
       # The pinned set, installed exactly as the build installs it, into its own
       # environment - then audited BY PATH. Auditing the requirement files instead
       # silently skips `packaging` and `setuptools` (measured), and a scanner that
       # covers less than it was asked to is worse than no scanner at all.
       - name: Install the pinned set into a clean environment
+        if: github.event_name != 'pull_request' || steps.scope.outputs.audit == 'yes'
         shell: bash
         run: |
           python -m venv audit-env
           audit-env/Scripts/python -m pip install --quiet \
             --require-hashes -r requirements.txt -r requirements-build.txt
       - name: Audit it
+        if: github.event_name != 'pull_request' || steps.scope.outputs.audit == 'yes'
         shell: bash
         # pip-audit exits non-zero when it finds something, and finding something
         # is what the next step is for - so the exit code is captured, not obeyed.
@@ -208,7 +271,27 @@ jobs:
           echo "pip-audit exit: $?"
           set -e
           test -s audit.json || { echo "no report was written"; exit 1; }
+      # 🔴 The pull-request path ENDS HERE, and it ends by failing. An issue is
+      # the right answer to "the world moved under a set nobody is touching this
+      # week"; it is the wrong answer to "this change adds a vulnerable pin",
+      # which has an author, a diff and a review open right now. The same JSON is
+      # read by the same tool, so the two paths cannot disagree about what counts
+      # as a finding.
+      - name: Refuse a pull request that pins something vulnerable
+        if: github.event_name == 'pull_request' && steps.scope.outputs.audit == 'yes'
+        shell: bash
+        run: |
+          verdict="$(python tools/audit_issue.py --audit audit.json)"
+          echo "verdict: $verdict"
+          if [ "$verdict" != "none" ]; then
+            echo "::error::This pull request changes a requirements file, and the set"
+            echo "::error::it pins carries a published advisory. Raise the pin, or drop"
+            echo "::error::the dependency - see the report above."
+            exit 1
+          fi
+          echo "nothing published against the set this pull request pins."
       - name: Open an issue if anything was found
+        if: github.event_name != 'pull_request'
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -585,3 +668,65 @@ jobs:
         with:
           name: BeanNetworkTester-windows
           path: dist/BeanNetworkTester
+
+  # 🔴 The weekly run tells nobody it went red. This job is the telling, and it
+  # reverses the 2026-08-17 decision - see the note beside `schedule` at the top.
+  #
+  # `needs` NAMES EVERY OTHER JOB, and that is load-bearing rather than tidy: a
+  # job left out of this list can fail every Monday for a year in perfect silence.
+  # tests/test_version_and_release.py holds the two lists to each other so adding
+  # a job to this workflow cannot quietly leave it unwatched.
+  #
+  # `always()` because `needs` on a job that was SKIPPED (public-text is
+  # pull-request-only, so it is skipped here) would otherwise skip this one too.
+  # `contains(needs.*.result, 'failure')` and not `failure()`: a cancelled run -
+  # superseded, or out of time - says nothing about the code, and an issue for it
+  # is the noise that teaches people to close these unread. The tool refuses that
+  # case a second time, in tests/test_cron_issue.py.
+  cron-issue:
+    name: open an issue when the weekly run is red
+    needs: [public-text, lint, types, semgrep, audit, mutations, tests, build]
+    if: >-
+      always() && github.event_name == 'schedule'
+      && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Raised on THIS job only, for the same reason as on `audit`: it opens an
+      # issue and does nothing else.
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Say which jobs went red, once
+        shell: bash
+        # Every context value travels through the environment, never into the
+        # script text: the repository's own guard refuses a `${{ }}` inside a
+        # `run:` block, and `toJSON(needs)` is exactly the kind of value that
+        # must not become source code.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEEDS: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          printf '%s' "$NEEDS" > needs.json
+          gh issue list --label ci-cron --state open --json number,title > open.json
+          action=$(python tools/cron_issue.py --needs needs.json --existing open.json \
+                     --title-out issue-title.txt --body-out issue-body.md \
+                     --run-url "$RUN_URL" --commit "$HEAD_SHA")
+          echo "verdict: $action"
+          case "$action" in
+            create)
+              gh label create ci-cron --color D93F0B \
+                  --description "opened by the weekly scheduled run" --force
+              gh issue create --label ci-cron \
+                  --title "$(cat issue-title.txt)" --body-file issue-body.md
+              ;;
+            skip) echo "an open issue already names exactly these jobs" ;;
+            none) echo "nothing in this run failed" ;;
+            *)    echo "unexpected verdict from tools/cron_issue.py"; exit 1 ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,9 +175,11 @@ jobs:
       - name: Decide
         run: python tools/semgrep_gate.py semgrep.json
 
-  # Weekly, on Windows, and only weekly: this asks whether the world changed
-  # under versions that did not. A pull request cannot make it red, so running it
-  # per pull request would burn minutes to re-answer the same question.
+  # On Windows, and on two schedules of its own - see the triggers below. The
+  # weekly half asks whether the world changed under versions that did not; the
+  # pull-request half asks whether the versions changed. It USED to be weekly and
+  # nothing else, which left a tag that moved a pin unchecked until the following
+  # Monday, with a merge and possibly a release in between (2026-08-21).
   #
   # windows-latest because that is where the shipped set actually exists:
   # `pydivert` carries a `sys_platform == "win32"` marker, so a Linux runner would

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,48 @@ jobs:
           python-version: "3.14"
           cache: pip
 
+      # 🔴 "CI was green on this commit" does NOT include this question, and that
+      # was the gap. The `audit` job in ci.yml runs on the schedule and on a pull
+      # request that moves a requirements file - neither of which is a tag push.
+      # So a release could ship a set that Monday's issue had already flagged,
+      # for as long as nobody read the issue.
+      #
+      # BOTH venvs are deliberate. `pip-audit` is pinned by version only, and the
+      # environment this job builds the executable from must contain exactly the
+      # hash-pinned bytes and nothing else - that is what `--require-hashes` is
+      # FOR. So the auditor lives in one throwaway environment, the audited set
+      # in another, and the job's own Python is not touched until the step below.
+      #
+      # Audited BY PATH for the reason measured on 2026-08-11: auditing the
+      # requirement files instead covers 7 of the 9 packages and silently skips
+      # `packaging` and `setuptools`.
+      - name: Refuse to build a release whose pins carry a published advisory
+        shell: bash
+        run: |
+          python -m venv audit-env
+          audit-env/Scripts/python -m pip install --quiet \
+            --require-hashes -r requirements.txt -r requirements-build.txt
+          python -m venv audit-tool
+          audit-tool/Scripts/python -m pip install --quiet -r requirements-scan.txt
+          set +e
+          audit-tool/Scripts/pip-audit --path audit-env/Lib/site-packages \
+            -f json -o release-audit.json
+          echo "pip-audit exit: $?"
+          set -e
+          test -s release-audit.json || { echo "no report was written"; exit 1; }
+          # The same reader the weekly job and the pull-request path use, so the
+          # three cannot disagree about what counts as a finding.
+          verdict="$(python tools/audit_issue.py --audit release-audit.json)"
+          echo "verdict: $verdict"
+          if [ "$verdict" != "none" ]; then
+            echo "::error::A published advisory names a version this tag would ship."
+            echo "::error::Raise the pin and tag again. Releasing over this would put"
+            echo "::error::a known-vulnerable dependency inside a signed binary."
+            exit 1
+          fi
+          echo "nothing published against the set this tag ships."
+          rm -rf audit-env audit-tool
+
       - name: Install dependencies
         run: |
           # One hash-checked resolution over both files - the same command the

--- a/README.md
+++ b/README.md
@@ -1188,9 +1188,10 @@ Every job in that workflow, and what a red one means:
 | `types` | **mypy** over the package |
 | `semgrep` | the default registry ruleset. ERROR, HIGH and CRITICAL fail the run, the rest is printed |
 | `mutations` | breaks each guarded behaviour and proves its test reddens. A pull request runs the entries it touched, the weekly run does all of them |
-| `audit` | weekly only: **pip-audit** against the pinned set, and it opens an issue when an advisory lands |
+| `audit` | **pip-audit** against the pinned set. Weekly, to ask whether the world moved under versions that did not, and on a pull request that edits a requirements file, to ask whether the set moved. The weekly run opens an issue, and a pull request that pins something vulnerable simply fails |
 | `tests` | the suite, the GUI smoke, the real-Tk render check and the CLI assertions, on Linux and Windows |
 | `build` | the Windows executable, smoke-tested, with the driver check and the licence registry scan |
+| `cron-issue` | opens an issue when the weekly run goes red, deduplicated by which jobs failed. A cron is easy to miss and nothing else announces one. Never runs on a pull request, and never closes an issue by itself |
 <!-- ci-jobs:end -->
 
 **Three static checks run beside the tests**, on Linux only, because they read the source rather

--- a/README.pl.md
+++ b/README.pl.md
@@ -1035,9 +1035,10 @@ Wszystkie joby tego workflow i co znaczy czerwony:
 | `types` | **mypy** na pakiecie |
 | `semgrep` | domyślny zestaw reguł z rejestru. ERROR, HIGH i CRITICAL wywracają przebieg, reszta ląduje w logu |
 | `mutations` | psuje każde pilnowane zachowanie i dowodzi, że jego test się czerwieni. PR odpala wpisy, których dotknął, cotygodniowy przebieg wszystkie |
-| `audit` | tylko co tydzień: **pip-audit** na przypiętym zestawie, a przy znalezisku zakłada issue |
+| `audit` | **pip-audit** na przypiętym zestawie. Co tydzień - czy świat ruszył się pod wersjami, które stoją - oraz na PR-ze zmieniającym plik wymagań - czy ruszył się zestaw. Cotygodniowy przebieg zakłada issue, a PR przypinający coś podatnego po prostu się wywraca |
 | `tests` | suite, smoke GUI, render na prawdziwym Tk i asercje CLI, na Linuksie i Windowsie |
 | `build` | plik .exe dla Windowsa, ze smoke'iem, sprawdzeniem sterownika i skanem rejestru licencji |
+| `cron-issue` | zakłada issue, gdy cotygodniowy przebieg zrobi się czerwony, z deduplikacją po tym, które joby padły. Crona bardzo łatwo przegapić, a nic innego go nie zgłasza. Nie chodzi na PR-ach i nigdy sam nie zamyka issue |
 <!-- ci-jobs:end -->
 
 **Obok testów chodzą trzy analizy statyczne**, wyłącznie na Linuksie, bo czytają kod, a nie go

--- a/tests/test_cron_issue.py
+++ b/tests/test_cron_issue.py
@@ -1,0 +1,118 @@
+"""The weekly red-run notice: when it opens an issue, and when it stays quiet.
+
+The decision guarded here is not "did the run fail" - GitHub answers that - but
+what the repository does about it. Opening an issue every Monday for a failure
+somebody already read would train everyone to close them unread; swallowing a
+DIFFERENT failure into the open issue about last week's would lose it. So the
+title carries the failing job names, and matching is exact.
+
+The other half is what must NOT open an issue: a cancelled run says nothing
+about the code (a superseded run, a timeout), and a skipped job says even less.
+Only a job that ran and failed counts.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tools"))
+
+import cron_issue                                          # noqa: E402
+from fakes import check                                    # noqa: E402
+
+
+def _needs(**results):
+    """The shape `toJSON(needs)` produces: {job_id: {"result": ...}}."""
+    return {job: {"result": result} for job, result in results.items()}
+
+
+def _write(tmp_path, name, payload):
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return str(path)
+
+
+def test_a_green_run_says_nothing(tmp_path, capsys):
+    path = _write(tmp_path, "n.json", _needs(tests="success", build="success"))
+    code = cron_issue.main(["--needs", path])
+    check("a green run exits 0", code == 0, f"(exit {code})")
+    check("and asks for nothing", capsys.readouterr().out.strip() == "none")
+
+
+def test_a_failure_asks_for_an_issue(tmp_path, capsys):
+    path = _write(tmp_path, "n.json", _needs(tests="success", build="failure"))
+    code = cron_issue.main(["--needs", path,
+                            "--title-out", str(tmp_path / "t.txt"),
+                            "--body-out", str(tmp_path / "b.md"),
+                            "--run-url", "https://example.invalid/run/1",
+                            "--commit", "abc1234"])
+    check("it exits 0", code == 0, f"(exit {code})")
+    check("and asks for an issue", capsys.readouterr().out.strip() == "create")
+    title = (tmp_path / "t.txt").read_text(encoding="utf-8")
+    check("the title names the failing job", "build" in title, f"({title})")
+    check("and not the passing one", "tests" not in title, f"({title})")
+    body = (tmp_path / "b.md").read_text(encoding="utf-8")
+    check("the body carries the run link", "https://example.invalid/run/1" in body)
+    check("and the commit", "abc1234" in body)
+
+
+def test_a_cancelled_run_is_not_a_failure(tmp_path, capsys):
+    """🔴 The one that must never fire.
+
+    A cancelled job means a newer push superseded this run, or it hit the time
+    limit. Neither says anything about the code, and an issue for it is noise
+    that teaches people to close these unread.
+    """
+    path = _write(tmp_path, "n.json", _needs(tests="cancelled", build="skipped"))
+    code = cron_issue.main(["--needs", path])
+    check("a cancelled run exits 0", code == 0, f"(exit {code})")
+    check("and opens nothing", capsys.readouterr().out.strip() == "none")
+
+
+def test_the_same_failure_does_not_open_a_second_issue(tmp_path, capsys):
+    path = _write(tmp_path, "n.json", _needs(build="failure"))
+    open_issues = _write(tmp_path, "open.json",
+                         [{"number": 7, "title": "Weekly CI run is red: build"}])
+    code = cron_issue.main(["--needs", path, "--existing", open_issues])
+    check("it exits 0", code == 0, f"(exit {code})")
+    check("and skips, because an open issue says exactly this",
+          capsys.readouterr().out.strip() == "skip")
+
+
+def test_a_different_failure_is_not_swallowed_by_the_open_issue(tmp_path, capsys):
+    """The other half of the rule above, and the one that loses information.
+
+    Last week the build failed; this week the mutation registry did. Matching on
+    the label alone would file the second under the first and nobody would see it.
+    """
+    path = _write(tmp_path, "n.json", _needs(mutations="failure"))
+    open_issues = _write(tmp_path, "open.json",
+                         [{"number": 7, "title": "Weekly CI run is red: build"}])
+    code = cron_issue.main(["--needs", path, "--existing", open_issues,
+                            "--title-out", str(tmp_path / "t.txt"),
+                            "--body-out", str(tmp_path / "b.md")])
+    check("it exits 0", code == 0, f"(exit {code})")
+    check("and asks for a second issue", capsys.readouterr().out.strip() == "create")
+
+
+def test_two_failures_are_one_issue_naming_both(tmp_path, capsys):
+    path = _write(tmp_path, "n.json", _needs(build="failure", mutations="failure",
+                                             tests="success"))
+    cron_issue.main(["--needs", path, "--title-out", str(tmp_path / "t.txt"),
+                     "--body-out", str(tmp_path / "b.md")])
+    capsys.readouterr()
+    title = (tmp_path / "t.txt").read_text(encoding="utf-8")
+    check("the title names both, sorted", title.endswith("build, mutations"), f"({title})")
+
+
+def test_an_unreadable_report_is_not_a_green_one(tmp_path, capsys):
+    """The rule the semgrep gate and the audit gate already live by.
+
+    A file that cannot be parsed must not read as "nothing failed" - that turns a
+    broken workflow step into a clean bill of health.
+    """
+    path = tmp_path / "n.json"
+    path.write_text("{not json", encoding="utf-8")
+    code = cron_issue.main(["--needs", str(path)])
+    check("it exits 2, not 0", code == 2, f"(exit {code})")
+    check("and says nothing that could be mistaken for a verdict",
+          capsys.readouterr().out.strip() == "")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -267,6 +267,34 @@ MUTATIONS = [
         "test": "test_the_selected_rules_only_ever_grow",
     },
     {
+        # A job outside `needs` fails every Monday in silence - the same defect
+        # the notice itself exists to cure, one level up.
+        "label": "cron notice: a job drops out of what the weekly notice watches",
+        "file": ".github/workflows/ci.yml",
+        "old": "    needs: [public-text, lint, types, semgrep, audit, mutations, tests, build]",
+        "new": "    needs: [public-text, lint, types, semgrep, audit, mutations, tests]",
+        "test": "test_the_cron_notice_watches_every_job_in_the_workflow",
+    },
+    {
+        # A tag can be cut days before the next cron, so the pinned set has to be
+        # asked about when it CHANGES, not only when the calendar turns.
+        "label": "audit: the pinned set stops being checked when a pull request moves it",
+        "file": ".github/workflows/ci.yml",
+        "old": "      || github.event_name == 'pull_request'",
+        "new": "      || false",
+        "test": "test_the_audit_job_answers_to_a_pull_request_that_moves_the_pins",
+    },
+    {
+        # File mode covers 7 of the 9 packages and silently skips `packaging` and
+        # `setuptools` - measured 2026-08-11. A release audited that way reads
+        # clean for a reason that has nothing to do with being clean.
+        "label": "release: the pre-release audit reads the requirement files instead of the install",
+        "file": ".github/workflows/release.yml",
+        "old": "          audit-tool/Scripts/pip-audit --path audit-env/Lib/site-packages \\",
+        "new": "          audit-tool/Scripts/pip-audit -r requirements.txt \\",
+        "test": "test_the_release_audits_its_pins_before_it_builds",
+    },
+    {
         # The gap the pairing exists for: `--select` on the command line REPLACES
         # the list in pyproject.toml, so a rule can stay configured, stay visible
         # to `ruff check` on a developer machine, and stop blocking anything.

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -1024,3 +1024,105 @@ def test_the_signing_certificate_expiry_is_a_condition_not_a_note():
     except SystemExit as exc:
         check("the refusal explains the renewal", "CODESIGN_SHA256" in str(exc),
               f"({str(exc)[:160]})")
+
+
+def _ci_text():
+    with open(os.path.join(ROOT, ".github", "workflows", "ci.yml"), encoding="utf-8") as f:
+        return f.read()
+
+
+def _ci_job_ids(text):
+    """Top-level job ids, which are the 2-space keys AFTER the `jobs:` line.
+
+    Parsed rather than hard-coded, and started at `jobs:` on purpose: `on:` has
+    2-space keys of its own (`push`, `schedule`), and counting those would make
+    the guard below demand that the notice watch a trigger.
+    """
+    lines = text.splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.rstrip() == "jobs:")
+    return [re.match(r"^  ([a-z][a-z0-9-]*):\s*$", ln).group(1)
+            for ln in lines[start + 1:] if re.match(r"^  [a-z][a-z0-9-]*:\s*$", ln)]
+
+
+def test_the_cron_notice_watches_every_job_in_the_workflow():
+    """A job left out of `needs` can fail every Monday for a year in silence.
+
+    The weekly run announces itself through `cron-issue`, and that job can only
+    see what it depends on. Adding a job to this workflow and forgetting this
+    list would leave the new job unwatched by exactly the mechanism that exists
+    because a cron is easy to miss - the same failure one level up.
+    """
+    text = _ci_text()
+    jobs = _ci_job_ids(text)
+    check("ci.yml still defines the weekly notice", "cron-issue" in jobs, f"({jobs})")
+
+    needs = re.search(r"^  cron-issue:.*?^    needs: \[(.*?)\]", text, re.S | re.M)
+    check("the notice declares what it watches", needs is not None)
+    if not needs:
+        return
+    watched = {name.strip() for name in needs.group(1).split(",")}
+    unwatched = sorted(set(jobs) - watched - {"cron-issue"})
+    check("the notice depends on every other job in the workflow", not unwatched,
+          f"({unwatched} - add them to `needs`, or they fail unannounced)")
+    ghosts = sorted(watched - set(jobs))
+    check("and on no job that no longer exists", not ghosts, f"({ghosts})")
+
+
+def test_the_audit_job_answers_to_a_pull_request_that_moves_the_pins():
+    """A tag can be cut days before the next cron, so the set must be checked when
+    it CHANGES, not only when the calendar turns.
+
+    Both halves are asserted: that the job runs on a pull request at all, and that
+    the pull-request path FAILS rather than opening an issue. An issue is the right
+    answer to "the world moved under a set nobody is touching"; it is the wrong
+    answer to a change with an author and an open review.
+    """
+    text = _ci_text()
+    audit = re.search(r"^  audit:.*?(?=^  [a-z][a-z0-9-]*:\s*$)", text, re.S | re.M)
+    check("ci.yml still has an audit job", audit is not None)
+    if not audit:
+        return
+    body = audit.group(0)
+    # 🔴 The JOB-LEVEL trigger, not the job text. The first version of this check
+    # looked for "pull_request" anywhere in the body and passed for a reason that
+    # had nothing to do with the claim - the STEPS mention it too, in their own
+    # conditions. Deleting the trigger left the guard green, and the mutation
+    # registry is what said so (2026-08-21, SURVIVED).
+    trigger = re.search(r"^    if: >-\n((?:      .*\n)+)", body, re.M)
+    check("the audit job declares its triggers", trigger is not None)
+    check("and one of them is a pull request",
+          trigger is not None and "pull_request" in trigger.group(1),
+          f"({trigger.group(1).strip() if trigger else None})")
+    check("a pull request that pins something vulnerable fails the run",
+          "Refuse a pull request that pins something vulnerable" in body)
+    check("and the pull-request path never opens an issue",
+          re.search(r"Open an issue if anything was found\n\s+if: github\.event_name != 'pull_request'",
+                    body) is not None)
+
+
+def test_the_release_audits_its_pins_before_it_builds():
+    """"CI was green on this commit" never included this question.
+
+    The audit job runs on the schedule and on a pull request that moves a
+    requirements file. A tag push is neither, so a release could ship a set that
+    an issue had already flagged, for as long as nobody read the issue.
+
+    Order matters and is asserted: auditing after the build would still publish
+    the artefact and only then complain.
+    """
+    with open(os.path.join(ROOT, ".github", "workflows", "release.yml"),
+              encoding="utf-8") as f:
+        text = f.read()
+    audit_at = text.find("Refuse to build a release whose pins carry a published advisory")
+    build_at = text.find("pyinstaller --noconfirm")
+    check("release.yml audits the pinned set", audit_at != -1)
+    check("release.yml still builds", build_at != -1)
+    if audit_at == -1 or build_at == -1:
+        return
+    check("and it audits BEFORE it builds", audit_at < build_at,
+          f"(audit at {audit_at}, build at {build_at})")
+    check("audited by path, not from the requirement files (7 of 9 packages)",
+          "--path audit-env" in text)
+    check("the auditor lives in its own environment, so the release set stays "
+          "exactly the hash-pinned bytes",
+          "audit-tool/Scripts/pip-audit" in text)

--- a/tools/audit_issue.py
+++ b/tools/audit_issue.py
@@ -14,12 +14,17 @@ Prints one word for the workflow to act on:
 
 Why an issue at all
 -------------------
-The weekly run deliberately does NOT open an issue when it goes red - that was
-decided on 2026-08-17, and the reasoning holds: a red cron usually means
-something drifted, and drift is read when somebody looks. A published advisory
-against a version we ship is a different animal. It has a clock on it, it does
-not resolve itself, and the person who needs to see it is not necessarily
-looking at Actions that week.
+A published advisory against a version we ship has a clock on it, it does not
+resolve itself, and the person who needs to see it is not necessarily looking at
+Actions that week.
+
+This used to be the NARROW exception to a rule - on 2026-08-17 the owner decided
+a red weekly run would be read by hand rather than announced, and advisories were
+carved out of that on 2026-08-19. The rule itself was reversed on 2026-08-21
+(`tools/cron_issue.py`), for the reason this file had already argued: a cron is
+easy to miss. The two stay separate tools with separate labels, because an
+advisory against a shipped version and a runner that could not install a package
+are different problems and must not deduplicate against each other.
 
 Why the title carries the advisory ids
 --------------------------------------

--- a/tools/cron_issue.py
+++ b/tools/cron_issue.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Turn a red WEEKLY run into an issue - once per set of failing jobs.
+
+    gh issue list --label ci-cron --state open --json number,title > open.json
+    python tools/cron_issue.py --needs needs.json --existing open.json \\
+           --title-out title.txt --body-out body.md --run-url "$RUN_URL"
+
+Prints one word for the workflow to act on, exactly like ``audit_issue.py``:
+
+    none     nothing in the run failed (the caller asked anyway)
+    create   something failed, and no open issue already says so
+    skip     something failed, and an open issue already says exactly that
+
+Why this exists, and why it reverses a decision
+-----------------------------------------------
+On 2026-08-17 the owner decided a red cron would be read by hand
+(``gh run list --workflow CI --branch master``) rather than announced. That was
+reversed on 2026-08-21, by the owner, for one reason: **a cron is very easy to
+miss.** Nothing arrives when it goes red, the run is not attached to any pull
+request anybody is looking at, and a week later it is off the first page.
+
+The exception carved out for advisories (``audit_issue.py``) had already made
+the same argument for a narrower case. This generalises it, and the two stay
+separate on purpose: different labels, different titles, different bodies. An
+advisory against a shipped version and a runner that could not install a package
+are not the same problem and must not deduplicate against each other.
+
+Why the title carries the failing job names
+-------------------------------------------
+So one stuck job cannot open fifty-two issues a year, and a DIFFERENT failure
+next week is not swallowed by the open issue about the old one. Matching on
+nothing but the label would do the second; matching on the run id would do the
+first.
+
+What this deliberately does NOT do
+-----------------------------------
+It never closes anything. A green run afterwards means the same jobs passed
+once, which is not the same as "the cause is gone" - the apt mirror that hung
+three runs in a row on 2026-08-19 would have closed and reopened the issue twice
+by itself. Closing stays a human act, and the issue body says so.
+"""
+import argparse
+import json
+import sys
+
+# A cancelled run is not a failed one, and neither is a skipped job. Only these
+# two count: GitHub reports "failure" for a job that ran and failed, and
+# "cancelled" separately (a superseded run, or the 6-hour limit) - which says
+# nothing about the code and must never open an issue.
+FAILING = ("failure",)
+
+
+def failed_jobs(needs):
+    """Sorted ids of the jobs that ran and failed."""
+    out = []
+    for job_id, data in (needs or {}).items():
+        if str((data or {}).get("result", "")).strip() in FAILING:
+            out.append(str(job_id))
+    return sorted(out)
+
+
+def title_for(jobs):
+    return "Weekly CI run is red: %s" % ", ".join(jobs)
+
+
+def body_for(jobs, run_url="", commit=""):
+    lines = ["The scheduled run of the CI workflow failed. Nothing in a pull request",
+             "caused this - the schedule asks whether the world moved under versions",
+             "that did not.", ""]
+    lines.append("**Jobs that failed:** " + ", ".join("`%s`" % j for j in jobs))
+    if commit:
+        lines.append("**Commit:** `%s`" % commit)
+    if run_url:
+        lines.append("**Run:** %s" % run_url)
+    lines += [
+        "",
+        "### The first question is whether this is us",
+        "",
+        "A weekly run fails for two quite different reasons and they look alike in",
+        "the summary. Read the log before filing this as a defect:",
+        "",
+        "* **The world moved.** An unpinned development dependency released a new",
+        "  version, the runner image changed, or the interpreter patch moved. That is",
+        "  what this schedule exists to catch, and the fix is in this repository.",
+        "* **The runner had a bad day.** A package mirror that stops answering looks",
+        "  exactly like a hang in our own step - on 2026-08-19 that burned a job's",
+        "  whole budget three runs in a row and nothing in the repository had changed.",
+        "",
+        "### This issue does not close itself",
+        "",
+        "A later green run means these jobs passed once, not that the cause is gone.",
+        "Close it when you know which of the two it was.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--needs", required=True,
+                        help="`toJSON(needs)` from the workflow, written to a file")
+    parser.add_argument("--existing", help="`gh issue list --json number,title` output")
+    parser.add_argument("--title-out", help="write the issue title here")
+    parser.add_argument("--body-out", help="write the issue body here")
+    parser.add_argument("--run-url", default="", help="link back to the workflow run")
+    parser.add_argument("--commit", default="", help="the commit the run was on")
+    args = parser.parse_args(argv)
+
+    try:
+        with open(args.needs, encoding="utf-8") as handle:
+            needs = json.load(handle)
+    except (OSError, ValueError) as exc:
+        # The same rule as the semgrep gate and the audit gate: a report that
+        # cannot be read is not a clean report. Fail loudly rather than "none".
+        print("cron_issue: cannot read %s: %s" % (args.needs, exc), file=sys.stderr)
+        return 2
+
+    jobs = failed_jobs(needs)
+    if not jobs:
+        print("none")
+        return 0
+
+    title = title_for(jobs)
+    existing = []
+    if args.existing:
+        try:
+            with open(args.existing, encoding="utf-8") as handle:
+                existing = json.load(handle) or []
+        except (OSError, ValueError) as exc:
+            print("cron_issue: cannot read %s: %s" % (args.existing, exc), file=sys.stderr)
+            return 2
+    if any(str(issue.get("title", "")).strip() == title for issue in existing):
+        print("skip")
+        return 0
+
+    if args.title_out:
+        with open(args.title_out, "w", encoding="utf-8") as handle:
+            handle.write(title)
+    if args.body_out:
+        with open(args.body_out, "w", encoding="utf-8") as handle:
+            handle.write(body_for(jobs, args.run_url, args.commit))
+    print("create")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

Three gaps around one question - "does the set we pin carry a published
advisory?" - plus the notice that a weekly run had never been able to send.

## The gaps

The audit job answered to the schedule and to nothing else. That is right for the
common case: the set is hash-pinned, so a change that does not touch a
requirements file cannot move the answer, and what does move it is a newly
published advisory, which is a clock event rather than a commit event.

It is wrong in two places. A pull request that edits a requirements file changes
what is installed, and waiting until Monday to find out means a merge and
possibly a release in between. And a tag push is neither a schedule nor a pull
request, so "CI was green on this commit" never included this question at all - a
release could ship a set that an issue had already flagged, for as long as nobody
read the issue.

The third gap is the notice itself. A red weekly run announced itself to nobody.

## What changed

**The audit runs on a pull request that edits a requirements file, and there it
fails instead of opening an issue.** An issue is the right answer to "the world
moved under a set nobody is touching this week". A change that pins something
vulnerable has an author, a diff and an open review, and can simply be refused. A
pull request that moves no requirements file cannot change the answer, so the job
starts, asks that with one `git diff`, and stops - about half a minute. If it
cannot determine the base it fails, because "could not tell, so assume nothing
changed" is the worst failure mode a gate has.

It runs rather than being skipped by a job-level condition, deliberately: a job
that reports "skipped" is an awkward thing for a required check to be, while one
that reports success after finding nothing to do is not.

**A release audits its own pins before it builds them**, in two throwaway
environments. `pip-audit` is pinned by version only, and the environment the
executable is frozen from must contain exactly the hash-pinned bytes and nothing
else - that is what `--require-hashes` is for. Audited by path rather than from
the requirement files, for the reason measured on 2026-08-11: file mode covers 7
of the 9 packages and silently skips `packaging` and `setuptools`.

**A red weekly run opens an issue.** This reverses the decision of 2026-08-17, at
the maintainer's request, for one reason: a cron is very easy to miss. Nothing
arrives when it goes red, the run hangs off no pull request anybody is looking at,
and a week later it is off the first page. Deduplicated by the SET OF JOBS that
failed, so one stuck job cannot open fifty-two issues a year and a different
failure next week is not swallowed by the open issue about the old one. A
cancelled run is explicitly not a failure - superseded, or out of time, and an
issue for it is the noise that teaches people to close these unread. It never
closes anything either: a later green run means those jobs passed once, not that
the cause is gone.

## Two things worth reading before the diff

**The audit job had never run. Not once.** It entered the workflow on 2026-08-19,
the last scheduled run was 2026-08-17, and the workflow had never been dispatched
by hand. Forty lines whose only proof was that they had been written carefully,
about to have two more gates built on top of them. Dispatched first: it ran green
against the pinned set and found nothing. The proof came before the extension, not
after it.

**One of the new guards was an assertion that could not fail, and the mutation
registry is what said so.** The check that the audit job answers to a pull request
looked for the trigger anywhere in the job body - and the steps mention it in
their own conditions, so deleting the trigger left the guard green. It reads the
job-level condition alone now.

## Verification

* Guards for everything touched: 95 tests, all passing, plus the new tool's own 7.
* `ruff` clean over the new and changed files.
* Three new registry entries, each run on its own and each `caught`. The one that
  came back `SURVIVED` is the assertion above, now fixed and caught.
* Both documentation guards fired during the work and were obeyed rather than
  worked around: the README job table refused a workflow job it did not document,
  and the repository-conventions guard refused a workflow that runs a script git
  does not carry.

The full suite, the real-Tk render, semgrep and the executable build are left to
this pull request, which is where the platforms are.
