### PR TITLE
fix(security): translation templates, CSV formulas and elevation quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Asking for administrator rights could change your command line.** When the program needs
+  administrator rights it restarts itself with the same arguments. An argument ending in a
+  backslash broke the quoting, so the restarted copy could receive different flags than the
+  ones you typed - including a flag you never passed. Arguments are now quoted the way Windows
+  reads them back.
+
+- **A translation file could reach into the program.** Adding a language means dropping a JSON
+  file into `lang/`, so a translation is something you get from somebody else. Its text was
+  being run through a formatter powerful enough to print the program's own internals into a
+  label, and one wrong character in it could stop the program. Translations now fill in names
+  and nothing else.
+
+- **An exported CSV could carry a formula.** The connections export writes the names of the
+  programs it saw, and a spreadsheet runs any cell that starts with `=`, `+`, `-` or `@` - all
+  of them legal first characters for a file name on Windows. These exports are made to be
+  shared, so such a name became a payload for whoever opened the file. Those cells are now
+  marked as text; numbers stay numbers.
+
 - **A scenario file checked the names of your settings but not their values.** A misspelled
   setting was refused with a suggestion; a nonsense VALUE went straight to the engine. Too
   large a number was simply used, and a value of the wrong kind stopped the timeline mid-run -

--- a/beantester/gui/csv_export.py
+++ b/beantester/gui/csv_export.py
@@ -63,6 +63,30 @@ def session_value(key, info):
     return ("yes" if value else "no") if isinstance(value, bool) else value
 
 
+# A cell a spreadsheet would run instead of showing. Excel and LibreOffice treat a
+# cell starting with one of these as a FORMULA, and this program writes strings it
+# did not choose: a process name comes from the filesystem, and `=cmd.exe` or
+# `=HYPERLINK("http://...")` are legal Windows file names. The CSV is written to be
+# shared - it goes into bug reports and measurements - so the person who opens it is
+# usually not the person whose machine produced it. CWE-1236.
+_FORMULA_LEAD = ("=", "+", "-", "@", "\t", "\r")
+
+
+def formula_safe(value):
+    """One data cell, with a leading apostrophe when a spreadsheet would run it.
+
+    Only strings are touched, which is what keeps the numeric columns numeric: the
+    writers below pass ints and floats as ints and floats, so a negative NUMBER
+    never reaches this and never turns into text. Header rows are deliberately not
+    passed through here either - the stats file compares the header it finds on
+    disk against the one it would write, and quoting one side of that comparison
+    would rotate the file on every append.
+    """
+    if isinstance(value, str) and value.startswith(_FORMULA_LEAD):
+        return "'" + value
+    return value
+
+
 def export_stats(app):
     snap = app.engine.stats_snapshot()
     info = app.engine.session_info()
@@ -86,8 +110,9 @@ def export_stats(app):
             writer = csv.writer(f)
             if write_header:
                 writer.writerow(header)
-            writer.writerow([time.strftime("%Y-%m-%d %H:%M:%S"),
-                             *session_cells, *snap.values()])
+            writer.writerow([formula_safe(v) for v in
+                             (time.strftime("%Y-%m-%d %H:%M:%S"),
+                              *session_cells, *snap.values())])
         # The WHOLE path, not just the file name: these files no longer sit next to
         # the executable, so the name alone would leave the user hunting for them.
         app.log(f"{T('log.stats_saved_to')} {CSV_FILE}")
@@ -141,7 +166,7 @@ def export_connections(app):
             for c in rows:
                 last = c.get("last", now)
                 packets = c.get("packets", 0) or 0
-                writer.writerow([
+                writer.writerow([formula_safe(v) for v in (
                     connection_proc(c, app.proc_map) or "?",
                     c.get("pid") or "",
                     c.get("proto", "IP"), c.get("remote_ip", ""),
@@ -152,7 +177,7 @@ def export_connections(app):
                     c.get("bytes_in", 0), c.get("bytes_out", 0), c.get("bytes", 0),
                     avg_packet_bytes(c),
                     f"{max(0.0, last - c.get('first', now)):.1f}",
-                    f"{max(0.0, now - last):.1f}"])
+                    f"{max(0.0, now - last):.1f}")])
         os.replace(tmp, path)
         app.log(f"{T('log.conns_saved_to')} {path} ({len(rows)})")
     except Exception as e:

