### PR TITLE
Answer two scanner findings: dismiss the pinned-dependencies alert in place, and name the two urllib suppressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,16 @@ jobs:
           python -m venv audit-env
           audit-env/Scripts/python -m pip install --quiet \
             --require-hashes -r requirements.txt -r requirements-build.txt
+          # 🔴 The next line is OpenSSF Scorecard alert 19, dismissed as "won't fix"
+          # on 2026-08-24, and MOVING IT is what mints alert 20. For that check
+          # "pinned" means exactly one thing - the `--require-hashes` flag
+          # (`isUnpinnedPipInstall` finds it and stops looking) - so a job's
+          # permissions are invisible to it and no new address quiets it. Alerts 5, 7,
+          # 10 and 17 are the same install elsewhere and were dismissed the same way.
+          #
+          # Alert 18 WAS real and IS fixed: this install used to sit inside the job
+          # that holds `contents: write`. Why the file is pinned by version and not by
+          # bytes: requirements-scan.txt, which names this exact cost in writing.
           pip install --quiet -r requirements-scan.txt
           set +e
           pip-audit --path audit-env/Lib/site-packages -f json -o release-audit.json

--- a/tests/test_repo_conventions.py
+++ b/tests/test_repo_conventions.py
@@ -583,6 +583,62 @@ def test_every_action_a_workflow_uses_is_pinned_to_a_commit():
     check("every action is pinned to a full commit SHA", not unpinned, f"({unpinned})")
     check("every pin says which version it is", not uncommented, f"({uncommented})")
 
