### PR TITLE
docs(readme): say what --doctor checks now, and when a scenario is validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ ranges, `!`, `>`, `<`, `>=`, `<=`, wildcards, `re:`, and `--dst-ip` additionally
 | `--print-config` | print the effective settings (after `defaults < file < preset < flags`) as JSON and exit |
 | `--min-packets N` | exit with code `6` if fewer than N packets were caught |
 | `--fail-on-no-traffic` | shorthand for `--min-packets 1` - **catches a filter that caught nothing** |
-| `--doctor` | check the environment (admin, `pydivert`, WinDivert driver state, `%TEMP%` leftovers) and exit |
+| `--doctor` | check the environment (admin, `pydivert`, WinDivert driver state, `%TEMP%` leftovers, whether the program folder can be written without admin rights) and exit |
 | `--cleanup-driver` | unload a stuck WinDivert driver (frees the locked `.sys` file **without a system restart**) and exit |
 
 Precedence order: **defaults < `--config` < `--preset` < flags**. Full list:
@@ -823,8 +823,10 @@ BeanNetworkTester.exe --simulate --scenario scenarios/cafe-wifi.json
 
 The seed guarantees identical **per-packet decisions** for the same packet sequence. Scenario steps
 are cumulative (each patches the state), and `action: reset_tcp` tears down TCP connections at that
-moment. The scenario file is **validated** - random JSON ends
-with a readable error, not a "scenario with 0 steps".
+moment. The scenario file is **validated when you open it** - random JSON ends with a readable
+error, not a "scenario with 0 steps", and a step's settings are checked by the same rules the
+form uses, so a value the program cannot use is named with its step number instead of stopping
+the run halfway through.
 
 Every CLI run ends by printing the **effective seed** and a ready command to reproduce it, and
 `--repro-out file.json` saves the full reproduction report.

--- a/README.pl.md
+++ b/README.pl.md
@@ -617,7 +617,7 @@ BeanNetworkTester.exe --simulate --duration 30 --format json > run.ndjson
 | `--print-config` | wypisz efektywne ustawienia (po `domyślne < plik < preset < flagi`) jako JSON i wyjdź |
 | `--min-packets N` | zakończ kodem `6`, jeśli złapano mniej niż N pakietów |
 | `--fail-on-no-traffic` | skrót na `--min-packets 1` - **łapie filtr, który nie złapał niczego** |
-| `--doctor` | sprawdź środowisko (admin, `pydivert`, stan sterownika WinDivert, resztki w `%TEMP%`) i wyjdź |
+| `--doctor` | sprawdź środowisko (admin, `pydivert`, stan sterownika WinDivert, resztki w `%TEMP%`, czy do folderu programu da się pisać bez praw administratora) i wyjdź |
 | `--cleanup-driver` | wyładuj zawieszony sterownik WinDivert (uwalnia zablokowany plik `.sys` **bez restartu systemu**) i wyjdź |
 
 Kolejność pierwszeństwa: **domyślne < `--config` < `--preset` < flagi**.
@@ -676,7 +676,10 @@ BeanNetworkTester.exe --simulate --scenario scenarios/cafe-wifi.json
 Seed gwarantuje identyczne **decyzje na pakiet** dla tej samej sekwencji pakietów.
 Kroki scenariusza są kumulatywne (każdy nakłada łatkę na stan), a `action: reset_tcp`
 zrywa w danym momencie połączenia TCP. Plik scenariusza
-jest **walidowany** - losowy JSON kończy się czytelnym błędem, a nie „scenariuszem z 0 kroków”.
+jest **walidowany przy otwarciu** - losowy JSON kończy się czytelnym błędem, a nie „scenariuszem
+z 0 kroków”, a wartości ustawień w kroku sprawdzane są tymi samymi regułami co formularz, więc
+wartość, której program nie umie użyć, jest nazwana razem z numerem kroku, zamiast przerywać
+przebieg w połowie.
 
 Każdy przebieg CLI kończy się wypisaniem **efektywnego seeda** i gotowej komendy do odtworzenia,
 a `--repro-out plik.json` zapisuje pełny raport reprodukcji.


### PR DESCRIPTION
Two corrections found by walking every checkable claim in the `.md` files after
the three security merges.

* Both READMEs **enumerate** what `--doctor` looks at, and the list had gone one
  item short: the program-folder check from
  donislawdev/BeanNetworkTester#159 landed without it. Nothing guards that
  parenthetical - which is exactly where prose drift hides.
* The scenario paragraph was true but understated. It promised that random JSON
  ends with a readable error; since a step's settings are validated too, it now
  says when that happens and what it buys you when it fails - the step number,
  instead of a run that stops halfway through.

## What else the sweep found, and why it stays

Named tests, quoted mutation labels and `module.function()` symbols were checked
across `README.md`, `README.pl.md`, `SECURITY.md`, the changelogs and the private
notes. Everything in `[Unreleased]` resolves. The only other hits - a renamed test
and a renamed helper - are in **released** changelog sections, and those stay: a
changelog records what was true when it was written, and correcting it would
falsify the record rather than fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)