### PR TITLE
chore(deps): raise the pinned tooling, and name PyInstaller in the licence gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
       # found at PR time is cheaper than one found while publishing. Syft is pinned
       # by SHA; the tag it stood at is in the comment.
       - name: Scan the bundle and hold the licence registry to it
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26  # v0.24.2
         with:
           path: dist/BeanNetworkTester
           format: syft-json

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -96,7 +96,7 @@ jobs:
       # Ask for what you want in the comment - "@claude review this" for the whole
       # change, or a narrower question when only one part worries you.
       - name: Answer the comment
-        uses: anthropics/claude-code-action@e5ad3c7725bc2459721893f88879fef9dbcf97b0  # v1.0.202
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10  # v1.0.210
         with:
           # The subscription token, not an API key: runs bill against the
           # maintainer's Claude subscription instead of opening a second meter.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -70,6 +70,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to the Security tab
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           sarif_file: results.sarif

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -49,19 +49,19 @@
 #     python tools/pin_hashes.py requirements-build.txt
 #
 # And then do what the note above already says: build the exe and launch it.
-pyinstaller==6.22.1 \
-    --hash=sha256:0f257d6329d90def6b96f3ad9b601f4e10e549017d2ad09e730f4a9741b42138 \
-    --hash=sha256:10d009ac9ddf17b57dbfe22a453363a02be4cb0d5bd8a119ba59ef530b936296 \
-    --hash=sha256:1df884760a6efc4cc9bdcd48899f1382c072ab499bb16ed0b03606f8f10380c6 \
-    --hash=sha256:3b654721a9fa13abdd8a3a8e266debf750a6f50115d17addc54e3269dc944e75 \
-    --hash=sha256:4e7ed495fccb9974d47cf72ef8cffc92afa05d60bc265c5585a68f3d229ca8d1 \
-    --hash=sha256:9fe5d028023073b63c3e396e145c68a9c3382ab59889c749c4c248126d313945 \
-    --hash=sha256:bb7a405ef0fbea9b20b7312484d2766d2aa157026a0406a8e7ce63a573748eae \
-    --hash=sha256:bc964609e73f32f79b4c967d1c29a05f913629fcf54b3752ec6ec82bf17cffdd \
-    --hash=sha256:bf5f4634b18add9381caa73bd1656a1f0736839aa41ca750fbd511116d5ae2ca \
-    --hash=sha256:c5d7859b59c17f5c28973eb683e2236abb7a6eed1a7f354dc7f65ee3a7dff8ab \
-    --hash=sha256:d519a5549bf560407a9cffa8547f278e79c1093dc1cade6d9658c67b650d66c4 \
-    --hash=sha256:ff3c51c1a3b793d1917f75d0f5f31ef8bd889c0accc8478d604bbcc363fcb74b
+pyinstaller==6.22.2 \
+    --hash=sha256:0260eaad6be3f6fbc1affffe6dc7b8e5b636dbca51b463224daba971610b6fc1 \
+    --hash=sha256:06d7b3827a8049db4a2d47e3ec4ae2f69a1041577d8833b8f169745cde573ab4 \
+    --hash=sha256:7bee432404eca5dc3ef37c36811c266561b03988f6d3e70ab0fa5352dd5de9e4 \
+    --hash=sha256:89b65a3ad07d9dd5832253e37bc45f31872d10d7f9d5c9fd0fdd6088a83829dd \
+    --hash=sha256:8c2c4b14caad38c1f3df8e9bf5276fc265e27fe8b4180cab4a37864288427bc0 \
+    --hash=sha256:9622686ecc5d5fa492fe6cde29d47df9dd41138cff8177be9f901ca3260f2096 \
+    --hash=sha256:9a078877caa3920558a3242d0a7019fe5b825cff4b65ed380c7d1e1bd200ddd9 \
+    --hash=sha256:9b990fa6bbe143572f06644a984ad0d7aa2e2ccc6929d4916031343a5888e9a7 \
+    --hash=sha256:afb6f9a95d19b6dcd3a7decc40d9adb6ba9c4f8802ddd6c972dfb552953f384e \
+    --hash=sha256:becb47ad78272bede87acf2ed830d7545a8f65ab11d06a68fe2b99ba1afaac6d \
+    --hash=sha256:ebd1b1ca932d7cf25d7366ce691aaf79a5ff9425811ed7328b5116e4471b6d6d \
+    --hash=sha256:f5ccb847451df4207bce18bf53a57b124c9bb4e7e4bad08c5ecc627bcf00b28c
 altgraph==0.17.5 \
     --hash=sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7 \
     --hash=sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597