+
+# Every semgrep suppression in this repository, by path and by the rule it silences.
+# The list IS the guard below - see its docstring for why adding a line here has to
+# be an edit somebody makes on purpose.
+SEMGREP_SUPPRESSIONS = {
+    ("tools/downloads.py", "python.lang.security.audit.dynamic-urllib-use-detected"
+                           ".dynamic-urllib-use-detected"),
+    ("tools/pin_hashes.py", "python.lang.security.audit.dynamic-urllib-use-detected"
+                            ".dynamic-urllib-use-detected"),
+}
+
+
+def test_every_semgrep_suppression_is_named_and_inventoried():
+    """A suppression says the scanner is wrong, and saying that must cost something.
+
+    Semgrep takes the comment in two forms: bare, which silences EVERY rule on that
+    line for ever, and with a rule id, which silences exactly the one that was
+    audited. This repository had none until 2026-08-24 and now has two, both over a
+    URL whose scheme and host are literals and whose one dynamic part is escaped or
+    regex-checked before it gets there.
+
+    Two things are guarded here, and neither of them is the rule itself:
+
+    * the bare form never appears. A line that silences everything goes on silencing
+      everything after the code under it has been rewritten, and nothing says so;
+    * the set of suppressions is written down in this file. Adding one means editing
+      a test, which lands in a diff as a decision - instead of a comment that slid in
+      while somebody was quieting a report.
+
+    Removing one is the same edit and equally visible. What this cannot check is
+    whether the audit behind a suppression is still true: that is the job of the two
+    guards named in the comments above them.
+    """
+    import re
+    pattern = re.compile(r"#\s*nosemgrep(?::\s*(\S+))?")
+    files = repo_text_files((".py", ".yml", ".yaml"))
+    # A walk that yields nothing passes every check below and looks like it worked.
+    check("the scan found files to read", len(files) >= 40, f"({len(files)})")
+    found, unnamed = set(), []
+    for path in files:
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        with open(path, encoding="utf-8") as handle:
+            for number, line in enumerate(handle, 1):
+                match = pattern.search(line)
+                if not match:
+                    continue
+                if not match.group(1):
+                    unnamed.append(f"{rel}:{number}")
+                else:
+                    found.add((rel, match.group(1)))
+    check("no suppression silences every rule at once", not unnamed, f"({unnamed})")
+    check("the suppressions in the tree are the ones written down here",
+          found == SEMGREP_SUPPRESSIONS,
+          f"(unlisted or missing: {sorted(found ^ SEMGREP_SUPPRESSIONS)})")
+
+
 def test_the_optional_review_never_runs_by_itself():
     """The one job here that spends money, and the reason it is not automatic.
 

--- a/tools/downloads.py
+++ b/tools/downloads.py
@@ -38,6 +38,13 @@ def fetch_releases(repo):
         "Accept": "application/vnd.github+json",
         "User-Agent": "bnt-downloads",
     })
+    # The audit that rule asks for is DONE, and it is the `REPO.match` above: the
+    # scheme and the host are literals, and the one value that reaches the URL is an
+    # owner and a name or nothing. Guarded by
+    # test_the_downloads_tool_refuses_anything_that_is_not_owner_slash_name.
+    # Suppressed so the finding stops costing an analysis on every scan; the
+    # suppression itself is inventoried by test_repo_conventions.py.
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     with urllib.request.urlopen(req, timeout=30) as resp:
         return json.load(resp)
 

--- a/tools/pin_hashes.py
+++ b/tools/pin_hashes.py
@@ -63,6 +63,13 @@ def _url(name, version):
 
 def artefact_hashes(name, version, timeout=30):
     """Every sha256 on PyPI for that exact version, newest artefact last."""
+    # The audit that rule asks for is DONE, and proved rather than asserted: `_url`
+    # above fixes the scheme and the host and escapes both parts, and
+    # tests/test_pin_hashes_url.py walks the hostile shapes - `file:///c:/windows`
+    # among them - and checks that none of them moves the request. Suppressed here
+    # so the finding stops costing an analysis on every scan; the suppression itself
+    # is inventoried by test_repo_conventions.py, so a second one is a decision.
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     with urllib.request.urlopen(_url(name, version), timeout=timeout) as response:
         payload = json.load(response)
     digests = [f["digests"]["sha256"] for f in payload.get("urls", [])]


### PR DESCRIPTION
Two scanner findings, one answer each, and neither of them was a defect.

## Scorecard alert 19 (`release.yml`, the `audit` job)

Pinned-Dependencies knows exactly one definition of "pinned": the `--require-hashes`
flag. `isUnpinnedPipInstall` finds it and stops looking, so a job's permissions are
invisible to that check and the same install raises the same finding at every address
it is ever given.

That is how fixing alert 18 produced alert 19. **Alert 18 was real and stays fixed**:
the install used to sit inside the job holding `contents: write`, and it now runs in a
job whose token can only read. Alert 19 is the same command at its new address; alerts
5, 7, 10 and 17 are the same install elsewhere, dismissed the same way. Alert 19 is
dismissed as "won't fix" too.

So this PR adds the one thing that was missing: a comment where somebody would
otherwise "fix" it by moving the line again, which only mints a new alert number. Why
`requirements-scan.txt` is pinned by version and not by bytes is already written in
that file, and this points at it rather than repeating it.

Hash-pinning the auditor's closure (27 packages, measured) was put to the maintainer
and not chosen: it is exactly the standing maintenance cost the 2026-08-19 decision
refused.

## semgrep `dynamic-urllib-use-detected` (WARNING, two sites)

`tools/semgrep_gate.py` blocks ERROR, HIGH and CRITICAL, so this never blocked
anything. What it cost was an analysis on every scan, and that analysis has now been
done twice with the same answer both times.

The audit the rule asks for is finished and proved rather than asserted:

* `tools/pin_hashes.py` - the scheme and the host are literals and both dynamic parts
  are escaped, checked by `tests/test_pin_hashes_url.py` over the hostile shapes,
  `file:///c:/windows/win.ini` among them;
* `tools/downloads.py` - the one value that reaches the URL must match `owner/name`
  first, checked by
  `test_the_downloads_tool_refuses_anything_that_is_not_owner_slash_name`.

Both suppressions name the rule id. The bare form silences every rule on that line for
ever, including rules written after the code under it has been rewritten, so it is
refused by a guard rather than by good intentions.

These are the first suppressions in this repository, so the mechanism arrives with its
own inventory: `test_every_semgrep_suppression_is_named_and_inventoried` requires the
set in the tree to equal the set written in the test. A third one is then an edit
somebody makes on purpose, in a diff. `non-literal-import` in `beantester/legal.py` is
deliberately left unsuppressed - that decision stands as it is.

## Evidence

Measured with semgrep 1.173.0, `--config p/default --oss-only`:

* `tools/` before: 2 findings, both this rule. After: 0.
* whole tree, through `tools/semgrep_gate.py`: **0 blocking, 1 other, 0 scan errors** -
  the one "other" is the known `non-literal-import`.

Green locally: `tests/test_repo_conventions.py`, `tests/test_pin_hashes_url.py`,
`tests/test_version_and_release.py` (52 checks), plus `ruff` and `mypy` on the touched
files. **Not run locally, on purpose:** the full suite, which is what this pull request
is for, and `smoke_gui.py`, since no GUI file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
