### PR TITLE
Move the pre-release audit into a read-only job of its own

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,68 @@ permissions:
   contents: read
 
 jobs:
+  # 🔴 ITS OWN JOB, and the reason is a premise this repository wrote down and then
+  # broke. `requirements-scan.txt` is pinned by version and NOT by hash on purpose
+  # (the reasoning is in that file), and one leg of that reasoning is: the scanners
+  # "cannot put a byte into a release", because the build and release workflows
+  # install only from the two hash-checked files. Auditing inside the release job
+  # made that sentence false - it put an unpinned install into the job that holds
+  # `contents: write` and the attestation permissions - and OpenSSF Scorecard said
+  # so (alert 18, PinnedDependenciesID, 2026-08-22).
+  #
+  # Restoring the premise is cheaper than pinning the auditor's 28-package closure
+  # and re-pinning it on every bump, which is exactly the maintenance cost the
+  # original decision refused. So the auditor runs here, in a job whose token can
+  # only read, and the release job below waits on it.
+  audit:
+    name: Refuse to release pins that carry a published advisory
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.14"
+      # 🔴 "CI was green on this commit" does NOT include this question, and that
+      # was the gap. The `audit` job in ci.yml runs on the schedule and on a pull
+      # request that moves a requirements file - neither of which is a tag push.
+      # So a release could ship a set that Monday's issue had already flagged, for
+      # as long as nobody read the issue.
+      #
+      # The audited set goes into a throwaway environment and is read BY PATH, for
+      # the reason measured on 2026-08-11: auditing the requirement files instead
+      # covers 7 of the 9 packages and silently skips `packaging` and `setuptools`.
+      - name: Audit the pinned set
+        shell: bash
+        run: |
+          python -m venv audit-env
+          audit-env/Scripts/python -m pip install --quiet \
+            --require-hashes -r requirements.txt -r requirements-build.txt
+          pip install --quiet -r requirements-scan.txt
+          set +e
+          pip-audit --path audit-env/Lib/site-packages -f json -o release-audit.json
+          echo "pip-audit exit: $?"
+          set -e
+          test -s release-audit.json || { echo "no report was written"; exit 1; }
+          # The same reader the weekly job and the pull-request path use, so the
+          # three cannot disagree about what counts as a finding.
+          verdict="$(python tools/audit_issue.py --audit release-audit.json)"
+          echo "verdict: $verdict"
+          if [ "$verdict" != "none" ]; then
+            echo "::error::A published advisory names a version this tag would ship."
+            echo "::error::Raise the pin and tag again. Releasing over this would put"
+            echo "::error::a known-vulnerable dependency inside a signed binary."
+            exit 1
+          fi
+          echo "nothing published against the set this tag ships."
+
   release:
     name: Build and publish the Windows executable
+    # Nothing is built until the audit above has passed. `needs` is what makes the
+    # gate a gate: a failed dependency skips this job rather than letting it start.
+    needs: audit
     runs-on: windows-latest
     timeout-minutes: 30
     permissions:
@@ -85,48 +145,6 @@ jobs:
         with:
           python-version: "3.14"
           cache: pip
-
-      # 🔴 "CI was green on this commit" does NOT include this question, and that
-      # was the gap. The `audit` job in ci.yml runs on the schedule and on a pull
-      # request that moves a requirements file - neither of which is a tag push.
-      # So a release could ship a set that Monday's issue had already flagged,
-      # for as long as nobody read the issue.
-      #
-      # BOTH venvs are deliberate. `pip-audit` is pinned by version only, and the
-      # environment this job builds the executable from must contain exactly the
-      # hash-pinned bytes and nothing else - that is what `--require-hashes` is
-      # FOR. So the auditor lives in one throwaway environment, the audited set
-      # in another, and the job's own Python is not touched until the step below.
-      #
-      # Audited BY PATH for the reason measured on 2026-08-11: auditing the
-      # requirement files instead covers 7 of the 9 packages and silently skips
-      # `packaging` and `setuptools`.
-      - name: Refuse to build a release whose pins carry a published advisory
-        shell: bash
-        run: |
-          python -m venv audit-env
-          audit-env/Scripts/python -m pip install --quiet \
-            --require-hashes -r requirements.txt -r requirements-build.txt
-          python -m venv audit-tool
-          audit-tool/Scripts/python -m pip install --quiet -r requirements-scan.txt
-          set +e
-          audit-tool/Scripts/pip-audit --path audit-env/Lib/site-packages \
-            -f json -o release-audit.json
-          echo "pip-audit exit: $?"
-          set -e
-          test -s release-audit.json || { echo "no report was written"; exit 1; }
-          # The same reader the weekly job and the pull-request path use, so the
-          # three cannot disagree about what counts as a finding.
-          verdict="$(python tools/audit_issue.py --audit release-audit.json)"
-          echo "verdict: $verdict"
-          if [ "$verdict" != "none" ]; then
-            echo "::error::A published advisory names a version this tag would ship."
-            echo "::error::Raise the pin and tag again. Releasing over this would put"
-            echo "::error::a known-vulnerable dependency inside a signed binary."
-            exit 1
-          fi
-          echo "nothing published against the set this tag ships."
-          rm -rf audit-env audit-tool
 
       - name: Install dependencies
         run: |

