### PR TITLE
feat(security): say whether the program folder can be tampered with

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,4 +69,9 @@ body:
     id: extra
     attributes:
       label: Anything else?
-      description: Logs (`--log-file`), screenshots, or a crash file from the `crashes/` folder.
+      description: >-
+        Logs (`--log-file`), screenshots, or a crash file from the `crashes/` folder.
+        Before attaching one: a crash file records the command line you ran, your
+        settings (including any process you targeted and any address you aimed at) and
+        file paths that contain your user name. This issue is public, so have a look at
+        it first and remove anything you would rather not publish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **`--doctor` now tells you whether your copy can be tampered with.** The program asks for
+  administrator rights and then loads its network driver from its own folder, so a folder
+  anyone can write to without those rights is worth knowing about. Run `--doctor` without
+  administrator rights and it says which case yours is, and what to install differently if you
+  want the other one. `SECURITY.md` has the same in a table. Run it elevated and it says it
+  could not tell, rather than pretending everything is fine.
+
 - **Asking for administrator rights could change your command line.** When the program needs
   administrator rights it restarts itself with the same arguments. An argument ending in a
   backslash broke the quoting, so the restarted copy could receive different flags than the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,3 +87,25 @@ The program has **no telemetry and no network client** - it sends no data anywhe
 Reports that are in scope include, for example: a way to make the tool affect traffic
 it was not told to target, a crash that corrupts a user's files (profiles, config,
 CSV), or unsafe handling of the files it reads and writes.
