### PR TITLE
Say where the secrets are, and when a release stops being supported

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,12 @@ Bean Network Tester has a single active line of development. Security fixes are 
 against the **latest release** and the `master` branch. Please confirm you can
 reproduce an issue on the latest version before reporting it.
 
+**Older releases receive nothing.** When a new version is published, the one before it
+stops being supported that day: no security updates, no backports, no patched builds. The
+supported version is whichever release is currently the latest, for as long as it is the
+latest. There is no long-term support line and none is planned, so the upgrade path for a
+security fix is always to move to the newest release.
+
 ## Reporting a vulnerability
 
 **Please do not open a public issue for security problems.**
@@ -30,6 +36,44 @@ Please include:
 You can expect an initial response within 14 days or fewer. Once a fix is ready it ships in
 the next release, and the advisory is published crediting the reporter (unless you
 prefer to remain anonymous).
+
+## Secrets and credentials
+
+The project uses as few of these as it can, and the release path deliberately keeps the
+most sensitive one away from any machine we do not control.
+
+**What exists.** One repository secret, read by one workflow: an OAuth token for the
+code-review assistant. Everything else in CI runs on the per-job token GitHub issues for
+the run, and nothing else is stored in the repository.
+
+**How access is scoped.** Every workflow declares a read-only permission set at the top
+(`contents: read`, or `read-all` in the one that only reads), so a job added to any of
+them later is read-only unless somebody says otherwise. A write scope is raised on the
+individual job that needs it and nowhere else: publishing a release, attesting a build,
+deploying the project site, uploading a scorecard result, and opening an issue when the
+dependency audit or the weekly run finds something. No workflow grants a write scope at
+the top of the file, where a later job would inherit it without anyone deciding.
+
+**The code-signing certificate never reaches CI.** It lives on a hardware token held by
+the maintainer, and the release is split into separate phases precisely so that the build
+happens on a runner while the signature happens on the maintainer's own machine. No
+workflow in this repository can sign anything, and none is given the chance to.
+
+**How the signing identity is checked.** The certificate's SHA-256 is pinned in the
+source, as `CODESIGN_SHA256` in `beantester/legal.py`. The signing script reads the
+certificate back out of the file it has just signed and refuses to go any further unless
+it hashes to that pin, so a second code-signing certificate on the same machine cannot
+sign a release by accident. The published release is checked against the same pin again
+after it goes out.
+
+**How it is rotated.** The current certificate expires on **2027-08-19**. The signing
+script prints the remaining life on every run, warns inside the expiry window, and
+refuses to sign at all once the date has passed, so the certificate cannot quietly lapse
+in the middle of a release. Renewal issues a new certificate with a new fingerprint, and
+the pin above is updated in the same change that first uses it.
+
+**Rotating the repository secret** is manual, and happens when its issuer rotates the
+token or when the workflow that reads it is removed.
 
 ## Scope: the nature of this tool
 


### PR DESCRIPTION
Two things a reader could not learn from the outside, both now in SECURITY.md.

**Secrets and credentials.** What exists: one repository secret, read by one
workflow, with everything else in CI running on the per-job token GitHub issues for
the run. How scopes are raised: on the individual job that needs one, never at the
top of a file where a job added later would inherit it. Where the code-signing
certificate lives: a hardware token that never reaches a runner, which is the
reason the release is split into separate phases in the first place. How the
signing identity is checked: a SHA-256 pinned in the source, read back out of the
file just signed, and checked again against the published release. How it rotates:
a known expiry date, a warning window before it, and a refusal to sign past it.

**End of support.** The file said which release receives security fixes. It did not
say that older ones receive nothing, which is the half a user actually needs when
deciding whether to upgrade. It says both now.

### Two claims in the first draft were wrong

Parsing all eight workflow files is what caught them. "Every workflow declares
`permissions: contents: read`" is false for one, which declares `read-all`; and the
list of jobs that raise a write scope was short by three, because attestation, the
site deployment and the scorecard upload raise one too. Both corrected against the
parse rather than against memory.

A security policy that overstates its own posture is worse than not having one: a
reader has no way to tell which sentences were checked and which merely sound right.

### Verified

* The repository conventions, README, release and licence-surface guards: 67 tests,
  all passing.
* Every factual claim checked at its source - the workflow permission blocks, the
  secret and the workflow that reads it, the pinned certificate hash in the package,
  and the expiry the signing script enforces.