### PR TITLE
Let the weekly notice be fired by hand, so it can ever be proven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,8 +688,23 @@ jobs:
   cron-issue:
     name: open an issue when the weekly run is red
     needs: [public-text, lint, types, semgrep, audit, mutations, tests, build]
+    # 🔴 `workflow_dispatch` is here so this path can be PROVEN. Until it was
+    # added, the only way to find out whether `gh issue create` works with these
+    # permissions was a red Monday - which is to say, the notice that exists
+    # because a cron is easy to miss was itself unexercised, and would have been
+    # discovered broken at exactly the moment it was needed.
+    #
+    # A hand-fired run can sit on any branch, so `tools/cron_issue.py` puts the
+    # ref in the title whenever it is not the default one. Without that, an issue
+    # from a test run would carry the same title a genuine Monday failure of the
+    # same job produces, and the real one would come back as `skip` - swallowed,
+    # silently, by the test issue.
+    #
+    # `pull_request` is deliberately absent and must stay absent: a notice that
+    # fired there would open an issue per pull request.
     if: >-
-      always() && github.event_name == 'schedule'
+      always()
+      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
       && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -714,12 +729,13 @@ jobs:
           NEEDS: ${{ toJSON(needs) }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEAD_SHA: ${{ github.sha }}
+          HEAD_REF: ${{ github.ref }}
         run: |
           printf '%s' "$NEEDS" > needs.json
           gh issue list --label ci-cron --state open --json number,title > open.json
           action=$(python tools/cron_issue.py --needs needs.json --existing open.json \
                      --title-out issue-title.txt --body-out issue-body.md \
-                     --run-url "$RUN_URL" --commit "$HEAD_SHA")
+                     --run-url "$RUN_URL" --commit "$HEAD_SHA" --ref "$HEAD_REF")
           echo "verdict: $action"
           case "$action" in
             create)

--- a/README.md
+++ b/README.md
@@ -1191,7 +1191,7 @@ Every job in that workflow, and what a red one means:
 | `audit` | **pip-audit** against the pinned set. Weekly, to ask whether the world moved under versions that did not, and on a pull request that edits a requirements file, to ask whether the set moved. The weekly run opens an issue, and a pull request that pins something vulnerable simply fails |
 | `tests` | the suite, the GUI smoke, the real-Tk render check and the CLI assertions, on Linux and Windows |
 | `build` | the Windows executable, smoke-tested, with the driver check and the licence registry scan |
-| `cron-issue` | opens an issue when the weekly run goes red, deduplicated by which jobs failed. A cron is easy to miss and nothing else announces one. Never runs on a pull request, and never closes an issue by itself |
+| `cron-issue` | opens an issue when the weekly run goes red, deduplicated by which jobs failed. A cron is easy to miss and nothing else announces one. It also answers to a hand-fired run, which is the only way to exercise it without waiting for a red Monday. Never runs on a pull request, and never closes an issue by itself |
 <!-- ci-jobs:end -->
 
 **Three static checks run beside the tests**, on Linux only, because they read the source rather

--- a/README.pl.md
+++ b/README.pl.md
@@ -1038,7 +1038,7 @@ Wszystkie joby tego workflow i co znaczy czerwony:
 | `audit` | **pip-audit** na przypiętym zestawie. Co tydzień - czy świat ruszył się pod wersjami, które stoją - oraz na PR-ze zmieniającym plik wymagań - czy ruszył się zestaw. Cotygodniowy przebieg zakłada issue, a PR przypinający coś podatnego po prostu się wywraca |
 | `tests` | suite, smoke GUI, render na prawdziwym Tk i asercje CLI, na Linuksie i Windowsie |
 | `build` | plik .exe dla Windowsa, ze smoke'iem, sprawdzeniem sterownika i skanem rejestru licencji |
-| `cron-issue` | zakłada issue, gdy cotygodniowy przebieg zrobi się czerwony, z deduplikacją po tym, które joby padły. Crona bardzo łatwo przegapić, a nic innego go nie zgłasza. Nie chodzi na PR-ach i nigdy sam nie zamyka issue |
+| `cron-issue` | zakłada issue, gdy cotygodniowy przebieg zrobi się czerwony, z deduplikacją po tym, które joby padły. Crona bardzo łatwo przegapić, a nic innego go nie zgłasza. Odpowiada też na przebieg odpalony ręcznie, bo tylko tak da się go sprawdzić bez czekania na czerwony poniedziałek. Nie chodzi na PR-ach i nigdy sam nie zamyka issue |
 <!-- ci-jobs:end -->
 
 **Obok testów chodzą trzy analizy statyczne**, wyłącznie na Linuksie, bo czytają kod, a nie go