--- a/requirements-scan.txt
+++ b/requirements-scan.txt
@@ -8,9 +8,17 @@
 #     with its own release cadence, and Dependabot has open bugs on rewriting
 #     `--hash` blocks. That is a standing maintenance cost on every bump;
 #   * what it would buy is smaller than it looks. Both run in a job whose token is
-#     `contents: read`, both produce a report, and neither can put a byte into a
-#     release: requirements.txt and requirements-build.txt are hash-checked, and
-#     those are the only two files the build and release workflows install from;
+#     `contents: read`, both produce a verdict rather than an artefact, and neither
+#     can put a byte into a release: the job that builds and publishes installs
+#     ONLY from requirements.txt and requirements-build.txt, which are hash-checked.
+#     🔴 That sentence stopped being true for two days and it matters that it did.
+#     On 2026-08-21 the pre-release audit was added as a STEP of the release job,
+#     which put an unpinned install inside the job holding `contents: write` and
+#     the attestation permissions. Scorecard raised it (alert 18,
+#     PinnedDependenciesID, 2026-08-22) and was right to. The audit is its own
+#     `contents: read` job now, and `release` waits on it - so the premise above is
+#     a property of the workflow again rather than a claim about it. A guard in
+#     tests/test_version_and_release.py asserts the auditor's token can only read;
 #   * semgrep in particular cannot be frozen in the sense that matters anyway. The
 #     pin fixes the ENGINE, and `--config p/default` fetches the RULES from the
 #     registry at scan time.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -300,8 +300,8 @@ MUTATIONS = [
         # clean for a reason that has nothing to do with being clean.
         "label": "release: the pre-release audit reads the requirement files instead of the install",
         "file": ".github/workflows/release.yml",
