### PR TITLE
fix(ci): let a bot sign-off through the public-text guard

### DIFF
--- a/tests/test_public_text_guard.py
+++ b/tests/test_public_text_guard.py
@@ -74,8 +74,46 @@ def test_the_scanner_passes_text_that_is_actually_fine(tmp_path):
     code, output = _scan(
         "Declare full prototypes for the window manager calls.\n"
         "Measured 5098 KB/s against a 5000 KB/s limit.\n"
-        "Co-authored-by: Someone <someone" + AT + "example.invalid>\n", tmp_path)
+        "Co-authored-by: Someone <someone" + AT + "example.invalid>\n"
+        "Signed-off-by: Someone <someone" + AT + "example.invalid>\n", tmp_path)
     check("clean text passes", code == 0, f"({output.strip()[:120]!r})")
+
+
+def test_a_bot_sign_off_does_not_stop_a_dependency_bump(tmp_path):
+    """The trailer Dependabot writes, in the shape it writes it.
+
+    Every commit it authors ends with a sign-off naming a GitHub address, so the
+    address rule stopped a required check on a line neither we nor the bot can
+    edit - measured on the merge commit of an earlier bump, which reported "an
+    email address" for exactly that line and nothing else.
+
+    The address is assembled rather than spelled out, like every other one in this
+    file: the rule that a leak detector may not contain what it hunts for does not
+    get an exception for the address that made us widen it.
+    """
+    trailer = ("Signed-off-by: dependabot[bot] <support" + AT + "github.com>")
+    code, output = _scan(
+        "chore(deps): bump the github-actions group with 2 updates\n\n"
+        + trailer + "\n"
+        "Co-authored-by: dependabot[bot] <49699333+dependabot[bot]"
+        + AT + "users.noreply.github.com>\n", tmp_path)
+    check("a bot sign-off passes", code == 0, f"({output.strip()[:120]!r})")
+
+
+def test_the_same_address_in_prose_is_still_caught(tmp_path):
+    """What the widening must NOT buy: an address anywhere but in a trailer.
+
+    A rule relaxed by shape has to be shown to still refuse the shape next door,
+    or "we allow trailers" quietly becomes "we allow addresses".
+    """
+    code, output = _scan(
+        "Write to support" + AT + "github.com if the bump looks wrong.\n", tmp_path)
+    check("the same address in a sentence is caught", code != 0,
+          f"({output.strip()[:120]!r})")
+    code, output = _scan(
+        "Signed-off-by: someone" + AT + "example.invalid\n", tmp_path)
+    check("a sign-off without the angle brackets is not a trailer", code != 0,
+          f"({output.strip()[:120]!r})")
 
 
 def test_a_literal_from_the_private_list_is_caught_without_being_printed(tmp_path):

--- a/tools/check_public_text.py
+++ b/tools/check_public_text.py
@@ -83,15 +83,24 @@ PRIVATE = (
     (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "a private key"),
 )
 
-# Co-author trailers carry an address by design. Matched by SHAPE rather than by
-# spelling the address out: a literal here would be an address in the public tree,
+# Git trailers carry an address by design. Matched by SHAPE rather than by
+# spelling any address out: a literal here would be an address in the public tree,
 # which is the thing this script exists to keep out of it.
 #
 # Case-insensitive because git trailers are, and because GitHub proves it: a
 # squash merge rewrites "Co-Authored-By" as "Co-authored-by", so the first version
 # of this line passed on every branch and then flagged the merge commit it had
 # just approved. Only running it over master found that.
-ALLOWED_LINE = re.compile(r"^co-authored-by: .+ <[^>]+>$", re.I)
+#
+# Sign-off joined co-authorship for a measured reason: Dependabot ends every commit
+# it writes with a Signed-off-by trailer naming a GitHub address, so the next
+# dependency bump would have stopped on a required check for a line neither we nor
+# the bot can edit. Widening this is a real trade and worth saying out loud: any
+# address now passes inside a sign-off line, a maintainer's private one included.
+# That is the same hole co-authorship already had, and both are trailers whose
+# entire purpose is to publish an identity - which is precisely why an address in
+# ordinary prose is still caught.
+ALLOWED_LINE = re.compile(r"^(co-authored-by|signed-off-by): .+ <[^>]+>$", re.I)
 
 # -- this machine's own strings, kept OUT of this file ------------------------ #
 #


### PR DESCRIPTION
## What and why

Dependabot ends every commit it writes with a `Signed-off-by` trailer naming a
GitHub address. The allowed-line rule in `tools/check_public_text.py` knew only
`Co-authored-by`, so the address rule fired on a line neither we nor the bot can
edit, on a required check.

That is not hypothetical, and it is not one PR. Every open dependency bump is
sitting on the same red check right now, with the same one-line report:

```
This text becomes public and stays public. Fix before pushing:
  commit ea081513 line 16: an email address
```

Four of them: #162, #163, #164, #165. With this branch checked out, the scanner
run over each of those four commits reports clean.

## The change

Both trailers are matched, by SHAPE, so no address is written into this repository
in order to allow one - the same reason the module builds its dashes from code
points and the canary assembles its examples.

The trade is worth stating rather than discovering later: any address now passes
inside a sign-off line, a maintainer's own included. That is the hole
co-authorship already had, and both are trailers whose entire purpose is to
publish an identity. An address anywhere else is still caught.

## The canary

The bot's trailer is added as a passing case, and two refusals go in beside it:

- the same address in ordinary prose still fails
- a sign-off without angle brackets is not a trailer and still fails

A rule relaxed by shape has to be shown to still refuse the shape next door, or
"we allow trailers" quietly becomes "we allow addresses".

## Verification

- [x] `python -m pytest tests/test_public_text_guard.py`
- [x] `ruff check` on both changed files
- [x] The scanner, over the merge commit that first showed this and over all four
      open bump PRs: clean
- [ ] Full suite left to CI, on both runners

No version bump, no dependency change, no product code touched.