@@ -71,9 +71,9 @@ packaging==26.3 \
 pefile==2024.8.26 \
     --hash=sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632 \
     --hash=sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f
-pyinstaller-hooks-contrib==2026.6 \
-    --hash=sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725 \
-    --hash=sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3
+pyinstaller-hooks-contrib==2026.7 \
+    --hash=sha256:24257a04c7a5a7a034cf28e39dcee20fbeeb9f043076729480f2e1b69904408a \
+    --hash=sha256:5fbcaacb22c4f4aac869a127dce283f67a4b4cfcc37d496f2446603e6d68aefa
 pywin32-ctypes==0.2.3 \
     --hash=sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8 \
     --hash=sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -27,25 +27,25 @@
 # Raise these by hand, deliberately, and read the release notes when you do: a new
 # ruff minor may add rules to a family we select, and that is a decision about what
 # blocks a pull request, not a routine bump.
-ruff==0.16.4 \
-    --hash=sha256:05d9d27a18c4bcbefada602480ec9e01e0bc949d432e0ced5df77edac195919c \
-    --hash=sha256:0c95538517af68004306b0fb3214ff2f2af67a65092aee77cd9eb86db6656604 \
-    --hash=sha256:13171aa9d9af2240ee3504e639de73122c67e74036de5ba2e1d01422cd17e3dc \
-    --hash=sha256:312769988007aaeb8e189b443ccdd03c0e6374489e053467be6d96518ebff76e \
-    --hash=sha256:32a5057c7ff3f6e6480a48fccfb3a412a690f48a3d03ac5cf08177d6c2da3ade \
-    --hash=sha256:3817b87dbcabc92f13b05019257c5b89b5b4d51b5fb20f56fb5235ceb723cd07 \
-    --hash=sha256:6baaf984aa7976edf93d3b627fe2d1d22ee94bbca05fa6f90fc76d73924e3454 \
-    --hash=sha256:7dc651db49283c69f8e72c834eec4fe5573e4c646856aebece0ce385dceb2a80 \
-    --hash=sha256:8528bf9a4b291a60bf02ea453511e8ce6215bd2b982ee80405b66b008b6c30a0 \
-    --hash=sha256:963f83df8e69e575b64d67dd447ebbc917db41a14bf38d4593a4183e7aaa8255 \
-    --hash=sha256:a3a61621c9b6f6a89573e938a080e648f1695baa3f58570a3a707bc51ff65a21 \
-    --hash=sha256:b3dce8d9b0c57c265b91885a66a567d8ea1372e8eb4e250fa8e5e3f579e99cff \
-    --hash=sha256:b66b02cb9b04f537643cadf5768e5f98dc461890d530cb67113d71c8c76e605d \
-    --hash=sha256:bdfcf0b28662eb890372d50f92c283bb94e67e7635ed93c7fd533970acff7b2b \
-    --hash=sha256:df4075f71ddac40b9934af60c3ec8a53047dd5a5fdc43224e6e4e8e9a27cb6f7 \
-    --hash=sha256:e9fce1499134b2c8c68e5166f95705a5812062bb93aacc5f9873bb1a27084bc7 \
-    --hash=sha256:f2d812e482f5a7e02eee26cd73d2a37ebbdf47d795ea63ba1b89110ae93e9fb3 \
-    --hash=sha256:fbd85d2875fdd67e833213a651f613bbf25303abf6aa822a5121f4531195678d
+ruff==0.16.5 \
+    --hash=sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29 \
+    --hash=sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b \
+    --hash=sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b \
+    --hash=sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9 \
+    --hash=sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7 \
+    --hash=sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26 \
+    --hash=sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025 \
+    --hash=sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91 \
+    --hash=sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e \
+    --hash=sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea \
+    --hash=sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde \
+    --hash=sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb \
+    --hash=sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a \
+    --hash=sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f \
+    --hash=sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3 \
+    --hash=sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105 \
+    --hash=sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf \
+    --hash=sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef
 
 # Same pin, same reason: a mypy release can start reporting a class of error the
 # previous one did not, and that is a decision about what blocks a pull request.