--- a/tests/test_cron_issue.py
+++ b/tests/test_cron_issue.py
@@ -116,3 +116,54 @@ def test_an_unreadable_report_is_not_a_green_one(tmp_path, capsys):
     check("it exits 2, not 0", code == 2, f"(exit {code})")
     check("and says nothing that could be mistaken for a verdict",
           capsys.readouterr().out.strip() == "")
+
+
+def test_a_hand_fired_run_on_another_branch_says_so_in_the_title(tmp_path, capsys):
+    """🔴 The reason the ref is in the title at all, and it is not cosmetic.
+
+    The notice can be fired by hand, which is the only way to exercise this path
+    without waiting for a red Monday. A hand-fired run can sit on any branch - so
+    without the ref, an issue from a test run where `build` was deliberately red
+    would carry exactly the title a genuine Monday failure of `build` produces.
+    """
+    path = _write(tmp_path, "n.json", _needs(build="failure"))
+    cron_issue.main(["--needs", path, "--ref", "refs/heads/some-experiment",
+                     "--title-out", str(tmp_path / "t.txt"),
+                     "--body-out", str(tmp_path / "b.md")])
+    capsys.readouterr()
+    title = (tmp_path / "t.txt").read_text(encoding="utf-8")
+    check("the title carries the branch", "some-experiment" in title, f"({title})")
+    body = (tmp_path / "b.md").read_text(encoding="utf-8")
+    check("and the body says it was not the schedule", "fired by hand" in body)
+
+
+def test_the_weekly_title_is_unchanged_on_the_default_branch(tmp_path, capsys):
+    """The other half: the ref must NOT leak into the title of a genuine run.
+
+    Otherwise every weekly issue would carry a suffix, the dedup key would still
+    work, and the titles would just be noisier for no reason.
+    """
+    path = _write(tmp_path, "n.json", _needs(build="failure"))
+    cron_issue.main(["--needs", path, "--ref", "refs/heads/master",
+                     "--title-out", str(tmp_path / "t.txt")])
+    capsys.readouterr()
+    title = (tmp_path / "t.txt").read_text(encoding="utf-8")
+    check("a run on the default branch keeps the plain title",
+          title == "Weekly CI run is red: build", f"({title})")
+
+
+def test_a_test_issue_cannot_swallow_a_genuine_weekly_one(tmp_path, capsys):
+    """The failure the two tests above exist to prevent, asserted end to end.
+
+    An open issue from a hand-fired run must NOT make a real Monday failure of the
+    same job report `skip` - that would lose the real one in silence, which is
+    worse than the gap this notice closes.
+    """
+    open_issues = _write(tmp_path, "open.json",
+                         [{"number": 9,
+                           "title": "Weekly CI run is red: build (refs/heads/some-experiment)"}])
+    path = _write(tmp_path, "n.json", _needs(build="failure"))
+    cron_issue.main(["--needs", path, "--existing", open_issues,
+                     "--ref", "refs/heads/master"])
+    check("the genuine failure still asks for its own issue",
+          capsys.readouterr().out.strip() == "create")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -267,6 +267,16 @@ MUTATIONS = [
         "test": "test_the_selected_rules_only_ever_grow",
     },
     {
+        # The notice exists because a cron is easy to miss. Pointed at pull
+        # requests it becomes an issue factory instead - one per pull request -
+        # and the fastest way to teach everyone that these issues are noise.
+        "label": "cron notice: the weekly notice starts firing on pull requests",
+        "file": ".github/workflows/ci.yml",
+        "old": "      && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')",
+        "new": "      && (github.event_name == 'schedule' || github.event_name == 'pull_request')",
+        "test": "test_the_cron_notice_watches_every_job_in_the_workflow",
+    },
+    {
         # A job outside `needs` fails every Monday in silence - the same defect
         # the notice itself exists to cure, one level up.
         "label": "cron notice: a job drops out of what the weekly notice watches",

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -1067,6 +1067,20 @@ def test_the_cron_notice_watches_every_job_in_the_workflow():
     ghosts = sorted(watched - set(jobs))
     check("and on no job that no longer exists", not ghosts, f"({ghosts})")
 
+    # 🔴 The invariant that keeps this from becoming an issue factory. The notice
+    # answers to the schedule and to a hand-fired run - the second so the path can
+    # be exercised at all - and to nothing else. On a pull request it would open
+    # an issue per pull request.
+    trigger = re.search(r"^  cron-issue:.*?^    if: >-\n((?:      .*\n)+)", text, re.S | re.M)
+    check("the notice declares its triggers", trigger is not None)
+    if not trigger:
+        return
+    events = trigger.group(1)
+    check("the notice never fires on a pull request",
+          "pull_request" not in events, f"({events.strip()})")
+    check("and it can be fired by hand, or nothing could ever prove it works",
+          "workflow_dispatch" in events, f"({events.strip()})")
+
 
 def test_the_audit_job_answers_to_a_pull_request_that_moves_the_pins():
     """A tag can be cut days before the next cron, so the set must be checked when

--- a/tools/cron_issue.py
+++ b/tools/cron_issue.py
@@ -59,11 +59,30 @@ def failed_jobs(needs):
     return sorted(out)
 
 
-def title_for(jobs):
-    return "Weekly CI run is red: %s" % ", ".join(jobs)
+# The branch the weekly run is about. Anything else is somebody firing the
+# workflow by hand, and its issue must not be mistaken for the real thing.
+DEFAULT_REF = "refs/heads/master"
 
 
-def body_for(jobs, run_url="", commit=""):
+def title_for(jobs, ref=""):
+    """The title, and it is the deduplication key - see the note below.
+
+    🔴 The ref is in the title for a reason that is not cosmetic. The notice can
+    also be fired by hand (`workflow_dispatch`), which is the only way to prove
+    this path works without waiting for a red Monday - and a hand-fired run can
+    sit on ANY branch. Without the ref, an issue opened from a test run on a
+    branch where `build` was deliberately red would carry exactly the title a
+    genuine Monday failure of `build` produces. The real one would then come back
+    as `skip` and be swallowed by the test issue, silently, which is worse than
+    the gap the notice exists to close.
+    """
+    base = "Weekly CI run is red: %s" % ", ".join(jobs)
+    if ref and ref != DEFAULT_REF:
+        return "%s (%s)" % (base, ref)
+    return base
+
+
+def body_for(jobs, run_url="", commit="", ref=""):
     lines = ["The scheduled run of the CI workflow failed. Nothing in a pull request",
              "caused this - the schedule asks whether the world moved under versions",
              "that did not.", ""]
@@ -72,6 +91,10 @@ def body_for(jobs, run_url="", commit=""):
         lines.append("**Commit:** `%s`" % commit)
     if run_url:
         lines.append("**Run:** %s" % run_url)
+    if ref and ref != DEFAULT_REF:
+        lines += ["", "> This run was fired by hand on `%s`, not by the schedule. "
+                      "It is here so the notice itself can be exercised without waiting "
+                      "for a red Monday." % ref]
     lines += [
         "",
         "### The first question is whether this is us",
@@ -103,6 +126,9 @@ def main(argv=None):
     parser.add_argument("--body-out", help="write the issue body here")
     parser.add_argument("--run-url", default="", help="link back to the workflow run")
     parser.add_argument("--commit", default="", help="the commit the run was on")
+    parser.add_argument("--ref", default="",
+                        help="the ref the run was on: kept out of the title on the "
+                             "default branch, and put IN it otherwise (see title_for)")
     args = parser.parse_args(argv)
 
     try:
@@ -119,7 +145,7 @@ def main(argv=None):
         print("none")
         return 0
 
-    title = title_for(jobs)
+    title = title_for(jobs, args.ref)
     existing = []
     if args.existing:
         try:
@@ -137,7 +163,7 @@ def main(argv=None):
             handle.write(title)
     if args.body_out:
         with open(args.body_out, "w", encoding="utf-8") as handle:
-            handle.write(body_for(jobs, args.run_url, args.commit))
+            handle.write(body_for(jobs, args.run_url, args.commit, args.ref))
     print("create")
     return 0
 


### PR DESCRIPTION
The weekly red-run notice could only be exercised by a red Monday. It answers to
`workflow_dispatch` now, which is the only way to learn whether `gh issue create`
works with these permissions before the day it matters.

That change on its own would have introduced the failure it prevents. A hand-fired
run sits on whatever branch it was fired from, so an issue from a test run where
`build` was deliberately red would have carried exactly the title a genuine Monday
failure of `build` produces - and the real one would then come back as `skip`,
swallowed in silence by the test issue. `tools/cron_issue.py` now puts the ref in
the title whenever it is not the default branch, and the body says the run was
fired by hand.

`pull_request` stays out of that condition, and a guard now asserts it: a notice
firing there would open an issue per pull request.

### Verified

* The condition evaluated across every event and result: it fires on schedule and
  on a hand-fired run when something failed, and is silent on a pull request, on a
  push, on a cancelled run and on a green one.
* The step's own shell body executed end to end with the `gh` calls stubbed - the
  right verdict, the right title, the right body, and both `gh` invocations formed
  correctly.
* Both directions of the deduplication: an open test issue does not stop a genuine
  weekly failure from opening its own, and a repeat of the same test run skips.
* Three new cases in the tool's suite, one new registry entry, both `caught`.