### PR TITLE
Correct what actually mints a new Scorecard alert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,15 +59,22 @@ jobs:
           audit-env/Scripts/python -m pip install --quiet \
             --require-hashes -r requirements.txt -r requirements-build.txt
           # 🔴 The next line is OpenSSF Scorecard alert 19, dismissed as "won't fix"
-          # on 2026-08-24, and MOVING IT is what mints alert 20. For that check
-          # "pinned" means exactly one thing - the `--require-hashes` flag
-          # (`isUnpinnedPipInstall` finds it and stops looking) - so a job's
-          # permissions are invisible to it and no new address quiets it. Alerts 5, 7,
-          # 10 and 17 are the same install elsewhere and were dismissed the same way.
+          # on 2026-08-24. For that check "pinned" means exactly one thing - the
+          # `--require-hashes` flag (`isUnpinnedPipInstall` finds it and stops looking)
+          # - so a job's permissions are invisible to it and no new address quiets it.
+          # Alerts 5, 7, 10 and 17 are the same install elsewhere, dismissed the same
+          # way.
           #
-          # Alert 18 WAS real and IS fixed: this install used to sit inside the job
-          # that holds `contents: write`. Why the file is pinned by version and not by
-          # bytes: requirements-scan.txt, which names this exact cost in writing.
+          # 🔴 What survives what, measured on this alert rather than assumed: EDITING
+          # around this line is safe. The comment you are reading pushed the install ten
+          # lines down, Scorecard re-graded the branch, and alert 19 came back as the
+          # same dismissed alert with a new location - so the fingerprint is not the
+          # line number. MOVING the command into another job is what mints a new alert,
+          # and that is exactly how 18 became 19. Alert 18 WAS real and IS fixed: this
+          # install used to sit inside the job that holds `contents: write`.
+          #
+          # Why the file is pinned by version and not by bytes: requirements-scan.txt,
+          # which names this exact cost in writing.
           pip install --quiet -r requirements-scan.txt
           set +e
           pip-audit --path audit-env/Lib/site-packages -f json -o release-audit.json


### PR DESCRIPTION
A one-sentence correction to the comment #152 added, now that the alert has been
measured instead of predicted.

That comment said moving the line is what mints a new alert. What actually happened
after the merge: the comment pushed the install from line 61 to line 71, Scorecard
re-graded master, and **alert 19 came back as the same dismissed alert with a new
location**. The fingerprint is therefore not the line number.

So the warning is kept and made accurate:

* editing around the line is safe;
* moving the command into another job mints a new alert, and that is how 18 became
  19 - which is exactly the move somebody makes while trying to "fix" this one.

Comment only, inside the `run` block of the audit job. Green locally:
`tests/test_version_and_release.py` and `tests/test_repo_conventions.py`, the two that
parse this workflow (49 checks). Not run locally: the full suite, which is what this
pull request is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