--- a/beantester/i18n.py
+++ b/beantester/i18n.py
@@ -6,6 +6,7 @@ English fallback -> the key itself. Adding a language = adding a JSON file;
 no code changes are needed.
 """
 import os
+import string
 
 from .jsonfile import load_json
 from .paths import lang_dir
@@ -137,11 +138,42 @@ def current_language():
     return _resolve_language()
 
 
+class _PlainFieldsOnly(string.Formatter):
+    """Substitutes ``{name}`` and nothing else - no attributes, no indexing.
+
+    ``str.format`` walks attributes: ``"{x.__class__.__mro__}".format(x=1)`` is a
+    perfectly valid template. The text being walked comes out of
+    ``lang/<code>.json``, and this module's own docstring calls adding one of those
+    the way to add a language - "no code changes are needed". So the first
+    translation somebody contributes is untrusted input by any honest reading, and
+    it was being handed a language feature nobody needs.
+
+    MEASURED 2026-08-26, both halves: a poisoned string rendered the internals of
+    its argument into a GUI label, and a template naming an attribute that does not
+    exist raised ``AttributeError`` - which ``translate`` did not catch, so one
+    stray character in a translation file could take the program down in whatever
+    window happened to render it.
+
+    The rule is as strict as it is because the files say it can be: every one of
+    the 222 placeholders across both shipped language files is a plain name. No
+    positional field, no attribute, no index, no format spec. Nothing legitimate
+    is refused here - that was checked before the rule was chosen, not after.
+    """
+
+    def get_field(self, field_name, args, kwargs):
+        if not field_name.isidentifier():
+            raise ValueError(f"unsupported placeholder: {field_name!r}")
+        return kwargs[field_name], field_name
+
+
+_FORMATTER = _PlainFieldsOnly()
+
+
 def translate(key, lang=None, **fmt):
     """Translate a key: requested language -> English fallback -> the key itself.
 
     Non-string input passes through unchanged. Optional keyword arguments are