--- a/requirements-scan.txt
+++ b/requirements-scan.txt
@@ -41,7 +41,7 @@
 # and vendoring is not open to us - the Semgrep Rules License permits use for our
 # own purposes and forbids redistributing the rules, which is what putting them in
 # a public repository would be.
-semgrep==1.173.0; sys_platform != "win32"
+semgrep==1.175.0; sys_platform != "win32"
 
 # The weekly audit of what we PIN. Not the same question as dependency-review,
 # which looks at what a pull request ADDS: this one asks whether an advisory has

--- a/tests/test_dependency_gate.py
+++ b/tests/test_dependency_gate.py
@@ -50,6 +50,32 @@ def test_gpl2_only_blocks_because_it_cannot_be_shipped_with_gpl3():
     check("GPL-2.0-only blocks", len(blocked) == 1 and blocked[0][0] == "denied", f"({blocked})")
 
 
+def test_an_exception_is_a_named_package_with_a_reason_beside_it():
+    """The escape hatch, and the two things that keep it from becoming a habit.
+
+    An entry is a NAME, so it can never widen `ALLOWED` for everything else: the
+    same licence on any other package still blocks, which is what separates "a
+    person looked at this one" from "we stopped checking". And a name with no
+    reason beside it is how a list like this rots - the next reader cannot tell a
+    decision from a way somebody once made a red build green.
+    """
+    for name in dependency_gate.EXCEPTIONS:
+        reason = str(dependency_gate.EXCEPTIONS[name] or "").strip()
+        check(f"the exception for {name} carries a reason", len(reason) > 20,
+              f"({reason!r})")
+
+    licence = "GPL-2.0-only AND GPL-2.0-or-later"      # what PyPI declares for it
+    blocked, passed = dependency_gate.split(
+        [_dep(name="pyinstaller", licence=licence)])
+    check("the named build tool passes", not blocked and len(passed) == 1,
+          f"(blocked={blocked})")
+
+    blocked, _passed = dependency_gate.split([_dep(name="something-else",
+                                                   licence=licence)])
+    check("the same licence on any other package still blocks",
+          len(blocked) == 1 and blocked[0][0] == "denied", f"({blocked})")
+
+
 def test_a_compound_expression_is_judged_by_its_worst_half():
     ok, _ = dependency_gate.split([_dep(licence="MIT OR Apache-2.0")])
     check("both halves allowed passes", not ok, f"({ok})")