-        "old": "          audit-tool/Scripts/pip-audit --path audit-env/Lib/site-packages \\",
-        "new": "          audit-tool/Scripts/pip-audit -r requirements.txt \\",
+        "old": "          pip-audit --path audit-env/Lib/site-packages -f json -o release-audit.json",
+        "new": "          pip-audit -r requirements.txt -f json -o release-audit.json",
         "test": "test_the_release_audits_its_pins_before_it_builds",
     },
     {

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -1133,27 +1133,33 @@ def test_the_release_audits_its_pins_before_it_builds():
     permissions - and Scorecard said so (alert 18, 2026-08-22). Splitting the job
     restored the premise; this check keeps it restored.
     """
-    import yaml
+    # Read as TEXT, not through a YAML parser. `yaml` is not in the pinned test
+    # environment, and the first version of this guard imported it - green here,
+    # `ModuleNotFoundError` on both runners (2026-08-22). Every other workflow
+    # guard in this file reads the text for the same reason.
     path = os.path.join(ROOT, ".github", "workflows", "release.yml")
     with open(path, encoding="utf-8") as f:
         text = f.read()
-    workflow = yaml.safe_load(text)
-    jobs = workflow.get("jobs") or {}
 
-    check("release.yml has an audit job", "audit" in jobs, f"({sorted(jobs)})")
-    check("release.yml still has a release job", "release" in jobs, f"({sorted(jobs)})")
-    if "audit" not in jobs or "release" not in jobs:
+    def job_block(name):
+        """The lines of one top-level job, up to the next 2-space key."""
+        match = re.search(r"^  %s:\n(.*?)(?=^  [a-z][a-z0-9-]*:\s*$|\Z)" % re.escape(name),
+                          text, re.S | re.M)
+        return match.group(1) if match else None
+
+    audit, release = job_block("audit"), job_block("release")
+    check("release.yml has an audit job", audit is not None)
+    check("release.yml still has a release job", release is not None)
+    if audit is None or release is None:
         return
 
-    needs = jobs["release"].get("needs")
-    needs = [needs] if isinstance(needs, str) else (needs or [])
-    check("nothing is built until the audit has passed", "audit" in needs,
-          f"(release needs {needs})")
+    check("nothing is built until the audit has passed",
+          re.search(r"^    needs: audit\s*$", release, re.M) is not None,
+          "(the release job does not declare `needs: audit`)")
 
-    permissions = jobs["audit"].get("permissions") or {}
-    writes = sorted(k for k, v in permissions.items() if v == "write")
+    writes = re.findall(r"^\s+([a-z-]+): write\s*$", audit, re.M)
     check("the auditor's token can only read, so an unpinned tool cannot reach "
-          "a release artefact", not writes, f"({writes})")
+          "a release artefact", not writes, f"({sorted(set(writes))})")
 
     check("audited by path, not from the requirement files (7 of 9 packages)",
           "--path audit-env" in text)

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -1121,22 +1121,41 @@ def test_the_release_audits_its_pins_before_it_builds():
     requirements file. A tag push is neither, so a release could ship a set that
     an issue had already flagged, for as long as nobody read the issue.
 
-    Order matters and is asserted: auditing after the build would still publish
-    the artefact and only then complain.
+    Order is expressed as a dependency rather than as text order, which is
+    stronger: `needs` skips the build when the audit fails, while a step further
+    down the same job merely happens later.
+
+    🔴 The auditor's job must be READ-ONLY, and that is the half worth guarding.
+    `requirements-scan.txt` is pinned by version and not by hash on purpose, and
+    one leg of that decision is that the scanners "cannot put a byte into a
+    release". Auditing inside the release job made that sentence false - it put
+    an unpinned install into the job holding `contents: write` and the attestation
+    permissions - and Scorecard said so (alert 18, 2026-08-22). Splitting the job
+    restored the premise; this check keeps it restored.
     """
-    with open(os.path.join(ROOT, ".github", "workflows", "release.yml"),
-              encoding="utf-8") as f:
+    import yaml
+    path = os.path.join(ROOT, ".github", "workflows", "release.yml")
+    with open(path, encoding="utf-8") as f:
         text = f.read()
-    audit_at = text.find("Refuse to build a release whose pins carry a published advisory")
-    build_at = text.find("pyinstaller --noconfirm")
-    check("release.yml audits the pinned set", audit_at != -1)
-    check("release.yml still builds", build_at != -1)
-    if audit_at == -1 or build_at == -1:
+    workflow = yaml.safe_load(text)
+    jobs = workflow.get("jobs") or {}
+
+    check("release.yml has an audit job", "audit" in jobs, f"({sorted(jobs)})")
+    check("release.yml still has a release job", "release" in jobs, f"({sorted(jobs)})")
+    if "audit" not in jobs or "release" not in jobs:
         return
-    check("and it audits BEFORE it builds", audit_at < build_at,
-          f"(audit at {audit_at}, build at {build_at})")
+
+    needs = jobs["release"].get("needs")
+    needs = [needs] if isinstance(needs, str) else (needs or [])
+    check("nothing is built until the audit has passed", "audit" in needs,
+          f"(release needs {needs})")
+
+    permissions = jobs["audit"].get("permissions") or {}
+    writes = sorted(k for k, v in permissions.items() if v == "write")
+    check("the auditor's token can only read, so an unpinned tool cannot reach "
+          "a release artefact", not writes, f"({writes})")
+
     check("audited by path, not from the requirement files (7 of 9 packages)",
           "--path audit-env" in text)
-    check("the auditor lives in its own environment, so the release set stays "
-          "exactly the hash-pinned bytes",
-          "audit-tool/Scripts/pip-audit" in text)
+    check("the audited set is installed with its hashes checked",
+          "--require-hashes -r requirements.txt -r requirements-build.txt" in text)


### PR DESCRIPTION
`requirements-scan.txt` is pinned by version and not by hash on purpose. One leg of
that written decision is that the scanners **cannot put a byte into a release**,
because the build and release workflows install only from the two hash-checked
files.

Adding the pre-release audit as a *step* of the release job made that sentence
false. It put an unpinned install inside the job that holds `contents: write` and
the attestation permissions, and OpenSSF Scorecard raised it (alert 18,
`PinnedDependenciesID`). Four alerts of that exact class had already been dismissed
as "won't fix" under reasoning that had just stopped applying to this one, so
dismissing this one the same way would have meant dismissing it with a reason that
no longer held.

### Two ways out, and why this one

Pinning the auditor means writing down a **28-package closure** and re-pinning it on
every bump - precisely the maintenance cost the original decision refused, and for a
tool that only ever produces a verdict.

Restoring the premise costs one job. The audit now runs with `contents: read`, and
the release job waits on it through `needs`, so a failed audit **skips** the build
rather than merely preceding it in the same script.

### The guard changed too

It asserted text order before, which is weaker than a dependency. It now asserts the
`needs` edge and, newly, that the auditor's job holds no write scope at all - the
half nobody was watching, and the half that made this regression possible.