-    applied with ``str.format()``; a malformed template never raises.
+    substituted into ``{name}`` placeholders; a malformed template never raises.
     """
     if not isinstance(key, str):
         return key
@@ -151,9 +183,12 @@ def translate(key, lang=None, **fmt):
     if text is None:
         text = _translations.get(FALLBACK_LANGUAGE, {}).get(key, key)
     if fmt:
+        # The untranslated text is a better answer than a crash OR than a leak:
+        # anything this formatter refuses comes back with its braces showing,
+        # which is visibly wrong to the translator and harmless to the user.
         try:
-            return text.format(**fmt)
-        except (KeyError, IndexError, ValueError):
+            return _FORMATTER.vformat(text, (), fmt)
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
             return text
     return text
 

--- a/beantester/winenv.py
+++ b/beantester/winenv.py
@@ -292,8 +292,33 @@ def qpc_now():
     return None
 
 
-def _quote(arg):
-    return '"%s"' % str(arg).replace('"', r"\"")
+def _relaunch_params(args):
+    """The parameter string for ``ShellExecuteW``, quoted the way Windows parses it.
+
+    This crosses a PRIVILEGE boundary: whatever it builds is what the elevated copy
+    receives. The hand-rolled version it replaces wrapped each argument in quotes
+    and escaped inner quotes, which is right until an argument ends in a backslash -
+    then the backslash escapes the closing quote and the rest of the command line is
+    re-read as part of that argument.
+
+    MEASURED 2026-08-26 by parsing the result back with ``CommandLineToArgvW``, the
+    same function the elevated process's own startup uses. It was not only a
+    mangled value:
+
+        asked for : --target 'evil\\" --loss 100 "' --loss 0
+        arrived as: --target 'evil\\'   --loss   100   '" --loss 0'
+
+    ``--loss 100`` appears in the elevated process as a flag the user never passed
+    - in a program whose whole purpose is damaging network traffic, and whose own
+    README hands people ``Reproduce:`` command lines to paste.
+
+    ``subprocess.list2cmdline`` is the stdlib's implementation of exactly these
+    rules (it is what Python itself uses to build a Windows command line). Imported
+    inside the function, like every other binding here, and for a pure string
+    helper: nothing in this module spawns a process.
+    """
+    import subprocess
+    return subprocess.list2cmdline([str(a) for a in args])
 
 
 def elevate_self(argv=None):
@@ -313,7 +338,7 @@ def elevate_self(argv=None):
             program, args = sys.executable, argv
         else:                       # running from sources: elevate the interpreter
             program, args = sys.executable, [os.path.abspath(sys.argv[0])] + argv
-        params = " ".join(_quote(a) for a in args)
+        params = _relaunch_params(args)
         # ShellExecuteW with the "runas" verb is the only supported way to ask
         # for elevation; a return value <= 32 means it did not start (e.g. 1223
         # = the user clicked "No").

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -169,6 +169,9 @@ KNOWN_UNUSED = {
                 "PROJECT_NOTES lists it as part of the scaling surface",
     "make_scrollable": "the compatibility alias the notes say stays. Deleting it is "
                        "a decision about that promise, not about this scan",
+    "get_field": "an OVERRIDE of string.Formatter.get_field - the base class calls "
+                 "it, so no line in this package ever names it. Deleting it would "
+                 "restore attribute access inside translation templates",
 }
 
 

--- a/tests/test_conns_export.py
+++ b/tests/test_conns_export.py
@@ -246,3 +246,44 @@ def test_both_exports_tell_the_user_the_whole_path():
             assert said, (name, lines)
             assert any(folder in l for l in said), (name, said)
     ''')
+
+
+def test_a_process_name_cannot_arrive_as_a_spreadsheet_formula():
+    """The export is written to be SHARED, and it carries names we did not choose.
+
+    Excel and LibreOffice run a cell that starts with `=`, `+`, `-` or `@`, and
+    those are all legal first characters for a Windows file name. So a process
+    called `=HYPERLINK("http://...")` turns this file into a payload for whoever
+    opens it - which, for a CSV that goes into bug reports and measurements, is
+    usually not the person whose machine produced it (CWE-1236).
+
+    The other half matters just as much: the numeric columns must stay numeric.
+    They are written as ints and floats, so nothing quotes them - a spreadsheet
+    that reads `packets` as text would make the export useless for the one job it
+    has.
+    """
+    run_gui('''
+        import os, tempfile, csv
+        import beantester.gui.csv_export as m
+        path = os.path.join(tempfile.mkdtemp(), "conns.csv")
+        m.CONNECTIONS_CSV_FILE = path
+
+        app.engine.now_ref = lambda: 10.0
+        app.engine.connections_snapshot = lambda limit=None: [
+            dict(local_port=51000, remote_ip="1.1.1.1", remote_port=443, proto="TCP",
+                 packets=4, bytes=3072, bytes_in=2048, bytes_out=1024,
+                 sent=2048, sent_in=1024, sent_out=1024, dropped=3,
+                 scoped=True, pid=1234, first=2.0, last=9.0, dir="in",
+                 proc='=HYPERLINK("http://evil.example","click")'),
+        ]
+        app.conn_query = ""
+        app.conn_sort = {"col": "up", "reverse": True}
+        app.export_connections_csv()
+
+        rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
+        name = rows[1][0]
+        assert name.startswith("'="), "a formula reached the file unquoted: %r" % name
+        assert "HYPERLINK" in name, "the name itself must survive: %r" % name
+        assert rows[1][6] == "4", "packets stopped being a number: %r" % rows[1][6]
+        assert rows[1][8] == "3", "dropped stopped being a number: %r" % rows[1][8]
+    ''')

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -1047,30 +1047,74 @@ def test_closing_the_window_always_releases_the_engine():
 # -- pure winenv helpers: no UAC, no ctypes, no excuse for being untested ----- #
 
 
-def test_the_relaunch_quoting_survives_a_path_with_spaces_and_quotes():
-    """``_quote`` builds the parameter string handed to ``ShellExecuteW`` when the
-    app re-launches itself elevated. It is a pure function and it was untested,
-    while a mis-quoted argument means the elevated copy starts with the WRONG
-    settings - or, with a crafted path, with extra ones.
+def test_the_relaunch_quoting_survives_the_arguments_windows_reparses():
+    """What crosses the UAC boundary must be what the user typed.
+
+    The version this replaces wrapped each argument in quotes and escaped inner
+    quotes - correct until an argument ENDS in a backslash, which then escapes the
+    closing quote and lets the rest of the command line be re-read as part of that
+    argument. Measured with ``CommandLineToArgvW``, the same parser the elevated
+    process starts with:
+
+        asked for : --target 'evil\\" --loss 100 "' --loss 0
+        arrived as: --target 'evil\'  --loss  100  '" --loss 0'
+
+    ``--loss 100`` in the ELEVATED process, from a command line that never said it,
+    in a program that damages network traffic for a living.
+
+    🔴 The test that used to be here is the reason this shipped. Its docstring named
+    this exact attack ("with a crafted path, with extra ones") and then asserted the
+    SHAPE of the answer - that the result starts and ends with a quote, that an
+    inner quote becomes a backslash-quote - which is a description of the
+    implementation, not a property of it. It passed for as long as the bug existed
+    and would have kept passing. This one asks the only question that matters: parse
+    it back, do you get what you asked for?
     """