--- a/tools/dependency_gate.py
+++ b/tools/dependency_gate.py
@@ -44,7 +44,25 @@ ALLOWED = frozenset({
 # looked at. A name here is a decision with a reason, not a way to make a red
 # build green - and it names the package, never a whole ecosystem.
 EXCEPTIONS = {
-    # (empty on purpose - add "name": "why this is fine" when it happens)
+    # PyPI declares "GPL-2.0-only AND GPL-2.0-or-later" for PyInstaller, and the
+    # rule above is right to stop on the first half. What that expression
+    # describes is a mixed source tree, not the terms this project distributes
+    # under, and the difference is the whole reason the exception exists:
+    #
+    #   * PyInstaller is a BUILD tool. It is never imported by the program and
+    #     never installed on a user's machine - it runs on a runner, in a job
+    #     whose output is an executable;
+    #   * the one piece of it that DOES reach a user is the bootloader, and that
+    #     carries the PyInstaller bootloader exception, which explicitly permits
+    #     building and distributing a program under the licence of that program's
+    #     own choosing. THIRD-PARTY-NOTICES.md has said so, in those terms, since
+    #     before this gate existed.
+    #
+    # So the blocking answer here would be right about the metadata and wrong
+    # about the obligation. Recorded on 2026-08-31, when the 6.22.2 bump was the
+    # first version to declare the expression this way.
+    "pyinstaller": "build tool, and the shipped bootloader carries the "
+                   "PyInstaller bootloader exception (THIRD-PARTY-NOTICES.md)",
 }
 
 


### PR DESCRIPTION
Supersedes #162 and #164, which land on versions this passes. #163 merged
while this was open, so ruff starts from 0.16.4 here.

## The licence gate

PyPI declares `GPL-2.0-only AND GPL-2.0-or-later` for PyInstaller as of 6.22.2, and
the gate is right to stop on the first half: `GPL-2.0-only` is absent from the
allowed set on purpose, because it is incompatible with this project's own licence.

What that expression describes is a mixed source tree, not the terms anything here
is distributed under. PyInstaller is a build tool - never imported, never installed
on a user's machine, run on a runner to produce an executable. The one piece that
does reach a user is the bootloader, and it carries the PyInstaller bootloader
exception, which permits exactly this. `THIRD-PARTY-NOTICES.md` has said so, in
those terms, since before the gate existed. Blocking here would be right about the
metadata and wrong about the obligation.

`EXCEPTIONS` was empty until now, and it gets its first guard at the same time: an
entry is a NAME, so the same licence on any other package still blocks, and an entry
with no reason beside it fails. A list of bare names is how one decision turns into
a habit.

## The bumps

| | from | to |
|---|---|---|
| ruff | 0.16.4 | 0.16.5 |
| semgrep | 1.173.0 | 1.175.0 |
| pyinstaller | 6.22.1 | 6.22.2 |
| pyinstaller-hooks-contrib | 2026.6 | 2026.7 |
| anchore/sbom-action | v0.24.0 | v0.24.2 |
| github/codeql-action | v4.37.8 | v4.37.9 |
| anthropics/claude-code-action | v1.0.202 | v1.0.210 |

Taken by hand rather than waiting for the proposals. Half of these were held only
by the seven-day cooldown, and skipping it is a decision rather than an oversight,
so it is made in the open and written down: the hold exists to close the window a
poisoned release would use.

## How each half was checked

- The two hash-checked files were rewritten with `tools/pin_hashes.py`. The diff is
  exactly three blocks: nothing else in either closure moved. Both still install
  under `--require-hashes`.
- ruff was run over the repository at 0.16.5, in a throwaway environment so the
  machine keeps its pinned one. Both CI selections are clean and identical to the
  version it replaces, so the bump changes no verdict.
- The conflict #163 caused was resolved by taking the file from master and
  re-applying the bump, so the hashes here were fetched fresh rather than carried
  over from what this branch first wrote.
- semgrep installs on Linux only and is deliberately not run here. CI answers for
  that one, and it is the half most able to surprise: the pin fixes the engine while
  the rules come from the registry at scan time.
- Action SHAs were resolved through the API, with annotated tags dereferenced to the
  commit they point at, rather than copied off a release page. Every workflow still
  parses and the pinning guard passes.
- Nothing in the shipped tree hardcodes any of these versions, checked rather than
  assumed.

## Verification

- [x] `pytest tests/test_dependency_gate.py`, `tests/test_repo_conventions.py -k action`
- [x] `pip install --require-hashes --dry-run` on both hash-checked files
- [x] ruff 0.16.5 over the repository, both selections
- [x] every workflow parses
- [ ] semgrep and the Windows build left to CI, which is where both actually run

No version bump. No runtime dependency changed: `requirements.txt` is untouched.