+
+## Where you install it matters
+
+The program asks for administrator rights and then loads `WinDivert.dll` from its own
+folder. So anything that can write to that folder **without** administrator rights can
+leave a DLL there for the elevated copy to load. That is a property of every user-scope
+install, not of this program in particular - but this program is the one that elevates,
+so it is worth saying plainly.
+
+Measured on 2026-08-26:
+
+| How you installed it | Folder | Writable without admin rights |
+|---|---|---|
+| `winget install` (default) | `%LOCALAPPDATA%\Microsoft\WinGet\Packages\` | **yes** |
+| `winget install --scope machine` | `%PROGRAMFILES%\WinGet\Packages\` | no |
+| Chocolatey | `C:\ProgramData\chocolatey\lib\` | no |
+| Zip unpacked in your profile | wherever you put it | **yes** |
+
+If that matters on your machine, install with `winget install --scope machine`, use
+Chocolatey, or unpack the zip somewhere only administrators can write.
+`BeanNetworkTester.exe --doctor` tells you which of the two your copy is in - run it
+**without** administrator rights, or it can only report that it could not tell.

--- a/beantester/driver.py
+++ b/beantester/driver.py
@@ -38,6 +38,7 @@ import os
 import tempfile
 
 from . import crashlog
+from .paths import directory_is_writable, executable_dir, is_frozen
 from .winenv import is_admin, is_windows
 
 # Set once a session actually opened a REAL WinDivert handle (not --simulate and
@@ -504,6 +505,48 @@ def open_failure_hint(exc, elevated=None):
     return "" if elevated else "dialogs.run_as_admin"
 
 
+def _program_folder_check():
+    """Could something running as this user replace the files we load when elevated?
+
+    This program asks for administrator rights and THEN loads ``WinDivert.dll`` from
+    its own folder. If that folder can be written without administrator rights, then
+    anything running as the user - no elevation needed - can leave its own DLL there
+    and have the elevated copy load it. That turns "code as you" into "code as
+    Administrator", and the UAC prompt shows a signed, trusted executable while it
+    happens.
+
+    It is not a defect of this program: it is what a user-scope install IS. But this
+    program is the one that does the elevating, so it is the one that should say so.
+    MEASURED 2026-08-26 on a real machine, because the first version of the audit
+    assumed the opposite: WinGet's default for this package (``InstallerType: zip``
+    with ``NestedInstallerType: portable``) is a USER-scope install under
+    ``%LOCALAPPDATA%\\Microsoft\\WinGet\\Packages``, where the user has full control -
+    and so does an archive unpacked anywhere in the profile. ``--scope machine`` and
+    Chocolatey's package folder do not.
+
+    Reported as a WARN rather than a FAIL: it does not stop a session from starting,
+    and on most machines the user cannot change it without reinstalling. "Not
+    checked" is a warn too - an unanswered question must not print as a clean bill of
+    health, which is the rule the WinDivert row above already lives by.
+    """
+    folder = executable_dir()
+    if is_admin():
+        return ("program folder", "warn",
+                f"{folder} - not checked: this run is already elevated, so a "
+                f"successful write says nothing about an ordinary user. Run "
+                f"--doctor WITHOUT administrator rights to check it")
+    writable = directory_is_writable(folder)
+    if writable is None:
+        return ("program folder", "warn", f"{folder} - could not be checked")
+    if writable:
+        return ("program folder", "warn",
+                f"{folder} - writable without administrator rights: anything running "
+                f"as you can replace the files this program loads when it elevates. "
+                f"Installing with 'winget install --scope machine' avoids this")
+    return ("program folder", "ok",
+            f"{folder} - not writable without administrator rights")
+
+
 def doctor():
     """Environment report used by ``--doctor``: ``(ok, [(check, state, detail)])``."""
     import platform
@@ -522,6 +565,12 @@ def doctor():
         checks.append(("pydivert", "ok" if pydivert_available() else "fail",
                        "importable" if pydivert_available()
                        else "missing - pip install pydivert"))
+        # Only for a frozen build: from sources the "program folder" is a source
+        # checkout the developer owns by definition, and the driver comes out of
+        # site-packages rather than from next to the exe. A row that is trivially
+        # true tells nobody anything and trains people to skip the report.
+        if is_frozen():
+            checks.append(_program_folder_check())
         drivers = installed_drivers()
         if drivers:
             running = [n for n, s in drivers.items() if s == "running"]

--- a/beantester/paths.py
+++ b/beantester/paths.py
@@ -99,6 +99,34 @@ def ensure_data_dir():
     return None
 
 
+def directory_is_writable(path):
+    """True when THIS process can create a file in ``path``. ``None`` if it cannot tell.
+
+    A probe, not an ACL walk. Reading the access list would mean deciding which
+    principals count as "an ordinary user", and that judgement is the question, not
+    the answer - while a write that SUCCEEDS is the answer, for exactly the token
+    doing the asking. Which is why the caller has to care whether it is elevated:
+    the same probe answers a different question then.
+    """
+    if not os.path.isdir(path):
+        return None
+    probe = os.path.join(path, f".bnt-write-probe-{os.getpid()}")
+    try:
+        with open(probe, "w"):
+            pass
+    except OSError:
+        return False                  # the answer, not a fault: nothing to record
+    try:
+        os.remove(probe)
+    except OSError as _exc:
+        # We just created it, so failing to remove it IS a surprise - and a probe
+        # that leaves litter behind should not do it quietly (convention 30).
+        # Imported here, not at the top: crashlog imports this module.
+        from . import crashlog
+        crashlog.note(_exc, "paths")
+    return True
+
+
 def _same_directory(a, b):
     return os.path.normcase(os.path.abspath(a)) == os.path.normcase(os.path.abspath(b))
 

--- a/tests/test_driver_windows.py
+++ b/tests/test_driver_windows.py
@@ -469,3 +469,54 @@ def test_every_open_failure_hint_is_a_key_both_languages_define():
         missing = sorted(k for k in driver.OPEN_ERROR_HINTS.values() if k not in texts)
         check(f"lang/{code}.json defines every open-failure hint", not missing,
               f"({missing})")
+
+
+def test_doctor_says_when_anything_running_as_you_could_replace_the_driver(monkeypatch):
+    """The program elevates itself and THEN loads WinDivert.dll from its own folder.
+
+    A folder that can be written without administrator rights therefore turns "code
+    as the user" into "code as Administrator", while the UAC prompt shows a signed,
+    trusted executable. Measured 2026-08-26: that is the DEFAULT WinGet install for
+    this package (portable, user scope, under %LOCALAPPDATA%) and any archive
+    unpacked in the profile - not a corner case somebody has to arrange.
+
+    Three answers, and the third is the one worth having a test for: "I could not
+    check" must not print as a clean bill of health.
+    """
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_frozen", lambda: True)
+    monkeypatch.setattr(driver, "installed_drivers", lambda: {})
+    monkeypatch.setattr(driver, "executable_dir", lambda: "C:" + chr(92) + "somewhere")
+
+    def row_when(admin, writable):
+        monkeypatch.setattr(driver, "is_admin", lambda: admin)
+        monkeypatch.setattr(driver, "directory_is_writable", lambda _p: writable)
+        _, checks = driver.doctor()
+        return next(c for c in checks if c[0] == "program folder")
+
+    warn = row_when(admin=False, writable=True)
+    check("doctor: a writable program folder is a warning", warn[1] == "warn", f"({warn})")
+    check("doctor: and it says what to do about it",
+          "--scope machine" in warn[2], f"({warn})")
+
+    fine = row_when(admin=False, writable=False)
+    check("doctor: a protected folder passes", fine[1] == "ok", f"({fine})")
+
+    elevated = row_when(admin=True, writable=True)
+    check("doctor: 'checked while elevated' is not a pass", elevated[1] == "warn",
+          f"({elevated})")
+    check("doctor: and it says how to get the real answer",
+          "WITHOUT administrator" in elevated[2], f"({elevated})")
+
+
+def test_doctor_does_not_ask_the_question_from_a_source_checkout(monkeypatch):
+    """From sources the folder is a checkout its owner writes by definition, and the
+    driver comes out of site-packages rather than from next to an exe. A row that is
+    trivially true teaches people to skim the report."""
+    monkeypatch.setattr(driver, "is_windows", lambda: True)
+    monkeypatch.setattr(driver, "is_frozen", lambda: False)
+    monkeypatch.setattr(driver, "installed_drivers", lambda: {})
+    _, checks = driver.doctor()
+    check("doctor: no program-folder row when running from sources",
+          not [c for c in checks if c[0] == "program folder"],
+          f"({[c[0] for c in checks]})")

--- a/tests/test_driver_windows.py
+++ b/tests/test_driver_windows.py
@@ -502,6 +502,10 @@ def test_doctor_says_when_anything_running_as_you_could_replace_the_driver(monke
     fine = row_when(admin=False, writable=False)
     check("doctor: a protected folder passes", fine[1] == "ok", f"({fine})")
 
+    unknown = row_when(admin=False, writable=None)
+    check("doctor: a folder that could not be probed is not a pass either",
+          unknown[1] == "warn", f"({unknown})")
+
     elevated = row_when(admin=True, writable=True)
     check("doctor: 'checked while elevated' is not a pass", elevated[1] == "warn",
           f"({elevated})")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -72,6 +72,15 @@ MUTATIONS = [
         "test": "test_start_only_fields_are_locked_while_a_session_runs",
     },
     {
+        # "I could not check" printing as a clean bill of health - the same lie the
+        # WinDivert row was fixed for, one check further down.
+        "label": "doctor: an unchecked program folder reports as a pass",
+        "file": "beantester/driver.py",
+        "old": '    if is_admin():\n        return ("program folder", "warn",',
+        "new": '    if is_admin():\n        return ("program folder", "ok",',
+        "test": "test_doctor_says_when_anything_running_as_you_could_replace_the_driver",
+    },
+    {
         # The hand-rolled quoting, restored exactly as it shipped: an argument
         # ending in a backslash escapes its own closing quote.
         "label": "winenv: relaunch quoting goes back to wrapping each argument",

--- a/tests/test_user_data_location.py
+++ b/tests/test_user_data_location.py
@@ -192,3 +192,26 @@ def test_an_unusable_data_directory_does_not_stop_the_program(tmp_path, monkeypa
 
     check("startup gets a problem to log instead of an exception",
           len(problems) == 1 and problems[0], f"({problems})")
+
+
+def test_the_write_probe_answers_for_the_token_that_asks(tmp_path):
+    """`directory_is_writable` is a probe, not a reading of the access list.
+
+    Reading the ACL would mean deciding which principals count as "an ordinary
+    user" - which is the question, not the answer. A write that succeeds is the
+    answer, for exactly the token doing the asking, and that is what `--doctor`
+    needs: it runs unelevated, so what it can write is what the user can write.
+
+    The two portable cases are here. "Not writable" is not: `chmod` genuinely
+    blocks a write on POSIX while on Windows it only toggles the read-only bit and
+    the directory stays writable, so a test for it would assert one thing on one
+    runner and nothing on the other. `test_driver_windows.py` covers that half
+    where it matters, by giving `doctor()` the answer instead of the filesystem.
+    """
+    check("a directory this process owns is writable",
+          paths.directory_is_writable(str(tmp_path)) is True)
+    check("a path that is not a directory cannot be answered, not guessed",
+          paths.directory_is_writable(str(tmp_path / "nope")) is None)
+
+    leftovers = [p.name for p in tmp_path.iterdir()]
+    check("the probe leaves nothing behind", not leftovers, f"({leftovers})")

--- a/tests/test_user_data_location.py
+++ b/tests/test_user_data_location.py
@@ -215,3 +215,21 @@ def test_the_write_probe_answers_for_the_token_that_asks(tmp_path):
 
     leftovers = [p.name for p in tmp_path.iterdir()]
     check("the probe leaves nothing behind", not leftovers, f"({leftovers})")
+
+
+def test_a_directory_that_refuses_the_write_is_answered_false(monkeypatch):
+    """The refusal is the interesting answer, and the filesystem cannot be asked
+    for it portably: ``chmod`` genuinely blocks a write on POSIX, while on Windows
+    it only toggles the read-only bit and the directory stays writable. So the
+    refusal is injected at the one call that can produce it, and the assertion is
+    that it becomes ``False`` - not an exception, and not the ``None`` that means
+    "there is nothing here to check"."""
+    def refuse(*_a, **_kw):
+        raise PermissionError("Access is denied")
+
+    monkeypatch.setattr("builtins.open", refuse)
+    answer = paths.directory_is_writable(os.path.dirname(os.path.abspath(__file__)))
+    monkeypatch.undo()
+
+    check("a directory that refuses the write is not writable", answer is False,
+          f"({answer!r})")


### PR DESCRIPTION
The last two audit findings, both decided rather than designed: report the risk,
do not police it. **Stacked on donislawdev/BeanNetworkTester#157 and
donislawdev/BeanNetworkTester#158** - merge those first and the diff here shrinks
to its own two commits.

## The program folder, and where the audit was wrong

The audit's first version assumed WinGet and Chocolatey both install into protected
locations, and that only a loose zip was exposed. That was wrong about the
**recommended** path. Measured with `icacls` on a real machine, against this
project's own manifest and Microsoft's documentation:

| How you installed it | Folder | Writable without admin rights |
|---|---|---|
| `winget install` (default) | `%LOCALAPPDATA%\Microsoft\WinGet\Packages\` | **yes** |
| `winget install --scope machine` | `%PROGRAMFILES%\WinGet\Packages\` | no |
| Chocolatey | `C:\ProgramData\chocolatey\lib\` | no |
| Zip unpacked in the profile | wherever it went | **yes** |

The manifest is `InstallerType: zip` + `NestedInstallerType: portable`, which is a
user-scope install; Microsoft documents its default root as `%LOCALAPPDATA%`. The
program asks for administrator rights and *then* loads `WinDivert.dll` from that
folder, so anything running as the user can leave a DLL there for the elevated copy
to load - while the UAC prompt shows a signed, trusted executable.

That is what a user-scope install IS, not a defect of this program. But this program
is the one that elevates, so it is the one that should say so.

* `--doctor` gains a `program folder` row, from a real write probe rather than an ACL
  walk. Reading the access list would mean deciding which principals count as "an
  ordinary user" - which is the question, not the answer. A write that succeeds
  answers it for exactly the token doing the asking.
* Which is why the row cares about elevation, and why **"not checked" is a warn and
  not an ok**. An unanswered question must not print as a clean bill of health -
  the rule the `windivert driver` row already lives by.
* The row is skipped from a source checkout: there the folder is a checkout its owner
  writes by definition, and the driver comes from site-packages. A trivially-true row
  only teaches people to skim the report.
* `SECURITY.md` gains the table and the `--scope machine` recommendation.

**Deliberately not done**, and the reasons are worth keeping: a warning before every
elevation would fire on every start of a default install, which teaches people to
click through; verifying the DLL signature puts new code on the session-start path
and creates a new failure class the day pydivert ships a differently-signed build.

The three lines a user can actually see:

```
WARN  program folder  ...\WinGet\Packages\BeanNetworkTester - writable without
      administrator rights: anything running as you can replace the files this
      program loads when it elevates. Installing with 'winget install --scope
      machine' avoids this
