### PR TITLE
fix(gui): open windows and tooltips on the monitor the app is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Tooltips opened on the wrong monitor.** With the window moved to a second monitor,
+  hovering a "?" put the explanation on the main monitor instead of next to what you were
+  pointing at. The program asked Windows how big "the screen" is, and that answer is always
+  the main monitor, whichever one you happen to be using. Tooltips now open on the monitor
+  the window is on, including a monitor placed to the left of or above the main one. While
+  fixing it: a tooltip near the bottom of the screen no longer slides under the taskbar.
+
 - **The command for checking your download did not work.** Both READMEs told you to run
   `gh attestation verify <file> -R donislawdev/BeanNetworkTester`, and it answers `HTTP 404`.
   It looks for proof the file was built on a runner, and the file you download is signed on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   the window is on, including a monitor placed to the left of or above the main one. While
   fixing it: a tooltip near the bottom of the screen no longer slides under the taskbar.
 
+- **A window left on a second monitor came back on the main one.** The program remembers where
+  you left each window, then threw that away at the next start if the position was outside the
+  main monitor - which every position on a second monitor is. Windows now open where you left
+  them, and the check that saves you from a window restored onto a monitor you have unplugged
+  still does its job. Settings, Event log and About open on the monitor the program is on too.
+
 - **The command for checking your download did not work.** Both READMEs told you to run
   `gh attestation verify <file> -R donislawdev/BeanNetworkTester`, and it answers `HTTP 404`.
   It looks for proof the file was built on a runner, and the file you download is signed on

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ with different scaling does not blur the interface.
 
 Window size and position, the selected tab, language, collapsed sections, the log/tabs split and
 table sort order are remembered in `bean_network_tester_ui.json` (next to the profiles). The saved