+    import ctypes
+
     from beantester import winenv
 
-    check("a plain argument is wrapped", winenv._quote("--simulate") == '"--simulate"')
-
-    # Built from parts so the test's own escaping cannot be what it measures.
     sep = chr(92)
-    spaced = "C:" + sep + "Program Files" + sep + "bean.py"
-    check("a path with spaces stays ONE argument",
-          winenv._quote(spaced) == '"' + spaced + '"', f"({winenv._quote(spaced)})")
-    check("...and its backslashes are passed through untouched",
-          winenv._quote(spaced).count(sep) == 2, f"({winenv._quote(spaced)})")
+    cases = [
+        ["--simulate"],
+        ["--target", "C:" + sep + "Program Files" + sep + "bean.py"],
+        ["--config", 'a"b.json'],
+        ["--target", "x" + sep, "--loss", "100"],
+        ["--target", "evil" + sep + '" --loss 100 "', "--loss", "0"],
+        ["--target", "a" + sep * 3, "--simulate"],
+        [7],                                    # a non-string argument, as before
+    ]
 
-    quoted = winenv._quote('a"b')
-    check("an embedded quote is escaped, not left to close the string early",
-          quoted == '"a\\"b"', f"({quoted})")
-    check("the result always opens and closes with a quote",
-          quoted.startswith('"') and quoted.endswith('"'), f"({quoted})")
-    check("a non-string argument does not explode", winenv._quote(7) == '"7"')
+    if not hasattr(ctypes, "windll"):
+        # Not Windows: there is no CommandLineToArgvW to ask, and the elevation
+        # path this builds for does not exist here either. Assert the part that is
+        # still true - it produces a string and does not raise on any of them -
+        # rather than a weaker version of the real check.
+        for args in cases:
+            check(f"a parameter string is built off Windows too: {args}",
+                  isinstance(winenv._relaunch_params(args), str))
+        return
+
+    from ctypes import wintypes                        # pragma: no cover - Windows
+
+    shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+    shell32.CommandLineToArgvW.argtypes = [wintypes.LPCWSTR,
+                                           ctypes.POINTER(ctypes.c_int)]
+    shell32.CommandLineToArgvW.restype = ctypes.POINTER(wintypes.LPWSTR)
+
+    def reparse(line):
+        count = ctypes.c_int(0)
+        argv = shell32.CommandLineToArgvW(line, ctypes.byref(count))
+        try:
+            return [argv[i] for i in range(count.value)][1:]   # drop argv[0]
+        finally:
+            ctypes.windll.kernel32.LocalFree(argv)
+
+    for args in cases:
+        wanted = [str(a) for a in args]
+        line = "bean.exe " + winenv._relaunch_params(args)
+        check(f"the elevated copy receives exactly these arguments: {wanted}",
+              reparse(line) == wanted, f"(it would receive {reparse(line)})")
 
 
 def test_the_no_elevate_switch_is_read_the_way_the_screenshot_workflow_uses_it():

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -204,6 +204,49 @@ def test_translate_placeholders():
           "ping" in n.translate("summary.latency", "en", v=100, extra=1))
 
 