OK    program folder  ... - not writable without administrator rights
WARN  program folder  ... - not checked: this run is already elevated, so a
      successful write says nothing about an ordinary user. Run --doctor WITHOUT
      administrator rights to check it
```

## What a crash file contains

`.github/ISSUE_TEMPLATE/bug_report.yml` asked people to attach a file from
`crashes/` to a **public** issue. That file records `sys.argv[1:]`, the settings
(the process you targeted, the address and port you aimed at) and tracebacks whose
paths carry your user name. Nothing said so.

It now does - one sentence, before the ask. Not a redaction mode: that would add
code and a judgement call about what to strip while leaving the report useful. This
repository already enforces the same rule machine-side for its own commits
(`tools/check_public_text.py`); this points it at what we ask users to send.

## Verification

* One registry mutation, `caught`: "doctor: an unchecked program folder reports as a
  pass".
* Diff coverage measured on Linux **before** pushing: it came back at **78%**, under
  the gate, and it was right - the "cannot write" answer and the "could not check"
  answer both had no test. Both now have one, on their own merit; 89% after.
* `--doctor` run for real on this machine (the row is correctly absent from a source
  checkout) and all three rendered lines read back.
* `ruff`, `mypy`, `smoke_gui.py`, and the guards around the driver, paths, the CLI
  runtime, code shape, hygiene and the repo conventions. `SECURITY.md` and the
  template are checked by the docs guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