-geometry is validated before use - if the monitor is gone, the window returns to the centre of the
-current screen.
+geometry is validated before use - a window left on a second monitor opens there again, and if that
+monitor is gone it returns to the centre of the current screen.
 
 - **Control** - all impairment settings, grouped into **collapsible sections** (the collapsed
   state is remembered). On a wide window the sections lay out **in two columns** (instead of one

--- a/README.pl.md
+++ b/README.pl.md
@@ -120,7 +120,7 @@ sterownika.
 
 Okno **dopasowuje się do ekranu i do skalowania systemu (DPI)**. Rozmiar startowy jest liczony z rozdzielczości (mieści się na 1366×768 i rośnie na Full HD / 2K / 4K), a wszystkie wymiary - szerokości kolumn, wysokość wierszy tabel, marginesy wykresu, zawijanie tekstu - skalują się razem z czcionką. Program deklaruje się jako **Per-Monitor-V2 DPI aware**, więc przeniesienie okna na drugi monitor o innym skalowaniu nie rozmywa interfejsu.
 
-Rozmiar i pozycja okna, wybrana zakładka, język, zwinięte sekcje, podział log/zakładki oraz sortowanie tabel są zapamiętywane w pliku `bean_network_tester_ui.json` (obok profili). Zapisana geometria jest przed użyciem sprawdzana - jeśli monitor zniknął, okno wraca na środek bieżącego ekranu.
+Rozmiar i pozycja okna, wybrana zakładka, język, zwinięte sekcje, podział log/zakładki oraz sortowanie tabel są zapamiętywane w pliku `bean_network_tester_ui.json` (obok profili). Zapisana geometria jest przed użyciem sprawdzana - okno zostawione na drugim monitorze otworzy się tam ponownie, a jeśli tego monitora już nie ma, wraca na środek bieżącego ekranu.
 
 - **Sterowanie** - wszystkie ustawienia zakłóceń, pogrupowane w **zwijane sekcje** (stan zwinięcia jest zapamiętywany). Na szerokim oknie sekcje układają się **w dwie kolumny** (zamiast jednej wąskiej i pustej prawej połowy), więc przewijania jest znacznie mniej. Cała zakładka jest przewijana - również **kółkiem myszy**.
 - **Statystyki** - trzy podzakładki, żeby nic nie było ucinane na małych ekranach:

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -32,7 +32,7 @@ from ..fields import NUMBER as F_NUMBER
 from ..fields import SEED as F_SEED
 from ..fields import FIELD_DEFS, SECTIONS, UI_ONLY_KEYS, off_value
 from ..filters import cli_key_for, i18n_key_for, i18n_keys, windivert_for
-from .. import crashlog
+from .. import crashlog, winenv
 from . import csv_export
 from ..i18n import (FALLBACK_LANGUAGE, T, available_languages, current_language,
                     field_name, set_language)
@@ -271,7 +271,7 @@ class App:
             screen_w, screen_h = 1366, 768
         maximum = max_window_size(screen_w, screen_h)
         saved = str(self.ui.get("geometry", "") or "")
-        if saved and geometry_fits(saved, screen_w, screen_h):
+        if saved and geometry_fits(saved, screen_w, screen_h, winenv.monitor_work_area):
             geometry = saved
         else:
             w, h, x, y = initial_geometry(screen_w, screen_h)

--- a/beantester/gui/scaling.py
+++ b/beantester/gui/scaling.py
@@ -148,6 +148,16 @@ def geometry_fits(geometry, screen_w, screen_h, bounds_at=None):
     straddling two monitors keeps being judged by the monitor its corner is on,
     which is the verdict it got before this argument existed - a fix here must not
     invent a new way to lose a window.
+
+    One consequence said out loud: the SIZE is measured against the work area too,
+    which is slightly stricter than the whole monitor. With the taskbar at the
+    bottom - where it is by default, and where it costs height only - nothing our
+    own UI can produce reaches that edge, because ``max_window_size`` already caps
+    a window below it. A taskbar down the SIDE of the screen makes the work area
+    narrower than the cap, and a window within about thirty pixels of it would be
+    re-centred at the next start instead of being restored. That is a remembered
+    size lost, not a window lost, and it buys the case that matters: a window on a
+    monitor LARGER than the primary one, which the old check rejected outright.
     """
     try:
         size, _, rest = str(geometry).partition("+")

--- a/beantester/gui/scaling.py
+++ b/beantester/gui/scaling.py
@@ -151,22 +151,35 @@ def geometry_fits(geometry, screen_w, screen_h):
 
 
 # -- pure geometry helpers used by the tooltip and the chart ------------------ #
-def tooltip_position(x, y, widget_h, tip_w, tip_h, screen_w, screen_h, margin=6):
-    """Where to put a tooltip bubble so it stays on screen.
+def tooltip_position(x, y, widget_h, tip_w, tip_h, bounds, margin=6):
+    """Where to put a tooltip bubble so it stays on the monitor it belongs to.
 
-    The old code always placed it below the widget, so hovering anything near the
-    bottom of the display pushed the bubble off the monitor.
+    ``bounds`` is the rectangle the bubble has to stay inside, ``(left, top,
+    right, bottom)`` in screen coordinates - normally the work area of the
+    monitor showing the widget (``winenv.monitor_work_area``).
+
+    It takes a RECTANGLE and not a width/height pair because a rectangle is the
+    only shape that can express a second monitor. ``(0, 0, screen_w, screen_h)``
+    is the primary monitor and nothing else, so clamping to it moved the bubble
+    back onto the primary monitor whenever the window was on another one - the
+    2026-08-26 report. ``left`` and ``top`` are NEGATIVE for a monitor placed
+    left of, or above, the primary one; nothing here may assume they are zero.
+
+    The other reason this function exists is older: the first version always put
+    the bubble below the widget, so hovering anything near the bottom edge pushed
+    it off the display.
     """
+    left, top, right, bottom = (int(edge) for edge in bounds)
     px = x + scaled(18)
     py = y + widget_h + margin
-    if py + tip_h > screen_h - margin:          # no room below -> flip above
+    if py + tip_h > bottom - margin:            # no room below -> flip above
         py = y - tip_h - margin
-    if py < margin:                             # nor above -> clamp
-        py = margin
-    if px + tip_w > screen_w - margin:
-        px = max(margin, screen_w - tip_w - margin)
-    if px < margin:
-        px = margin
+    if py < top + margin:                       # nor above -> clamp
+        py = top + margin
+    if px + tip_w > right - margin:
+        px = max(left + margin, right - tip_w - margin)
+    if px < left + margin:
+        px = left + margin
     return int(px), int(py)
 
 

--- a/beantester/gui/scaling.py
+++ b/beantester/gui/scaling.py
@@ -127,11 +127,27 @@ def max_window_size(screen_w, screen_h, want=(1280, 1000), scale=None):
     return (w, h)
 
 
-def geometry_fits(geometry, screen_w, screen_h):
-    """True when a saved ``WxH+X+Y`` string still fits on the current screen.
+def geometry_fits(geometry, screen_w, screen_h, bounds_at=None):
+    """True when a saved ``WxH+X+Y`` string still describes a reachable window.
 
     A geometry restored from ``ui.json`` must be re-validated: the user may have
-    unplugged the 4K monitor it was saved on.
+    unplugged the 4K monitor it was saved on, and a window put back where nobody
+    can reach it is worse than a window in the middle of the screen.
+
+    ``bounds_at(x, y)`` says which monitor that spot is on and hands back its work
+    area (``winenv.monitor_work_area``). Without it the check falls back to the
+    primary screen, which is the only display Tk itself can describe - and that
+    fallback is why a window MOVED TO A SECOND MONITOR came back on the first one
+    at the next start: ``x`` was simply larger than the primary monitor's width,
+    so a perfectly good geometry was thrown away as "off screen". The unplugged
+    case still works, and for the same reason it always did: the nearest monitor
+    is then the primary one, and the numbers below say no.
+
+    Asking about the window's own top-left CORNER is deliberate. The nearest
+    monitor rule makes the off-screen slack below work by itself, and a window
+    straddling two monitors keeps being judged by the monitor its corner is on,
+    which is the verdict it got before this argument existed - a fix here must not
+    invent a new way to lose a window.
     """
     try:
         size, _, rest = str(geometry).partition("+")
@@ -139,15 +155,36 @@ def geometry_fits(geometry, screen_w, screen_h):
         w, h = int(w_s), int(h_s)
     except (TypeError, ValueError):
         return False
-    if w < 320 or h < 320 or w > int(screen_w) or h > int(screen_h):
-        return False
     parts = rest.split("+")
     try:
+        # Tk writes a negative coordinate as "+-1882", so splitting on "+" leaves
+        # the sign on the number - a monitor left of the primary one survives the
+        # round trip through ui.json.
         x, y = (int(parts[0]), int(parts[1])) if len(parts) >= 2 else (0, 0)
     except ValueError:
         return False
+    left, top, right, bottom = 0, 0, int(screen_w), int(screen_h)
+    if bounds_at is not None:
+        area = bounds_at(x, y)
+        if area is not None:
+            left, top, right, bottom = (int(edge) for edge in area)
+    if w < 320 or h < 320 or w > right - left or h > bottom - top:
+        return False
     # allow a little off-screen slack, but the title bar must stay reachable
-    return -20 <= x <= int(screen_w) - 100 and 0 <= y <= int(screen_h) - 60
+    return left - 20 <= x <= right - 100 and top <= y <= bottom - 60
+
+
+def centred_in(bounds, width, height):
+    """Top-left corner for a ``width`` x ``height`` window centred in ``bounds``.
+
+    Slightly above centre, like ``initial_geometry`` - the same reason, it reads
+    better - and expressed as a rectangle so a window can be centred on the
+    monitor the application is actually on rather than on the primary one.
+    """
+    left, top, right, bottom = (int(edge) for edge in bounds)
+    x = left + max(0, ((right - left) - int(width)) // 2)
+    y = top + max(0, ((bottom - top) - int(height)) // 3)
+    return x, y
 
 
 # -- pure geometry helpers used by the tooltip and the chart ------------------ #

--- a/beantester/gui/tooltip.py
+++ b/beantester/gui/tooltip.py
@@ -16,6 +16,7 @@ from ..i18n import T
 from .scaling import scaled, tooltip_position
 from .theme import FONT, TIP_BG, TIP_FG
 from .. import crashlog
+from .. import winenv
 
 _BUBBLES: dict[str, tuple] = {}     # toplevel name -> (window, label)
 
@@ -91,6 +92,27 @@ def _grab_active(widget):
     return False
 
 
+def _bounds_for(widget, x_root, y_root):
+    """The rectangle the bubble must stay inside, for THIS widget's monitor.
+
+    The anchor is the widget's own corner rather than its window, and that is the
+    interesting half: a window straddling two monitors has no single monitor, but
+    the "?" the pointer is resting on does, and that is the one the bubble belongs
+    to. ``MonitorFromPoint`` answers exactly that question.
+
+    The fallback - the primary screen, as Tk reports it - is what this module did
+    for every window before, so off Windows and on any machine where the system
+    will not answer, the behaviour is unchanged rather than worse.
+    """
+    area = winenv.monitor_work_area(x_root, y_root)
+    if area is not None:
+        return area
+    with crashlog.quiet("gui.tooltip"):
+        return (0, 0, widget.winfo_screenwidth() or 1920,
+                widget.winfo_screenheight() or 1080)
+    return (0, 0, 1920, 1080)
+
+
 def _show_bubble(widget, text, x_root, y_root, height=0):
     if not text:
         return None
@@ -105,10 +127,8 @@ def _show_bubble(widget, text, x_root, y_root, height=0):
         window.update_idletasks()
         tip_w = window.winfo_reqwidth() or scaled(340)
         tip_h = window.winfo_reqheight() or scaled(60)
-        screen_w = widget.winfo_screenwidth() or 1920
-        screen_h = widget.winfo_screenheight() or 1080
         px, py = tooltip_position(x_root, y_root, height, tip_w, tip_h,
-                                  screen_w, screen_h)
+                                  _bounds_for(widget, x_root, y_root))
         window.wm_geometry(f"+{px}+{py}")
         window.deiconify()
         window.lift()

--- a/beantester/gui/tooltip.py
+++ b/beantester/gui/tooltip.py
@@ -15,8 +15,7 @@ import tkinter as tk
 from ..i18n import T
 from .scaling import scaled, tooltip_position
 from .theme import FONT, TIP_BG, TIP_FG
-from .. import crashlog
-from .. import winenv
+from .. import crashlog, winenv
 
 _BUBBLES: dict[str, tuple] = {}     # toplevel name -> (window, label)
 

--- a/beantester/gui/windows.py
+++ b/beantester/gui/windows.py
@@ -46,7 +46,8 @@ import tkinter as tk
 from tkinter import ttk
 
 from ..i18n import T
-from .scaling import geometry_fits, max_window_size, scaled
+from .scaling import centred_in, geometry_fits, max_window_size, scaled
+from .. import winenv
 from .theme import BG, apply_dark_titlebar, disable_maximize
 from .. import crashlog
 
@@ -164,12 +165,37 @@ class PanelWindow:
     def _state_key(self):
         return f"window.{self.ID}"
 
+    def _app_monitor(self, screen_w, screen_h):
+        """The work area of the monitor the MAIN window is on.
+
+        A window centred on the primary monitor while the application sits on the
+        second one opens where the user is not looking. That is the same
+        single-monitor assumption the tooltip bubble had, one window bigger:
+        ``winfo_screenwidth()`` is the primary monitor whatever the app is on.
+
+        The probe point is the MIDDLE of the main window, not its corner - this
+        asks "where is the application", and a window overhanging a monitor edge
+        should not send its panels to the neighbouring screen. (``geometry_fits``
+        asks about a corner, and says in its own docstring why the answer there is
+        the other one.)
+        """
+        root = self.app.root
+        with crashlog.quiet("gui.windows"):
+            area = winenv.monitor_work_area(
+                root.winfo_rootx() + root.winfo_width() // 2,
+                root.winfo_rooty() + root.winfo_height() // 2)
+            if area is not None:
+                return area
+        return (0, 0, int(screen_w), int(screen_h))
+
     def _restore_geometry(self):
-        """Reuse the saved size/position - but only if it still fits the screen.
+        """Reuse the saved size/position - but only if it is still reachable.
 
         A geometry saved on a second monitor that is no longer attached puts the
         window somewhere the user cannot reach it. The main window learned this the
-        hard way; this is the same guard (``scaling.geometry_fits``).
+        hard way; this is the same guard (``scaling.geometry_fits``), and since
+        2026-08-26 the guard knows the difference between a monitor that was
+        unplugged and one that is simply not the primary.
         """
         win = self.win
         saved = self.app.ui.get(self._state_key())
@@ -178,7 +204,8 @@ class PanelWindow:
             screen_h = win.winfo_screenheight()
         except Exception:
             screen_w = screen_h = 0
-        if saved and screen_w and geometry_fits(saved, screen_w, screen_h):
+        if saved and screen_w and geometry_fits(saved, screen_w, screen_h,
+                                                winenv.monitor_work_area):
             try:
                 win.geometry(saved)
                 return
@@ -186,8 +213,7 @@ class PanelWindow:
                 crashlog.note(_exc, "gui.windows")
         width, height = scaled(self.SIZE[0]), scaled(self.SIZE[1])
         try:
-            x = max(0, (screen_w - width) // 2)
-            y = max(0, (screen_h - height) // 3)
+            x, y = centred_in(self._app_monitor(screen_w, screen_h), width, height)
             win.geometry(f"{width}x{height}+{x}+{y}")
         except Exception as _exc:
             crashlog.note(_exc, "gui.windows")

--- a/beantester/gui/windows.py
+++ b/beantester/gui/windows.py
@@ -47,9 +47,8 @@ from tkinter import ttk
 
 from ..i18n import T
 from .scaling import centred_in, geometry_fits, max_window_size, scaled
-from .. import winenv
 from .theme import BG, apply_dark_titlebar, disable_maximize
-from .. import crashlog
+from .. import crashlog, winenv
 
 WINDOWS: dict[str, type] = {}   # id -> PanelWindow subclass (the registry)
 

--- a/beantester/winenv.py
+++ b/beantester/winenv.py
@@ -86,6 +86,34 @@ def elevation_disabled():
 # Declaring the prototypes costs nothing and removes the whole question.
 _USER32 = [None]
 _DWMAPI = [None]
+_MONITORINFO = [None]
+
+# MonitorFromPoint: the point is on no monitor at all (a window dragged past the
+# edge of the desktop), so answer with the nearest one rather than nothing.
+MONITOR_DEFAULTTONEAREST = 2
+
+
+def monitorinfo_type():
+    """The ``MONITORINFO`` layout, built on first use and cached.
+
+    Not at module scope, and not a plain ``c_void_p`` at the call site either:
+    ``ctypes.wintypes`` cannot even be IMPORTED off Windows (which is why every
+    binding in this file is lazy), and this is the one struct here the system
+    WRITES THROUGH a pointer we hand it - the shape that took the interpreter
+    down in ``driver._advapi``. Declaring it is what makes the prototype real.
+    """
+    if _MONITORINFO[0] is None:
+        import ctypes
+        from ctypes import wintypes
+
+        class MONITORINFO(ctypes.Structure):
+            _fields_ = [("cbSize", wintypes.DWORD),
+                        ("rcMonitor", wintypes.RECT),
+                        ("rcWork", wintypes.RECT),
+                        ("dwFlags", wintypes.DWORD)]
+
+        _MONITORINFO[0] = MONITORINFO
+    return _MONITORINFO[0]
 
 
 def user32():
@@ -106,6 +134,13 @@ def user32():
         lib.SetWindowPos.argtypes = [H, H, ctypes.c_int, ctypes.c_int,
                                      ctypes.c_int, ctypes.c_int, wintypes.UINT]
         lib.SetWindowPos.restype = wintypes.BOOL
+        # HMONITOR is a HANDLE, so its result is pointer-sized: exactly the shape
+        # ctypes' default 32-bit restype truncates.
+        lib.MonitorFromPoint.argtypes = [wintypes.POINT, wintypes.DWORD]
+        lib.MonitorFromPoint.restype = wintypes.HMONITOR
+        lib.GetMonitorInfoW.argtypes = [wintypes.HMONITOR,
+                                        ctypes.POINTER(monitorinfo_type())]
+        lib.GetMonitorInfoW.restype = wintypes.BOOL
         # 64-bit Windows has the ...Ptr forms; 32-bit has only the plain ones, and
         # there LONG_PTR is a LONG. Declared for whichever this build actually has,
         # so the guard walks what exists instead of a list somebody wrote down.
@@ -148,6 +183,62 @@ def dwmapi():
 # factory nothing checks, so the list is the registry and the test reads it -
 # rather than the test naming six function names that drift the day one moves.
 NATIVE_FACTORIES = {"user32": user32, "dwmapi": dwmapi}
+
+
+def monitor_work_area(x, y):
+    """The usable rectangle of the monitor showing ``(x, y)``: ``(l, t, r, b)``.
+
+    ``None`` off Windows, or when the system will not answer - callers must have
+    a fallback, and today's fallback is the primary screen, which is what the
+    whole program used before this existed.
+
+    WHY THIS IS NOT ``winfo_screenwidth()``. Tk has no concept of a second
+    monitor: on Windows it reports the screen as ``GetSystemMetrics(SM_CXSCREEN)``,
+    which Microsoft documents as ALWAYS the primary monitor, "not necessarily the
+    monitor that displays your application" ("Positioning Objects on Multiple
+    Display Monitors"). Anything that clamps a window into ``(0, 0, screen_w,
+    screen_h)`` therefore drags it back onto the primary monitor - reported
+    2026-08-26 for the tooltip bubble, which appeared on the first monitor while
+    the window it explained was on the second.
+
+    Three properties this returns that the screen metrics cannot:
+
+    * the rectangle of the monitor the point is really on, whichever that is;
+    * NEGATIVE coordinates, because the primary monitor owns the origin and a
+      monitor placed left of - or above - it lives at negative x/y. Measured on
+      this machine 2026-08-26: Tk honours ``wm_geometry("+-500+100")`` as a real
+      position, so a bubble can be put there;
+    * the WORK area, not the whole monitor, so a bubble at the bottom of the
+      screen no longer slides under the taskbar (measured here: 2160 px of
+      monitor, 2088 px of work area).
+
+    Deliberately NOT cached: monitors are plugged in, unplugged and rearranged
+    while the program runs, and a cached rectangle would be a stale answer that
+    nothing invalidates. Two user32 calls, once per hover after a 400 ms delay -
+    this is not a hot path.
+    """
+    lib = user32()
+    if lib is None:
+        return None
+    with crashlog.quiet("winenv.monitor"):
+        import ctypes
+        from ctypes import wintypes
+
+        handle = lib.MonitorFromPoint(wintypes.POINT(int(x), int(y)),
+                                      MONITOR_DEFAULTTONEAREST)
+        if not handle:
+            return None
+        info = monitorinfo_type()()
+        info.cbSize = ctypes.sizeof(info)
+        if not lib.GetMonitorInfoW(handle, ctypes.byref(info)):
+            return None
+        area = info.rcWork
+        if area.right <= area.left or area.bottom <= area.top:
+            # A monitor with no usable area is not an answer, it is a reason to
+            # fall back. Nothing observed producing one; it costs one comparison.
+            return None
+        return (int(area.left), int(area.top), int(area.right), int(area.bottom))
+    return None
 
 
 # QueryPerformanceCounter, because that is the clock WinDivert stamps its packets

--- a/beantester/winenv.py
+++ b/beantester/winenv.py
@@ -214,8 +214,10 @@ def monitor_work_area(x, y):
 
     Deliberately NOT cached: monitors are plugged in, unplugged and rearranged
     while the program runs, and a cached rectangle would be a stale answer that
-    nothing invalidates. Two user32 calls, once per hover after a 400 ms delay -
-    this is not a hot path.
+    nothing invalidates. The price of asking every time was MEASURED rather than
+    assumed - 4 us per call on this machine, 2026-08-26 - against one call per
+    hover, after a 400 ms delay. A cache here would buy nothing and owe an
+    invalidation nobody would write.
     """
     lib = user32()
     if lib is None:

--- a/beantester/winenv.py
+++ b/beantester/winenv.py
@@ -93,8 +93,13 @@ _MONITORINFO = [None]
 MONITOR_DEFAULTTONEAREST = 2
 
 
-def monitorinfo_type():
+def monitorinfo_type():                       # pragma: no cover - Windows only
     """The ``MONITORINFO`` layout, built on first use and cached.
+
+    The pragma is not a hidden line, it is a platform: this is reached only from
+    ``user32()``, which returns None before it off Windows, and the coverage gate
+    is computed on the Linux runner. The Windows runner really does execute it -
+    ``test_native_prototypes.py`` calls through these prototypes there.
 
     Not at module scope, and not a plain ``c_void_p`` at the call site either:
     ``ctypes.wintypes`` cannot even be IMPORTED off Windows (which is why every
@@ -222,7 +227,9 @@ def monitor_work_area(x, y):
     lib = user32()
     if lib is None:
         return None
-    with crashlog.quiet("winenv.monitor"):
+    # Everything below runs on Windows only - the line above is where the Linux
+    # runner leaves, and the Windows runner covers the rest for real.
+    with crashlog.quiet("winenv.monitor"):    # pragma: no cover - Windows only
         import ctypes
         from ctypes import wintypes
 
@@ -240,7 +247,7 @@ def monitor_work_area(x, y):
             # fall back. Nothing observed producing one; it costs one comparison.
             return None
         return (int(area.left), int(area.top), int(area.right), int(area.bottom))
-    return None
+    return None                               # pragma: no cover - Windows only
 
 
 # QueryPerformanceCounter, because that is the clock WinDivert stamps its packets

--- a/smoke_gui.py
+++ b/smoke_gui.py
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "tes
 import fake_tk                                    # noqa: E402
 
 tk = fake_tk.install()
+fake_tk.single_monitor()      # one monitor, exactly the fake screen (see its docstring)
 
 # The user's own files (UI state, profiles, crash log) must not be written into
 # the repository by a smoke run. Same helper the pytest GUI harness uses; without

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -14,6 +14,7 @@ import sys
 import types
 
 SCREEN = [1920, 1080]     # mutable: tests can pretend to be on a 1366x768 laptop
+# ...and the monitor LAYOUT has to be part of the same fiction, see single_monitor()
 DPI = [96.0]
 CLIPBOARD = []            # what the app copied (Ctrl+C, "copy row", repro CLI)
 GRAB = [None]             # what currently holds the Tk grab (an open popdown)
@@ -692,6 +693,24 @@ class Font:
 
     def metrics(self, *a):
         return 16
+
+
+def single_monitor():
+    """Make the machine's MONITOR layout agree with the fake screen.
+
+    ``beantester.winenv.monitor_work_area`` asks Windows, not Tk. On the Windows
+    runner it therefore answers with the runner's REAL monitor while every widget
+    in this double believes the screen is ``SCREEN`` - and since 2026-08-26 the
+    GUI positions windows from both. Without this, the same test lands the same
+    window somewhere else on the Windows runner than on the Linux one (where the
+    call returns None), which is a difference that has nothing to do with the code
+    under test.
+
+    Call it after settling ``SCREEN``. A test that wants a second monitor
+    overrides the same attribute afterwards.
+    """
+    from beantester import winenv
+    winenv.monitor_work_area = lambda x, y: (0, 0, SCREEN[0], SCREEN[1])
 
 
 def install():

--- a/tests/fake_tk.py
+++ b/tests/fake_tk.py
@@ -485,6 +485,13 @@ class Root(W):
         self.kw["geometry"] = spec
         return None
 
+    # Real tkinter defines `wm_geometry` and aliases `geometry` to it, so the two
+    # names are ONE call. Without this line the alias fell through to
+    # `W.__getattr__`, which answers any unknown name with a no-op: the tooltip
+    # bubble positions itself with `wm_geometry`, so every assertion about where
+    # a bubble landed would have passed while recording nothing at all.
+    wm_geometry = geometry
+
     def minsize(self, w=None, h=None):
         self.kw["minsize"] = (w, h)
 

--- a/tests/gui_harness.py
+++ b/tests/gui_harness.py
@@ -20,6 +20,7 @@ import fake_tk
 fake_tk.SCREEN[:] = [{screen_w}, {screen_h}]
 fake_tk.DPI[0] = {dpi}
 tk = fake_tk.install()
+fake_tk.single_monitor()      # one monitor, exactly the fake screen (see its docstring)
 
 # user files (profiles / ui state / crash log) must never be written into the
 # repo by a test - shared with smoke_gui.py so both stay isolated the same way

--- a/tests/test_gui_helpers.py
+++ b/tests/test_gui_helpers.py
@@ -183,6 +183,11 @@ def test_a_tooltip_stays_on_the_monitor_that_shows_the_widget():
     x, _ = scaling.tooltip_position(2960, 300, 20, 300, 80, right)
     check("tooltip: clamped to THAT monitor's right edge, not the primary's",
           1920 <= x and x + 300 <= 3000, f"(x={x})")
+    # The LEFT edge of a monitor that does not start at zero: a widget whose corner
+    # sits just past the boundary would otherwise put the bubble on the neighbour.
+    x, _ = scaling.tooltip_position(1890, 300, 20, 300, 80, right)
+    check("tooltip: clamped to that monitor's LEFT edge too",
+          x >= 1920, f"(x={x})")
 
     left = (-1920, -200, 0, 880)              # monitor left of and above primary
     x, y = scaling.tooltip_position(-1900, 800, 20, 300, 80, left)

--- a/tests/test_gui_helpers.py
+++ b/tests/test_gui_helpers.py
@@ -74,6 +74,79 @@ def test_geometry_fits_rejects_stale_saved_geometry():
     check("geometry: garbage is rejected", not scaling.geometry_fits("nonsense", 1366, 768))
 
 
+def _primary_only(x, y):
+    """One monitor, 3840x2088 of work area. The nearest one is always this one."""
+    return (0, 0, 3840, 2088)
+
+
+def _second_monitor_right(x, y):
+    """A portrait monitor attached to the right of a 3840-wide primary."""
+    return (3840, 0, 4920, 1920) if x >= 3820 else (0, 0, 3840, 2088)
+
+
+def test_geometry_fits_tells_a_second_monitor_from_an_unplugged_one():
+    """A window left on a second monitor used to come back on the first one.
+
+    Both checks below use the SAME saved geometry, at x=4000 - past the primary
+    monitor's width, so the old code called it "off screen" and threw it away. The
+    only thing that separates a window on a second monitor from a window on a
+    monitor that has been unplugged is whether that spot is still on a display,
+    and nothing but the system can answer that. Hence ``bounds_at``.
+    """
+    saved = "800x600+4000+100"
+    check("geometry: a window on the second monitor is kept",
+          scaling.geometry_fits(saved, 3840, 2088, _second_monitor_right))
+    check("geometry: the same spot with that monitor gone is rejected",
+          not scaling.geometry_fits(saved, 3840, 2088, _primary_only))
+    check("geometry: with nothing to ask, the old primary-screen answer stands",
+          not scaling.geometry_fits(saved, 3840, 2088))
+
+
+def test_geometry_fits_accepts_the_monitors_that_have_negative_coordinates():
+    """The primary monitor owns the origin, so a monitor left of or above it is at
+    negative coordinates - and Tk writes those into ``ui.json`` as "+-1800"."""
+    def left(x, y):
+        return (-1920, 0, 0, 1080)
+
+    def above(x, y):
+        return (0, -1080, 1920, 0)
+
+    check("geometry: a monitor to the left is a valid place for a window",
+          scaling.geometry_fits("800x600+-1800+100", 1920, 1080, left))
+    check("geometry: so is a monitor above the primary one",
+          scaling.geometry_fits("800x600+100+-900", 1920, 1080, above))
+    check("geometry: and the numbers are still checked there",
+          not scaling.geometry_fits("800x600+-5000+100", 1920, 1080, left))
+
+
+def test_a_window_bigger_than_the_primary_monitor_still_fits_its_own():
+    """The size half of the same assumption: a 4K second monitor next to a laptop
+    screen. The saved window fits where it was left, and only the primary screen
+    said otherwise."""
+    def four_k_on_the_right(x, y):
+        return (1366, 0, 5206, 2160)
+
+    check("geometry: judged against the monitor it is on",
+          scaling.geometry_fits("2400x1300+1400+100", 1366, 768, four_k_on_the_right))
+    check("geometry: and a window that fits NOTHING is still rejected",
+          not scaling.geometry_fits("9000x5000+1400+100", 1366, 768,
+                                    four_k_on_the_right))
+
+
+def test_a_window_centres_on_the_monitor_it_is_given():
+    x, y = scaling.centred_in((0, 0, 1920, 1080), 800, 600)
+    check("centred: on the primary monitor", x == 560 and 0 < y < 200, f"({x}, {y})")
+    x, _ = scaling.centred_in((1920, 0, 3000, 1920), 800, 600)
+    check("centred: on the second monitor, not back on the first",
+          1920 <= x and x + 800 <= 3000, f"(x={x})")
+    x, y = scaling.centred_in((-1920, -200, 0, 880), 800, 600)
+    check("centred: a monitor at negative coordinates is a monitor",
+          -1920 <= x and x + 800 <= 0 and y >= -200, f"({x}, {y})")
+    x, y = scaling.centred_in((1920, 0, 2200, 200), 800, 600)
+    check("centred: a window bigger than its monitor still STARTS on it",
+          (x, y) == (1920, 0), f"({x}, {y})")
+
+
 def test_min_window_size_never_exceeds_the_smallest_screen():
     for scale in (1.0, 1.5, 2.0):
         w, h = scaling.min_window_size(scale)

--- a/tests/test_gui_helpers.py
+++ b/tests/test_gui_helpers.py
@@ -83,12 +83,52 @@ def test_min_window_size_never_exceeds_the_smallest_screen():
 
 # -- tooltip / chart --------------------------------------------------------- #
 def test_tooltip_flips_above_at_the_bottom_of_the_screen():
-    _, y = scaling.tooltip_position(100, 1040, 20, 300, 80, 1920, 1080)
+    screen = (0, 0, 1920, 1080)
+    _, y = scaling.tooltip_position(100, 1040, 20, 300, 80, screen)
     check("tooltip: flips above instead of falling off the screen", y < 1040, f"(y={y})")
-    x, _ = scaling.tooltip_position(1900, 100, 20, 300, 80, 1920, 1080)
+    x, _ = scaling.tooltip_position(1900, 100, 20, 300, 80, screen)
     check("tooltip: clamped to the right edge", x + 300 <= 1920, f"(x={x})")
-    x, y = scaling.tooltip_position(100, 100, 20, 300, 80, 1920, 1080)
+    x, y = scaling.tooltip_position(100, 100, 20, 300, 80, screen)
     check("tooltip: normal case sits below the widget", y > 100 and x >= 100)
+
+
+def test_a_tooltip_stays_on_the_monitor_that_shows_the_widget():
+    """Reported 2026-08-26: on a second monitor the bubble opened on the first one.
+
+    The bubble was clamped into ``(0, 0, screen_w, screen_h)``, and on Windows
+    that pair is the PRIMARY monitor whatever the window is on - so hovering a "?"
+    on a monitor to the right pinned the bubble to the right edge of the primary
+    one. Both rectangles below are ones a single-monitor clamp gets wrong, and the
+    second is the one easiest to write off as impossible: the primary monitor owns
+    the origin, so a monitor left of or above it has NEGATIVE coordinates.
+    """
+    right = (1920, 0, 3000, 1920)             # portrait monitor, right of primary
+    x, y = scaling.tooltip_position(2400, 300, 20, 300, 80, right)
+    check("tooltip: opens on the monitor the widget is on",
+          1920 <= x and x + 300 <= 3000, f"(x={x})")
+    check("tooltip: and still sits below the widget there", y > 300, f"(y={y})")
+    x, _ = scaling.tooltip_position(2960, 300, 20, 300, 80, right)
+    check("tooltip: clamped to THAT monitor's right edge, not the primary's",
+          1920 <= x and x + 300 <= 3000, f"(x={x})")
+
+    left = (-1920, -200, 0, 880)              # monitor left of and above primary
+    x, y = scaling.tooltip_position(-1900, 800, 20, 300, 80, left)
+    check("tooltip: a negative origin is a position, not an error",
+          -1920 <= x and x + 300 <= 0, f"(x={x})")
+    check("tooltip: flips above WITHIN the left monitor", -200 <= y < 800, f"(y={y})")
+
+
+def test_a_tooltip_bigger_than_the_monitor_still_starts_on_it():
+    """The degenerate case, kept honest: a bubble wider or taller than the screen.
+
+    It cannot fit, so it will overflow - but it must overflow off the FAR edge
+    with its top-left corner still on the monitor, or the text starts off-screen
+    and the bubble is unreadable rather than merely clipped.
+    """
+    monitor = (1920, 0, 2600, 400)
+    x, y = scaling.tooltip_position(2000, 100, 20, 900, 700, monitor)
+    check("tooltip: oversized bubble starts inside the monitor",
+          1920 <= x <= 2600 and 0 <= y <= 400, f"({x}, {y})")
 
 
 def test_chart_geometry_leaves_room_for_the_axes():

--- a/tests/test_gui_layout.py
+++ b/tests/test_gui_layout.py
@@ -20,6 +20,32 @@ def test_window_fits_the_smallest_supported_screen():
     """, screen=(1366, 768))
 
 
+def test_the_main_window_goes_back_to_the_second_monitor_it_was_left_on():
+    """Wiring, not arithmetic: `app._restore_geometry` has to ASK about monitors.
+
+    `scaling.geometry_fits` learned to take a monitor lookup, and the way to lose
+    that fix quietly is to leave the caller passing nothing - the function keeps
+    its old default and the window keeps coming back to the primary monitor. Both
+    halves are here: the geometry is restored while that monitor exists, and it is
+    dropped once it does not, which is the guard this used to be.
+    """
+    run_gui("""
+        from beantester import winenv
+
+        winenv.monitor_work_area = lambda x, y: (1920, 0, 3000, 1920)
+        app.ui.set("geometry", "800x600+2400+100")
+        app._restore_geometry()
+        assert root.kw["geometry"] == "800x600+2400+100", root.kw["geometry"]
+
+        # ...and with that monitor unplugged the window must NOT be put back there.
+        winenv.monitor_work_area = lambda x, y: (0, 0, 1920, 1080)
+        app._restore_geometry()
+        spec = root.kw["geometry"]
+        assert spec != "800x600+2400+100", spec
+        assert int(spec.split("+")[1]) < 1920, spec
+    """)
+
+
 def test_window_scales_up_on_a_4k_screen():
     run_gui("""
         spec = root.kw["geometry"]

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -83,6 +83,32 @@ MUTATIONS = [
         "test": "test_the_bubble_opens_on_the_monitor_the_widget_is_on",
     },
     {
+        # The caller half of the same fix: `geometry_fits` grew an argument, and
+        # the quiet way to lose the fix is to stop passing it - the default is the
+        # old primary-screen answer, so nothing looks broken.
+        "label": "gui: the main window validates its geometry against the primary screen",
+        "file": "beantester/gui/app.py",
+        "old": "        if saved and geometry_fits(saved, screen_w, screen_h,"
+               " winenv.monitor_work_area):",
+        "new": "        if saved and geometry_fits(saved, screen_w, screen_h):",
+        "test": "test_the_main_window_goes_back_to_the_second_monitor_it_was_left_on",
+    },
+    {
+        "label": "gui: a panel centres on the primary monitor, not on the app's",
+        "file": "beantester/gui/windows.py",
+        "old": "            x, y = centred_in(self._app_monitor(screen_w, screen_h), width, height)",
+        "new": "            x, y = centred_in((0, 0, screen_w, screen_h), width, height)",
+        "test": "test_a_window_opens_on_the_monitor_the_application_is_on",
+    },
+    {
+        "label": "gui: a panel forgets a position that is not on the primary screen",
+        "file": "beantester/gui/windows.py",
+        "old": "        if saved and screen_w and geometry_fits(saved, screen_w, screen_h,\n"
+               "                                                winenv.monitor_work_area):",
+        "new": "        if saved and screen_w and geometry_fits(saved, screen_w, screen_h):",
+        "test": "test_a_window_opens_on_the_monitor_the_application_is_on",
+    },
+    {
         # The SBOM could not name the tool that froze the binary, whose bootloader
         # ships inside it under its own licence.
         "label": "sbom: the registry stops asking for the PyInstaller version",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -72,6 +72,17 @@ MUTATIONS = [
         "test": "test_start_only_fields_are_locked_while_a_session_runs",
     },
     {
+        # The 2026-08-26 report in one line. "The screen" is SM_CXSCREEN on
+        # Windows, which is the PRIMARY monitor whatever the window is on, so this
+        # patch is not an invented break: it is the code that shipped.
+        "label": "gui: the tooltip bubble is clamped to the primary monitor again",
+        "file": "beantester/gui/tooltip.py",
+        "old": "                                  _bounds_for(widget, x_root, y_root))",
+        "new": "                                  (0, 0, widget.winfo_screenwidth() or 1920,\n"
+               "                                   widget.winfo_screenheight() or 1080))",
+        "test": "test_the_bubble_opens_on_the_monitor_the_widget_is_on",
+    },
+    {
         # The SBOM could not name the tool that froze the binary, whose bootloader
         # ships inside it under its own licence.
         "label": "sbom: the registry stops asking for the PyInstaller version",

--- a/tests/test_native_prototypes.py
+++ b/tests/test_native_prototypes.py
@@ -92,7 +92,8 @@ _DIRECT = re.compile(r"\bwindll\.(\w+)\.(\w+)")
 # OpenSCManagerW's restype.) ``argtypes`` DOES default to None, so that half is
 # checked generically below; the width of a result is checked here, by name.
 POINTER_SIZED_RESULTS = {
-    "user32": ("GetParent", "GetWindowLongPtrW", "SetWindowLongPtrW"),
+    "user32": ("GetParent", "GetWindowLongPtrW", "SetWindowLongPtrW",
+               "MonitorFromPoint"),
     "advapi32": ("OpenSCManagerW", "OpenServiceW"),
 }
 
@@ -144,6 +145,39 @@ def test_every_declared_native_function_has_a_full_prototype():
     # The canary this project puts on every scan: a walk that finds nothing
     # satisfies every assertion above perfectly.
     check("the walk actually found native functions", checked >= 10, f"({checked})")
+
+
+def test_the_monitor_lookup_answers_a_usable_rectangle():
+    """The prototypes above are only half of it - this CALLS through them.
+
+    ``monitor_work_area`` is what stops the GUI from clamping windows and tooltip
+    bubbles onto the primary monitor (see its docstring). A prototype guard cannot
+    tell whether the struct is laid out correctly, because a wrong layout returns
+    numbers rather than raising: it just returns the WRONG numbers, and the only
+    cheap way to notice is to insist the answer is a usable rectangle of plain
+    Python ints.
+
+    On a single-monitor machine this cannot prove the multi-monitor case. What it
+    does prove is the part that would break for everyone: the call works, the
+    fields land where we said they do, and a point that is on NO monitor still
+    gets an answer instead of None - the case a window dragged past the edge of
+    the desktop produces.
+    """
+    area = winenv.monitor_work_area(10, 10)
+    if not winenv.is_windows():
+        check("monitor_work_area degrades to None off Windows", area is None, f"({area})")
+        return
+    check("the monitor lookup answers at all", area is not None)     # pragma: no cover
+    check("it is four plain ints",                                   # pragma: no cover
+          isinstance(area, tuple) and len(area) == 4
+          and all(isinstance(edge, int) for edge in area), f"({area})")
+    left, top, right, bottom = area                                  # pragma: no cover
+    check("the work area is a real rectangle, not an empty one",     # pragma: no cover
+          right - left >= 640 and bottom - top >= 480,
+          f"({area}) - a mislaid struct field reads as garbage, not as an error")
+    far = winenv.monitor_work_area(1 << 20, 1 << 20)                 # pragma: no cover
+    check("a point on no monitor still gets the nearest one",        # pragma: no cover
+          far is not None and far[2] > far[0], f"({far})")
 
 
 def test_the_pointer_sized_table_still_matches_the_factories():

--- a/tests/test_tooltip_bubble.py
+++ b/tests/test_tooltip_bubble.py
@@ -189,6 +189,53 @@ def test_hiding_still_withdraws_a_live_bubble():
     """)
 
 
+def test_the_bubble_opens_on_the_monitor_the_widget_is_on():
+    """The 2026-08-26 report, end to end: window on the second monitor, bubble on
+    the first one.
+
+    ``_show_bubble`` asked Tk how big "the screen" is, and on Windows that is the
+    PRIMARY monitor however many are attached - so the bubble was clamped onto a
+    monitor the user was not looking at. This drives the whole show path (the
+    monitor lookup is the only thing stubbed) and reads back the geometry the
+    bubble was actually given.
+
+    The second half is the half that would have shipped broken: on Linux CI, and
+    on any machine where the system will not answer, ``monitor_work_area``
+    returns None and the bubble must fall back to the old screen box rather than
+    to nothing.
+    """
+    run_gui("""
+        from beantester import winenv
+        from beantester.gui import tooltip
+        from tkinter import ttk
+
+        def where(window):
+            spec = window.kw.get("geometry")
+            assert spec, "the bubble never positioned itself"
+            x, _, y = spec.lstrip("+").partition("+")
+            return int(x), int(y)
+
+        # A portrait monitor to the right of the primary one - the reporter's setup.
+        # The fake Tk still answers 1920x1080 for "the screen", which is exactly
+        # the lie the old code believed.
+        tooltip._BUBBLES.clear()
+        winenv.monitor_work_area = lambda x, y: (1920, 0, 3000, 1920)
+        label = ttk.Label(root, text="?")
+        window = tooltip._show_bubble(label, "filter expression syntax", 2400, 300, 20)
+        assert window is not None
+        x, y = where(window)
+        assert 1920 <= x < 3000, "the bubble jumped back to the primary monitor: %d" % x
+        assert 0 <= y < 1920, y
+
+        # No answer from the system: the old behaviour, not no behaviour.
+        winenv.monitor_work_area = lambda x, y: None
+        window = tooltip._show_bubble(label, "filter expression syntax", 100, 100, 20)
+        assert window is not None
+        x, y = where(window)
+        assert 0 <= x <= 1920 and 0 <= y <= 1080, (x, y)
+    """)
+
+
 def test_dead_bubbles_do_not_pile_up_across_windows():
     """The cache is keyed by toplevel NAME and Tk does not reuse names, so without
     pruning every window ever opened leaves an entry holding a dead Toplevel and

--- a/tests/test_tooltip_bubble.py
+++ b/tests/test_tooltip_bubble.py
@@ -233,7 +233,18 @@ def test_the_bubble_opens_on_the_monitor_the_widget_is_on():
         assert window is not None
         x, y = where(window)
         assert 0 <= x <= 1920 and 0 <= y <= 1080, (x, y)
-    """)
+
+        # ...and no answer from Tk either. Nothing can tell us how big anything is,
+        # and the bubble still has to be SOMEWHERE rather than take the window down.
+        def no_idea(*a, **kw):
+            raise RuntimeError("Tk cannot measure the screen")
+
+        label.winfo_screenwidth = no_idea
+        window = tooltip._show_bubble(label, "filter expression syntax", 10, 10, 20)
+        assert window is not None, "a bubble must survive a screen it cannot measure"
+        x, y = where(window)
+        assert 0 <= x <= 1920 and 0 <= y <= 1080, (x, y)
+    """, allow_faults=("gui.tooltip",))
 
 
 def test_dead_bubbles_do_not_pile_up_across_windows():

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -79,6 +79,15 @@ def test_a_window_opens_on_the_monitor_the_application_is_on():
         panel.close()
         panel = app.open_window("probe_monitor")
         assert panel.win.kw["geometry"] == "640x480+2500+300", panel.win.kw["geometry"]
+
+        # With no answer from the system - every non-Windows machine, and the Linux
+        # runner - the window centres on the screen Tk describes, as it always did.
+        panel.close()
+        app.ui.set("window.probe_monitor", "")
+        winenv.monitor_work_area = lambda x, y: None
+        panel = app.open_window("probe_monitor")
+        spec = panel.win.kw["geometry"]
+        assert 0 <= int(spec.split("+")[1]) < 1920, spec
     """)
 
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -46,6 +46,42 @@ def test_a_registered_window_opens_raises_and_closes():
     """)
 
 
+def test_a_window_opens_on_the_monitor_the_application_is_on():
+    """A panel centred on the primary monitor while the app sits on the second one
+    opens where the user is not looking.
+
+    Same single-monitor assumption as the tooltip bubble, one window bigger:
+    ``winfo_screenwidth()`` describes the primary monitor whatever the application
+    is on. The stub is what a monitor to the right would answer for the fake main
+    window; the panel has no saved geometry, so this is the centring path.
+    """
+    run_gui("""
+        from beantester import winenv
+        from beantester.gui.windows import PanelWindow, register_window
+
+        class Probe(PanelWindow):
+            ID = "probe_monitor"
+            TITLE = "app.tabs.statistics"        # any real i18n key
+            def build(self, body):
+                pass
+
+        register_window(Probe)
+        winenv.monitor_work_area = lambda x, y: (1920, 0, 3000, 1920)
+
+        panel = app.open_window("probe_monitor")
+        spec = panel.win.kw["geometry"]
+        x = int(spec.split("+")[1])
+        assert 1920 <= x < 3000, "the panel opened on the primary monitor: %s" % spec
+
+        # ...and once the user has moved it, the remembered position must survive
+        # being on a monitor Tk cannot describe.
+        panel.win.geometry("640x480+2500+300")
+        panel.close()
+        panel = app.open_window("probe_monitor")
+        assert panel.win.kw["geometry"] == "640x480+2500+300", panel.win.kw["geometry"]
+    """)
+
+
 def test_a_window_is_dark_and_hidden_before_it_is_shown():
     """Windows draws the title bar in DWM: a window that does not ask for the dark
     variant BEFORE it is mapped shows a bright white bar until the user clicks it."""


### PR DESCRIPTION
A user reported that with the window on a second monitor, hovering a `?` shows the
tooltip on the primary monitor instead of next to the control. Fixing it turned up
two more places with the same assumption, so this branch has both: the reported bug
first, then the ones found while fixing it.

## Why it happened

`_show_bubble` asked Tk how big "the screen" is and clamped the bubble into
`(0, 0, screen_w, screen_h)`. On Windows those are `SM_CXSCREEN`/`SM_CYSCREEN`,
which Microsoft documents as always the primary monitor, "not necessarily the
monitor that displays your application"
([Positioning Objects on Multiple Display Monitors](https://learn.microsoft.com/windows/win32/gdi/positioning-objects-on-multiple-display-monitors)).
A bubble anchored past the primary monitor's width was therefore pushed back onto
it, pinned to its right edge.

The reporter's own evidence separated the two mechanisms: clicking the same `?`
opens a help sheet that appeared correctly, because it positions itself relative to
its parent window rather than to the screen metrics.

## What changed

**1 - the tooltip (`fix(gui): open the tooltip on the monitor its window is on`)**

* `winenv.monitor_work_area(x, y)` -> `(l, t, r, b)`, via `MonitorFromPoint`
  (nearest) and `GetMonitorInfoW`, `None` off Windows.
* `scaling.tooltip_position` takes a rectangle instead of a width/height pair. A
  rectangle is the only shape that can express a monitor which does not start at
  the origin: left/top are negative for a monitor placed left of or above the
  primary one.
* The anchor is the widget's own corner, so a window straddling two monitors puts
  the bubble on the one the user is looking at.
* Free with it: the lookup returns the WORK area, so a tooltip near the bottom of
  the screen no longer slides under the taskbar.

**2 - saved geometry and panels (`fix(gui): put a window back on the monitor it was left on`)**

* `scaling.geometry_fits` takes an optional monitor lookup and judges both the size
  and the position against the monitor that spot is on, so a window left on a
  second monitor is no longer discarded as "off screen". The unplugged-monitor
  guard survives for the reason it always worked: the nearest monitor is then the
  primary one and the arithmetic says no.
* `scaling.centred_in` plus `PanelWindow._app_monitor`: Settings, Event log and
  About open on the monitor the application is on, not on the primary one.
* The two probe points differ on purpose. `geometry_fits` asks about the window's
  own corner, which keeps the existing off-screen slack working and leaves a
  straddling window with the verdict it had; `_app_monitor` asks about the middle
  of the main window, because "where is the application" is a different question.

**3 - review pass**, no behaviour change: merged imports, and two claims replaced
with what was measured.

## How it was verified without a second monitor

I have one monitor, so the multi-monitor case cannot be shown on screen here. It
was split into parts that can each be checked for real:

* **The Win32 layer, really.** `MonitorFromPoint` + `GetMonitorInfoW` through the
  new prototypes answer `rcWork=(0, 0, 3840, 2088)` against `rcMonitor=(0, 0, 3840,
  2160)` - the 72 px being the taskbar, which is why the bubble used to slide under
  it - and a point on no monitor at all still gets the nearest one.
* **The arithmetic, in unit tests**: an offset rectangle, a negative-origin one, a
  monitor larger than the primary, and a bubble too big for its monitor.
* **Tk and Windows really accept these positions.** Driven through the production
  show path on real Tk: the bubble maps at x=4418 and at x=-1882, both outside the
  only monitor on this machine, and the bottom-edge case lands at 2072 against a
  work area of 2088.
* **The saved-geometry round trip, on real Tk**: Tk writes a negative position as
  `800x600+-1200+300` and reads it back byte for byte, so the sign survives
  `ui.json`. The old check rejects both off-primary positions and accepts the
  on-primary one, which is what makes the new argument provably load-bearing.
* **Four registry mutations, all `caught`.** Putting the screen box back reddens
  the bubble test at x=1714 - the primary monitor's right edge minus the bubble
  width, which is the reported symptom reproduced as a number.

What this does NOT prove: that a real two-monitor desktop behaves exactly like the
stubbed rectangles. The parts that a single-monitor machine can check are checked;
confirmation from the reporter on a build with this branch would close the rest.

## Notes

* `fake_tk.single_monitor()` pins the monitor lookup to the fake screen for the GUI
  harness and the smoke run. The lookup asks Windows rather than Tk, so without it
  the same test would place the same window differently on the Windows runner than
  on the Linux one.
* `PanelWindow._max_size` still clamps to the primary screen. It is an upper bound
  that only binds on a screen smaller than the window's own cap, so the miss is a
  window that can be dragged wider than a small secondary monitor. Left alone
  deliberately, and said here rather than fixed quietly.
* Ran locally: the guards for everything touched (GUI, windows, tooltip, geometry,
  native prototypes, mutation registry, repo conventions), `ruff`, `mypy` and
  `smoke_gui.py`. The full suite runs here on both runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