+def test_a_translation_file_cannot_reach_inside_the_values_it_formats():
+    """A language file is contributed input, and it was being handed `str.format`.
+
+    "Adding a language = adding a JSON file; no code changes are needed" is this
+    module's own docstring, so the first translation somebody sends is untrusted
+    text - and `str.format` walks attributes. Measured before the fix:
+    `{name.__class__.__mro__}` rendered the internals of the argument into the
+    label, and `{name.nope}` raised AttributeError, which `translate` did not catch.
+    One stray character in a translation could take the program down.
+
+    The three cases are the three outcomes that matter: nothing leaks, nothing
+    raises, and the thing translations actually do still works.
+    """
+    from beantester import i18n
+
+    i18n.load_languages()
+    poisoned = {
+        "probe.leak": "leak: {name.__class__.__mro__}",
+        "probe.missing_attr": "{name.no_such_attribute}",
+        "probe.index": "{name[0]}",
+        "probe.plain": "hello {name}",
+    }
+    i18n._translations.setdefault("en", {}).update(poisoned)
+    try:
+        leak = i18n.translate("probe.leak", "en", name="x")
+        # Compared against the raw template, not searched for words: the template
+        # ITSELF contains "__class__", so "no internals leaked" has to mean
+        # "nothing was substituted at all" to be worth anything.
+        check("i18n: a template cannot walk into the value it was given",
+              leak == poisoned["probe.leak"] and "<class" not in leak, f"({leak})")
+
+        for key in ("probe.missing_attr", "probe.index"):
+            out = i18n.translate(key, "en", name="x")
+            check(f"i18n: {key} does not raise, it comes back unrendered",
+                  isinstance(out, str) and "{" in out, f"({out!r})")
+
+        check("i18n: a plain placeholder still works",
+              i18n.translate("probe.plain", "en", name="world") == "hello world")
+    finally:
+        for key in poisoned:
+            i18n._translations["en"].pop(key, None)
+
+
 def test_settings_summary_uses_current_language():
     import beantester as n
     orig = n.current_language()

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -72,6 +72,25 @@ MUTATIONS = [
         "test": "test_start_only_fields_are_locked_while_a_session_runs",
     },
     {
+        # The hand-rolled quoting, restored exactly as it shipped: an argument
+        # ending in a backslash escapes its own closing quote.
+        "label": "winenv: relaunch quoting goes back to wrapping each argument",
+        "file": "beantester/winenv.py",
+        "old": "    import subprocess\n"
+               "    return subprocess.list2cmdline([str(a) for a in args])",
+        "new": "    return ' '.join('\"%s\"' % str(a).replace('\"', chr(92) + '\"')\n"
+               "                    for a in args)",
+        "test": "test_the_relaunch_quoting_survives_the_arguments_windows_reparses",
+    },
+    {
+        # Back to str.format, which walks attributes into whatever it was given.
+        "label": "i18n: a translation file gets str.format back",
+        "file": "beantester/i18n.py",
+        "old": "            return _FORMATTER.vformat(text, (), fmt)",
+        "new": "            return text.format(**fmt)",
+        "test": "test_a_translation_file_cannot_reach_inside_the_values_it_formats",
+    },
+    {
         # The half that was missing for years: the step's setting NAMES were
         # checked, its VALUES went to the engine untouched.
         "label": "scenario: a step's settings values stop being validated",


### PR DESCRIPTION
The remaining three code findings from the security audit. **Stacked on
donislawdev/BeanNetworkTester#157** - merge that one first and the diff here shrinks to its own
three commits' worth of change.

Each of these is the same shape: text somebody else wrote, handed to something
more powerful than it needed to be.

## Elevation quoting - argument injection, not a mangled value

The audit rated this Low on the assumption that a badly quoted argument only
corrupts its own value. Parsing the result back with `CommandLineToArgvW` - the
parser the elevated process itself starts with - says otherwise:

```
asked for : --target 'evil\" --loss 100 "' --loss 0
arrives as: --target 'evil\'   --loss   100   '" --loss 0'
```

`--loss 100` in the ELEVATED process, from a command line that never said it, in a
program whose purpose is damaging network traffic - and this project hands people
`Reproduce:` command lines to paste. `_quote` is replaced by `_relaunch_params`,
which uses `subprocess.list2cmdline`. Nothing spawns a process; it is imported
inside the function for a pure string helper.

**The old test is why this shipped.** Its docstring named this exact attack ("with
a crafted path, with extra ones") and then asserted the *shape* of the answer:
starts and ends with a quote, an inner quote becomes backslash-quote. That
describes the implementation rather than any property of it, so it passed for as
long as the bug existed and would have kept passing. The replacement asks the only
question that matters - parse it back, do you get what you asked for - across seven
argument shapes including the one above.

## A translation file was a template, not text

`translate()` ran text from `lang/<code>.json` through `str.format`, which walks
attributes. "Adding a language = adding a JSON file; no code changes are needed" is
that module's own docstring, so a contributed translation is untrusted input by any
honest reading. Measured: `{name.__class__.__mro__}` printed the internals of its
argument into a GUI label, and `{name.nope}` raised `AttributeError`, which
`translate` did not catch - one stray character could take down whatever window
rendered it.

A formatter that substitutes bare names and nothing else replaces it. The rule is
that strict because the files say it can be: **all 222 placeholders across both
shipped language files are plain names** - no positional field, no attribute, no
index, no format spec. That was checked before the rule was chosen, not after. Cost
measured too: 2.75 us against `str.format`'s 0.47, and only on calls that pass
arguments at all.

## The CSV exports handed a spreadsheet a formula

`=`, `+`, `-` and `@` all start a formula in Excel and LibreOffice, and all four are
legal first characters for a Windows file name. The connections export writes
process names, and both exports exist to be SHARED - into bug reports and
measurements - so the person opening the file is usually not the person whose
machine produced it (CWE-1236).

`formula_safe` marks such cells as text. Two things it deliberately does not do:
never a non-string (the numeric columns are written as ints and floats, so a
negative NUMBER cannot become text), and never the header - `export_stats` compares
the header on disk against the one it would write, and quoting one side of that
comparison would rotate the file on every append.

## Verification

* Three registry mutations, all `caught`.
* Diff coverage measured on Linux **before** pushing: 95%. The one uncovered line
  is inside `elevate_self`, which no test may run.
* `ruff`, `mypy`, `smoke_gui.py`, and the guards around i18n, the exports, the
  failsafe path, code shape and hygiene.
* `get_field` is added to `test_code_hygiene.KNOWN_UNUSED` with its reason: it is an
  override the base class calls, so no line in the package names it.

## What is left from the audit

* **Install-directory writability (H-3)** - measured, not yet acted on: WinGet's
  default portable install lands in `%LOCALAPPDATA%`, which is fully writable by the
  user, and so is an unpacked ZIP. Chocolatey's is not. That is a decision about how
  strongly to react, not a code change to slip into this PR.
* **What a crash file contains (M-2)** - a policy question about what the issue
  template asks people to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
