### PR TITLE
fix: eighteen stability findings, verified and measured before fixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   same collision could damage a profile file while it was being carried over. Each save now uses
   a temporary file of its own. Nothing changes for a single copy, which is the normal case.
 
+- **A crash while the program was closing could leave no report at all.** The part that records
+  a crash with no error message - the kind that just makes the program vanish - was switched off
+  a moment before the network capture was released, which is one of the places such a crash can
+  happen. It is now switched off last.
+
+- **A long session could fill the crash log with copies of one fault.** Repeated faults are
+  counted rather than written out again, but that stopped working once the program had seen a
+  great many different ones: from then on, anything new was written to the log on every single
+  occurrence. It now keeps counting the faults that are actually happening and forgets the
+  oldest ones instead.
+
 - **Saving could close the program instead of reporting a problem.** A value that cannot be
   written to a settings or profile file used to escape as a crash rather than an error message.
   It is now reported the same way every other bad save already was.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Switching language left timers running against windows that no longer existed.** Changing
+  the language rebuilds the whole interface. The parts being replaced were never told, so the
+  connection table's refresh, the chart redraw and the field search were still scheduled against
+  widgets that had just been thrown away. They are now put away first.
+
+- **One glitch could bury you in error windows.** When something in the interface failed
+  repeatedly, and some things fail on every mouse move, each occurrence opened its own error
+  window to close by hand. You now get one window per problem. Repeats still go to the log and
+  the crash report, which is where the count of them lives.
+
+- **A failed start or stop could kill the START button for good.** If the work behind the button
+  ended in an unusual way, the program stayed convinced a start was still in progress, and START
+  and STOP did nothing for the rest of the session - possibly with the driver still loaded. The
+  outcome is now always reported back, so the button always comes back.
+
 - **A frozen capture could keep a session looking healthy forever.** The program already stops
   itself and hands the network back when the thread reading packets dies. A thread that is still
   alive but no longer doing anything looked fine to it, even though the effect on you is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   same collision could damage a profile file while it was being carried over. Each save now uses
   a temporary file of its own. Nothing changes for a single copy, which is the normal case.
 
+- **Changing settings mid-session could judge a packet by half the old settings and half the
+  new.** Applying settings - from "Apply changes", from the command line, or from a scenario step -
+  set roughly fifteen values one after another, and a packet that arrived in between was handled
+  by a mixture: the new loss with the old destination filter, say. The window was tiny, but a
+  scenario step is exactly where somebody is watching, and it also meant a run could not be
+  reproduced exactly from its seed. Settings now change as one. Process targeting is still applied
+  a moment afterwards, because working out which connections belong to a process means asking the
+  operating system, and nothing that slow may hold up the traffic being tested.
+
 - **When targeting a process, a closed connection could stay targeted after trouble reading the
   system's connection list.** The tool keeps a short list of connections it learned about between
   two scans so none is missed. That list was only ever cleared by a scan that worked, so if scans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A frozen capture could keep a session looking healthy forever.** The program already stops
+  itself and hands the network back when the thread reading packets dies. A thread that is still
+  alive but no longer doing anything looked fine to it, even though the effect on you is the
+  same: traffic piles up in the driver, the machine loses its connection and the window stops
+  responding. That state is now detected too, and it ends the session and releases the driver
+  the way any other failure does.
+
 - **A filter expression could freeze the whole program.** A regular expression in a target,
   address or port field runs on every packet. Some perfectly valid patterns take practically
   forever on ordinary input, and one of those stopped the capture: the machine quietly lost its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **A filter expression could freeze the whole program.** A regular expression in a target,
+  address or port field runs on every packet. Some perfectly valid patterns take practically
+  forever on ordinary input, and one of those stopped the capture: the machine quietly lost its
+  network and the window stopped responding, with no way out but Task Manager. The tool now tries
+  a pattern before accepting it, and refuses one that is too slow with a message saying why.
+  Patterns people actually write are unaffected.
+
 - **`--interval nan` ran forever at full CPU and printed nothing.** The report interval was
   checked only for being above zero, so `nan` and `inf` got through. With `nan` the run spun on a
   full processor core, printed no reports, and without `--duration` never ended. With `inf`, or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Two copies of the program running at once could damage your saved files.** Settings,
+  profiles and window state are written to a temporary file first and then swapped into place,
+  so a crash halfway through cannot leave half a file. The temporary file was named after the
+  one being saved, though, which meant two copies of the program saving at the same moment were
+  writing into the same temporary file - and one of them could end up saving a mixture of both.
+  The first copy is also what adopts your files from an older version on first start, so the
+  same collision could damage a profile file while it was being carried over. Each save now uses
+  a temporary file of its own. Nothing changes for a single copy, which is the normal case.
+
+- **Saving could close the program instead of reporting a problem.** A value that cannot be
+  written to a settings or profile file used to escape as a crash rather than an error message.
+  It is now reported the same way every other bad save already was.
+
 - **Exporting connections to CSV froze the window.** On a big table the export could take
   seconds, and during those seconds nothing responded - including STOP. It now runs in the
   background and tells you in the log when the file is written. A second click while one export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   same collision could damage a profile file while it was being carried over. Each save now uses
   a temporary file of its own. Nothing changes for a single copy, which is the normal case.
 
+- **A scenario could apply one more step after it was stopped.** Stopping a session or a scenario
+  asked the timeline to end and moved on without waiting, so it could still change the settings
+  once more - which showed up as a scenario line in the log after the session had already
+  stopped. Stopping now waits for it, and the wait is too short to notice.
+
 - **A crash while the program was closing could leave no report at all.** The part that records
   a crash with no error message - the kind that just makes the program vanish - was switched off
   a moment before the network capture was released, which is one of the places such a crash can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **`--interval nan` ran forever at full CPU and printed nothing.** The report interval was
+  checked only for being above zero, so `nan` and `inf` got through. With `nan` the run spun on a
+  full processor core, printed no reports, and without `--duration` never ended. With `inf`, or a
+  huge value like `1e18`, the session ended as an internal failure. The interval must now be
+  greater than 0 and at most 86 400 seconds, the same ceiling `--duration` has. A longer one
+  could never report even once, so it is refused with a clear message.
+
 - **`--doctor` now tells you whether your copy can be tampered with.** The program asks for
   administrator rights and then loads its network driver from its own folder, so a folder
   anyone can write to without those rights is worth knowing about. Run `--doctor` without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,31 +42,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
-- **Two copies of the program running at once could damage your saved files.** Settings,
-  profiles and window state are written to a temporary file first and then swapped into place,
-  so a crash halfway through cannot leave half a file. The temporary file was named after the
-  one being saved, though, which meant two copies of the program saving at the same moment were
-  writing into the same temporary file - and one of them could end up saving a mixture of both.
-  The first copy is also what adopts your files from an older version on first start, so the
-  same collision could damage a profile file while it was being carried over. Each save now uses
-  a temporary file of its own. Nothing changes for a single copy, which is the normal case.
+- **Two copies of the program running at once could damage your saved files.** Settings, profiles
+  and window state are written to a temporary file and then swapped into place, so a crash halfway
+  through cannot leave half a file. That temporary file was named after the one being saved, so two
+  copies saving at the same moment wrote into one and either could end up with a mixture. The same
+  collision could damage a profile carried over from an older version on first start. Each save now
+  uses a temporary file of its own.
 
-- **Changing settings mid-session could judge a packet by half the old settings and half the
-  new.** Applying settings - from "Apply changes", from the command line, or from a scenario step -
-  set roughly fifteen values one after another, and a packet that arrived in between was handled
-  by a mixture: the new loss with the old destination filter, say. The window was tiny, but a
-  scenario step is exactly where somebody is watching, and it also meant a run could not be
-  reproduced exactly from its seed. Settings now change as one. Process targeting is still applied
-  a moment afterwards, because working out which connections belong to a process means asking the
-  operating system, and nothing that slow may hold up the traffic being tested.
+- **Changing settings mid-session could judge a packet by half the old settings and half the new.**
+  Applying settings set about fifteen values one after another, so a packet arriving in between met
+  a mixture: the new loss with the old destination filter, say. The window was tiny, but a scenario
+  step is exactly where somebody is watching, and it meant a run could not be reproduced from its
+  seed. Settings now change as one. Process targeting still follows a moment later, because it
+  means asking the operating system which connections a process owns.
 
 - **When targeting a process, a closed connection could stay targeted after trouble reading the
-  system's connection list.** The tool keeps a short list of connections it learned about between
-  two scans so none is missed. That list was only ever cleared by a scan that worked, so if scans
-  kept failing it kept old entries - and once a scan finally succeeded, a connection that had
-  closed in the meantime could be treated as still belonging to the target. On Windows the port
-  it used may already belong to another program by then, so the wrong traffic could be affected.
-  The list is now cleared at the start of every scan, whether or not the scan succeeds.
+  system's connection list.** The tool keeps a short list of connections learned between two scans,
+  and only a scan that worked cleared it. If scans kept failing it held old entries, so once one
+  succeeded, a connection that had closed meanwhile could still count as the target's - and on
+  Windows its port may belong to another program by then. The list is now cleared at the start of
+  every scan.
 
 - **A scenario could apply one more step after it was stopped.** Stopping a session or a scenario
   asked the timeline to end and moved on without waiting, so it could still change the settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Fixed
 
+- **Exporting connections to CSV froze the window.** On a big table the export could take
+  seconds, and during those seconds nothing responded - including STOP. It now runs in the
+  background and tells you in the log when the file is written. A second click while one export
+  is still running is refused with a message instead of two exports fighting over the same file.
+
+- **Searching the connection table is about twice as fast.** With something typed in the search
+  box the table was filtered twice on every refresh, once for the rows and once for the totals
+  under them. Now it is filtered once. With an empty box nothing changes.
+
+- **The connection table could quietly stop updating.** If a refresh failed in an unusual way,
+  the table kept showing what it had and never rebuilt again for the rest of the session, with
+  no sign that anything was wrong. It now recovers on the next refresh.
+
 - **Switching language left timers running against windows that no longer existed.** Changing
   the language rebuilds the whole interface. The parts being replaced were never told, so the
   connection table's refresh, the chart redraw and the field search were still scheduled against

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   same collision could damage a profile file while it was being carried over. Each save now uses
   a temporary file of its own. Nothing changes for a single copy, which is the normal case.
 
+- **When targeting a process, a closed connection could stay targeted after trouble reading the
+  system's connection list.** The tool keeps a short list of connections it learned about between
+  two scans so none is missed. That list was only ever cleared by a scan that worked, so if scans
+  kept failing it kept old entries - and once a scan finally succeeded, a connection that had
+  closed in the meantime could be treated as still belonging to the target. On Windows the port
+  it used may already belong to another program by then, so the wrong traffic could be affected.
+  The list is now cleared at the start of every scan, whether or not the scan succeeds.
+
 - **A scenario could apply one more step after it was stopped.** Stopping a session or a scenario
   asked the timeline to end and moved on without waiting, so it could still change the settings
   once more - which showed up as a scenario line in the log after the session had already

--- a/README.md
+++ b/README.md
@@ -1281,7 +1281,8 @@ beantester/              the implementation package
   appinfo.py             app identity and version reader (one source: VERSION.txt)
   i18n.py  paths.py  utils.py  processes.py  synthetic.py  legal.py  scenario_runner.py
   gui/                   the tkinter interface
-    app.py               window composition, state, log, start/stop, dirty-state
+    app.py               window composition, state, start/stop, dirty-state
+    logview.py           the log box: its queue, its line buffer and its widget
     form.py              form generated from fields.FIELD_DEFS
     form_search.py       matching a typed query against the field registry (pure)
     scaling.py           DPI, scaled pixels, window/chart/tooltip geometry

--- a/README.md
+++ b/README.md
@@ -767,7 +767,7 @@ ranges, `!`, `>`, `<`, `>=`, `<=`, wildcards, `re:`, and `--dst-ip` additionally
 | `--seed N` | randomness seed - the same run can be repeated |
 | `--duration N` | **run time in seconds** (0 = until Ctrl+C, or until a `--scenario` timeline runs out). The same field is in the GUI ("Session") |
 | `--row-limit N` | a **GUI-only** setting: max rows in the tables (0 = no limit, default 50 000). In headless CLI (no window) it does nothing - it is only saved to the config file and takes effect when that config is opened in the GUI. The "Row limit" field's equivalent |
-| `--interval N` | how often to report, in seconds (must be > 0) |
+| `--interval N` | how often to report, in seconds (greater than 0, at most 86 400 - the same ceiling `--duration` has, so an interval that could never fire is refused instead of accepted) |
 | `--log-conns` | print the observed connections at the end |
 | `--repro-out FILE` | save a reproduction report (JSON) |
 | `--simulate` | synthetic traffic instead of WinDivert (test with no Windows, no driver, no admin) |

--- a/README.pl.md
+++ b/README.pl.md
@@ -613,7 +613,7 @@ BeanNetworkTester.exe --simulate --duration 30 --format json > run.ndjson
 | `--seed N` | ziarno losowości - ten sam przebieg da się powtórzyć |
 | `--duration N` | **czas pracy w sekundach** (0 = do Ctrl+C albo do końca osi czasu z `--scenario`). To samo pole jest w GUI (sekcja „Sesja”) |
 | `--row-limit N` | ustawienie **tylko dla GUI**: maks. wierszy w tabelach (0 = bez limitu, domyślnie 50 000). W samym CLI (bez okna) nic nie robi - jest jedynie zapisywane do pliku konfiguracji i działa dopiero, gdy ten config otworzysz w GUI. Odpowiednik pola „Limit wierszy” |
-| `--interval N` | co ile sekund raportować (musi być > 0) |
+| `--interval N` | co ile sekund raportować (więcej niż 0, najwyżej 86 400 - ten sam sufit co przy `--duration`, więc interwał, który i tak nigdy by nie wystrzelił, jest odrzucany zamiast przyjmowany) |
 | `--log-conns` | wypisz na końcu zaobserwowane połączenia |
 | `--repro-out PLIK` | zapisz raport reprodukcji (JSON) |
 | `--simulate` | sztuczny ruch zamiast WinDivert (test bez Windows, bez sterownika i bez admina) |

--- a/README.pl.md
+++ b/README.pl.md
@@ -1124,7 +1124,8 @@ beantester/              pakiet z implementacją
   appinfo.py             tożsamość aplikacji i odczyt wersji (jedno źródło: VERSION.txt)
   i18n.py  paths.py  utils.py  processes.py  synthetic.py  legal.py  scenario_runner.py
   gui/                   interfejs tkinter
-    app.py               kompozycja okna, stan, log, start/stop, dirty-state
+    app.py               kompozycja okna, stan, start/stop, dirty-state
+    logview.py           okno logu: jego kolejka, bufor linii i widget
     form.py              formularz generowany z fields.FIELD_DEFS
     form_search.py       dopasowanie wpisanego hasła do rejestru pól (czyste)
     scaling.py           DPI, skalowane piksele, geometria okna/wykresu/tooltipa

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -22,7 +22,7 @@ from .appinfo import APP_NAME, command_name, program_name, __version__
 from .clilog import CliLog
 from . import crashlog
 from .engine import BeanEngine
-from .fields import BOOL, FIELD_DEFS
+from .fields import BOOL, FIELD_DEFS, SECONDS
 from .filters import CLI_FILTERS
 from .i18n import T
 from .paths import is_frozen, user_data_dir
@@ -35,6 +35,13 @@ from .settings import (DEFAULT_SETTINGS, apply_settings, build_matchers,
                        range_errors, warn_if_unbounded)
 from .synthetic import SyntheticDivert
 from .utils import bytes_to_mb
+
+# The report cadence is bounded by the same ceiling as every other time value in
+# the program, taken from the registry rather than written down a second time -
+# a copy would drift the day somebody decides a run may last longer than a day.
+# See the comment beside the check in `config_from_args` for why it has a ceiling
+# at all.
+MAX_INTERVAL_S = SECONDS[1]
 
 
 class CliError(SystemExit):
@@ -217,7 +224,8 @@ def build_arg_parser():
                         "(the tables are virtualised, so this only bounds the "
                         "filter/sort work, not the rendering)")
     p.add_argument("--interval", type=float, default=2.0,
-                   help="report every N seconds [s] (must be > 0)")
+                   help=f"report every N seconds [s] "
+                        f"(greater than 0, at most {MAX_INTERVAL_S:g})")
     p.add_argument("--log-conns", action="store_true", help="print observed connections at the end")
     p.add_argument("--repro-out", help="save a reproduction report (JSON) to a file at the end")
     p.add_argument("--simulate", action="store_true",
@@ -345,9 +353,26 @@ def config_from_args(args):
         _fail(exitcodes.CONFIG, "; ".join(bad))
 
     interval = float(getattr(args, "interval", 2.0) or 0)
-    if interval <= 0:
-        # 0 used to mean "busy-loop at 100% CPU and spam the log"
-        _fail(exitcodes.CONFIG, "--interval must be greater than 0")
+    # BOTH ends, and the upper one is not tidiness. `--interval` is the only
+    # `type=float` flag that does not reach `range_errors` (it is not a field in
+    # `fields.py`, because a reporting cadence is not a setting - it changes
+    # nothing about the traffic and belongs in no profile), so it was the one
+    # numeric door in the program that took NaN and infinity. Measured 2026-09-02:
+    #   --interval nan   busy-loops at 100% CPU, prints no report, and without
+    #                    --duration never returns at all
+    #   --interval inf   OverflowError out of time.sleep, exit 1 reason=fault
+    #   --interval 1e18  the SAME OverflowError - time.sleep is int64 nanoseconds
+    #                    and gives up above ~9.223e9 s
+    # So a finiteness test would have closed two values out of a class. The bound
+    # closes the class, and 86400 is not a new number: it is `fields.SECONDS`, the
+    # ceiling every other time value here already lives under, including
+    # --duration. A report interval longer than the longest run this tool accepts
+    # cannot fire even once, which makes it a typo rather than a request.
+    # The lower end is older and stays: 0 used to mean "busy-loop at 100% CPU and
+    # spam the log", which is the same failure NaN turned out to be.
+    if not (0 < interval <= MAX_INTERVAL_S):
+        _fail(exitcodes.CONFIG,
+              f"--interval must be greater than 0 and at most {MAX_INTERVAL_S:g}")
 
     min_packets = int(getattr(args, "min_packets", 0) or 0)
     if getattr(args, "fail_on_no_traffic", False):

--- a/beantester/core.py
+++ b/beantester/core.py
@@ -10,9 +10,11 @@
 import random
 import threading
 import time
+from contextlib import contextmanager
 from typing import List, NamedTuple, Optional
 
-from .matchers import KIND_INT, KIND_IP, PORT_BOUNDS, parse_matcher, port_expression
+from .matchers import (KIND_INT, KIND_IP, PORT_BOUNDS, Matcher, parse_matcher,
+                       port_expression)
 from .utils import clamp01, is_lan_ip, is_local_ip
 
 
@@ -276,11 +278,56 @@ class _FlowTable:
         return key in self._new or key in self._old
 
 
+def compile_endpoint(ip, port):
+    """Compile an (ip, port) filter pair into matchers. NO LOCK IS HELD HERE.
+
+    One definition for both endpoint pairs the core carries - the destination
+    (:meth:`BeanCore.set_dest`) and the block list (:meth:`BeanCore.set_block`)
+    compile identically, and a second copy would drift at the first edit.
+
+    🔴 It is a MODULE-LEVEL function, and that is the point rather than tidiness.
+    Compiling an expression is the one part of applying settings that can take
+    real time - a pathological ``re:`` pattern is why ``matchers`` grew a time
+    budget - and it must never happen under ``BeanCore._lock``, because the
+    CAPTURE THREAD waits for whatever that lock holds (convention 20). Callers
+    that apply several settings at once (``settings.apply_settings``) call this
+    FIRST and hand the matchers in, so the batched apply holds the lock over
+    assignments only. MEASURED on this machine 2026-09-03: two benign expressions
+    cost 19.5 us median and 84 us at the worst, against 5.3 us for every
+    assignment in an apply put together - four times the whole batch, for input
+    that is not even trying.
+    """
+    # `port_expression` normalises a port field that may still hold a legacy
+    # NUMBER, and a compiled matcher is not one - passing it through would
+    # stringify it and hand `parse_matcher` text to compile all over again. Caught
+    # by test_an_apply_holds_the_core_lock_over_assignments_only, which counts
+    # real compilations rather than calls: without this line the batched apply
+    # recompiled both port expressions under the lock, which is precisely what
+    # hoisting the compilation out was for.
+    return (parse_matcher(ip, KIND_IP, "fields.ip"),
+            parse_matcher(port if isinstance(port, Matcher) else port_expression(port),
+                          KIND_INT, "fields.port", bounds=PORT_BOUNDS))
+
+
 class BeanCore:
     """Decide what to do with a single packet. No network dependency."""
 
     def __init__(self):
-        self._lock = threading.Lock()
+        # REENTRANT, so a caller applying a whole settings dict can hold the lock
+        # across every setter and no packet is judged by a mixture of the old
+        # configuration and the new one (see `batch`). Every setter below takes
+        # this lock on its own, so a batch that holds it would deadlock a plain
+        # Lock - which is the only reason this is an RLock.
+        #
+        # It is taken on EVERY packet in decide(), so the surcharge was measured
+        # rather than assumed, on every interpreter this project supports
+        # (2026-09-03, `with` statement, paired in one process): 3.11 0.99x,
+        # 3.12 1.02x, 3.13 1.15-1.19x (+16 to +19 ns, the worst), 3.14 1.03-1.06x.
+        # Against one decide() call at 1826 ns that is 0.3% on the interpreter CI
+        # runs and 1.0% on the worst one. The batch also REPLACES twelve separate
+        # acquire/release pairs with one, so the total time this lock is held
+        # during an apply goes down, not up.
+        self._lock = threading.RLock()
         # impairments
         self.loss = 0.0
         # Burst loss: the average length, in PACKETS, of a run of lost packets.
@@ -394,6 +441,38 @@ class BeanCore:
         if bps <= 0 and kbps > 0:
             bps = 1
         return max(0, bps)
+
+    @contextmanager
+    def batch(self):
+        """Hold the lock across several setters, so a packet sees ONE of them.
+
+        ``settings.apply_settings`` calls fourteen setters. Each took and released
+        this lock on its own, so a packet decided between two of them was judged
+        by a MIXTURE of the old configuration and the new: new loss with the old
+        destination gate, a new rate limit with the old schedule. It matters in
+        two places in particular - a scenario step, where the mixed window falls
+        exactly where the tester is looking, and reproducibility under ``--seed``,
+        where the mixture is not in the seed.
+
+        What it costs, and it is not what it looks like: the batch replaces twelve
+        separate acquire/release pairs with one, so the TOTAL time the lock is
+        held during an apply goes down. MEASURED 2026-09-03: 5.3 us median for
+        every assignment in an apply together (p99 15.9, max 25.8), against ~1.1 us
+        of pure lock overhead saved. For scale, ``portmap.refresh`` holds its own
+        lock ~18 us and that is the figure this project already accepted for the
+        capture thread.
+
+        🔴 **Nothing that can take real time may run inside this.** Compiling an
+        expression is the obvious one (:func:`compile_endpoint` exists so callers
+        can do it first) and resolving a process target is the other - that walks
+        the socket table, which this project has measured at 1.7 s cold. So
+        ``apply_settings`` leaves ``apply_targeting`` OUTSIDE the batch, and the
+        atomicity this offers is over the impairment parameters and the gates, not
+        over process targeting. A scenario step may legally carry ``target``, so
+        that boundary is real and is stated here rather than glossed.
+        """
+        with self._lock:
+            yield self
 
     def set_params(self, loss_pct, corrupt_pct, dup_pct,
                    latency_ms, jitter_ms, down_kbps, up_kbps):
@@ -512,10 +591,13 @@ class BeanCore:
 
         Raises a translated ``ValueError`` on a malformed expression; callers
         (GUI, CLI, ``apply_settings``) validate before applying.
+
+        ``ip``/``port`` may also be matchers that are already compiled, which is
+        how a batched apply keeps the compilation out from under the lock -
+        ``parse_matcher`` returns a ``Matcher`` unchanged, so this signature did
+        not have to grow a second form. See :func:`compile_endpoint`.
         """
-        ip_matcher = parse_matcher(ip, KIND_IP, "fields.ip")
-        port_matcher = parse_matcher(port_expression(port), KIND_INT, "fields.port",
-                                     bounds=PORT_BOUNDS)
+        ip_matcher, port_matcher = compile_endpoint(ip, port)
         with self._lock:
             self.dst_active = bool(active)
             # raw text is kept for summaries/reports; the matchers do the work
@@ -623,10 +705,10 @@ class BeanCore:
         part, so ``port='443'`` with no IP blocks 443 to any address rather than
         blocking everything. Raises a translated ``ValueError`` on a malformed
         expression; callers (GUI, CLI, ``apply_settings``) validate before applying.
+
+        Takes already-compiled matchers too, for the same reason as ``set_dest``.
         """
-        ip_matcher = parse_matcher(ip, KIND_IP, "fields.ip")
-        port_matcher = parse_matcher(port_expression(port), KIND_INT, "fields.port",
-                                     bounds=PORT_BOUNDS)
+        ip_matcher, port_matcher = compile_endpoint(ip, port)
         with self._lock:
             self.block_active = bool(active)
             self.block_ip = ip_matcher.raw

--- a/beantester/crashlog.py
+++ b/beantester/crashlog.py
@@ -64,7 +64,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from .appinfo import __version__
-from .paths import user_data_dir
+from .paths import temp_beside, user_data_dir
 
 CRASH_DIR_NAME = "crashes"
 LOG_NAME = "crashes.ndjson"
@@ -509,8 +509,13 @@ def breadcrumb(**state):
     payload["pid"] = os.getpid()
     payload["threads"] = [t.name for t in threading.enumerate()]
     path = os.path.join(directory, BREADCRUMB_NAME)
-    tmp = path + ".tmp"
+    # Unique per writer: two copies of the GUI both leave a breadcrumb, and they
+    # used to leave it through one `breadcrumb.json.tmp`. See paths.temp_beside -
+    # and note that this one is written from a TICK, so "two writers at the same
+    # moment" is not a corner case here, it is 1.4 chances a second.
+    tmp = None
     try:
+        tmp = temp_beside(path)
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
         os.replace(tmp, path)
@@ -520,7 +525,7 @@ def breadcrumb(**state):
         # a value json cannot serialise must not take the process down on the way
         # to describing a crash.
         try:
-            if os.path.exists(tmp):
+            if tmp and os.path.exists(tmp):
                 os.remove(tmp)
         except OSError:
             pass
@@ -542,7 +547,12 @@ def _cleanup_native():
     The breadcrumb goes the same way and for the same reason: it describes the
     state a native crash happened IN, so a clean exit means nobody wants it. Its
     ``.tmp`` is removed too - a process killed mid-write leaves one, and a stray
-    temp file would stop the directory from ever being cleaned up again.
+    temp file would stop the directory from ever being cleaned up again. That
+    sweep is by PREFIX rather than by one known name, because the temp file is now
+    unique per writer (``paths.temp_beside``): there is no single name left to
+    remove, and an orphan here is exactly the leftover the paragraph above says
+    must not survive. The old fixed name matches the same prefix, so a temp file
+    left behind by a version before this one is still cleaned up.
     """
     global _native_stream, _native_path, _breadcrumb_last
     try:
@@ -550,9 +560,15 @@ def _cleanup_native():
     except Exception:
         pass
     _breadcrumb_last = None
-    for name in (BREADCRUMB_NAME, BREADCRUMB_NAME + ".tmp"):
+    directory = crash_dir()
+    try:
+        stale = [n for n in os.listdir(directory)
+                 if n.startswith(BREADCRUMB_NAME) and n.endswith(".tmp")]
+    except OSError:
+        stale = []
+    for name in [BREADCRUMB_NAME, *stale]:
         try:
-            os.remove(os.path.join(crash_dir(), name))
+            os.remove(os.path.join(directory, name))
         except OSError:
             pass
     stream, path = _native_stream, _native_path
@@ -569,7 +585,6 @@ def _cleanup_native():
         except OSError:
             pass
     try:
-        directory = crash_dir()
         if os.path.isdir(directory) and not os.listdir(directory):
             os.rmdir(directory)
     except OSError:

--- a/beantester/crashlog.py
+++ b/beantester/crashlog.py
@@ -48,7 +48,10 @@ The two things that would break it at scale
 * **Duplicate storms.** A crash inside the tick loop fires 1.4 times a second,
   forever. Records are therefore FINGERPRINTED (exception type + the top frames)
   and counted, not appended: the tenth thousand occurrence of a bug costs one
-  integer, not another disk write.
+  integer, not another disk write. The table that holds those counters is bounded,
+  and it makes room by dropping the coldest fault rather than by refusing the
+  newest - refusing was the same thing as switching the de-duplication off for
+  whatever broke last.
 * **Unbounded disk.** The log rotates and is capped, so a program left running for
   a fortnight with a repeating fault cannot fill the volume it is diagnosing.
 """
@@ -60,6 +63,7 @@ import platform
 import sys
 import threading
 import traceback
+from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
@@ -82,7 +86,9 @@ ERROR = "error"
 DEBUG = "debug"
 
 _lock = threading.Lock()
-_seen: dict[str, dict] = {}         # fingerprint -> record (with a count)
+# Ordered because the order IS the eviction policy: freshest last, so the table
+# makes room by dropping the fault nobody has seen for longest. See _record.
+_seen: OrderedDict[str, dict] = OrderedDict()   # fingerprint -> record (+ a count)
 _context_provider = None            # set by the App/CLI: returns a dict of state
 _installed = False
 _enabled = True
@@ -211,6 +217,9 @@ def _record(exc, source, subsystem, severity, note):
         if existing is not None:
             existing["count"] += 1
             existing["last_seen"] = _now_iso()
+            # Freshest last. The eviction below drops the OTHER end of the table,
+            # and a fault firing right now is the last thing it may drop.
+            _seen.move_to_end(fingerprint)
             # A repeating fault (a crash inside the tick loop fires 1.4x a second)
             # costs one integer from here on - not another disk write.
             return existing
@@ -230,8 +239,28 @@ def _record(exc, source, subsystem, severity, note):
                 traceback.format_exception(exc_type, exc, tb))[:8000],
             "context": _collect_context(),
         }
-        if len(_seen) < MAX_RECORDS:
-            _seen[fingerprint] = entry
+        # The table used to REFUSE a new fingerprint once it was full, and that
+        # turned the ceiling into a cliff: a fault arriving late never got a slot,
+        # so every one of its occurrences looked new, built a full context and
+        # wrote to disk again. MEASURED on this machine (2026-09-03), the same
+        # repeating fault: 137 us and zero writes with a slot, 1926 us and a write
+        # PER OCCURRENCE without one - 14x, with the expensive half built inside
+        # the lock every other caller of this module waits on. In other words the
+        # de-duplication this module is built around stopped working exactly when
+        # the program was failing most.
+        #
+        # So the table makes room instead of refusing: in a shipped build it is a
+        # dedup CACHE and nothing else, since neither read-back helper at the
+        # bottom of this module has a caller in the package (B-16) and the crash
+        # log on disk already holds every fault's first occurrence. What eviction
+        # costs is therefore one counter nobody reads. What REFUSING costs is the
+        # ability to recognise the fault that is happening now, which is the half
+        # worth having. (Naming those two helpers here would have been enough to
+        # make the dead-code scan call them alive - it counts words, comments
+        # included. Their names are in tests/test_code_hygiene.py.)
+        _seen[fingerprint] = entry
+        if len(_seen) > MAX_RECORDS:
+            _seen.popitem(last=False)       # the least recently seen fault
 
     _write(entry)
     return entry
@@ -555,6 +584,27 @@ def _cleanup_native():
     left behind by a version before this one is still cleaned up.
     """
     global _native_stream, _native_path, _breadcrumb_last
+    # Close the diverts BEFORE the handler that would record a hard crash inside
+    # one of them goes away. `atexit` is LIFO, `engine.py` registers its own
+    # `_stop_live_engines` at IMPORT and `install()` registers this handler later,
+    # so this one runs FIRST - and it used to disable faulthandler while a ctypes
+    # call into the WinDivert kernel driver was still to come. MEASURED rather than
+    # reasoned (2026-09-03): with a stand-in engine in `_LIVE_ENGINES`,
+    # `faulthandler.is_enabled()` read False at the moment `stop()` ran, so a
+    # segfault in `divert.close()` at exit would have left nothing at all - the one
+    # failure this whole module exists for.
+    #
+    # Looked up in `sys.modules` rather than imported: `engine` imports THIS module,
+    # so an import here would be a cycle, and importing a module at interpreter
+    # shutdown is its own hazard. A process that never loaded the engine has no
+    # divert to close. The registration in `engine.py` stays as the net for the
+    # case where `install()` never ran at all.
+    live = sys.modules.get("beantester.engine")
+    if live is not None:
+        try:
+            live._stop_live_engines()       # idempotent: stop() forgets the engine
+        except Exception:
+            pass
     try:
         faulthandler.disable()
     except Exception:

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -225,6 +225,12 @@ class BeanEngine:
         self._t_cap = None          # capture thread (joined on stop)
         self._t_inj = None          # inject thread (joined on stop)
         self._t_wd = None           # watchdog thread (deadline + worker health)
+        # The capture thread's pulse, read by the watchdog. Two values, because one
+        # cannot answer the question: a thread that has not moved is either blocked
+        # in `recv()` on a quiet link, which is normal and may last all session, or
+        # stuck in our own code, which is the failure. `_cap_waiting` says which.
+        self._cap_waiting = False
+        self._cap_beat_at = None
         self._stop_lock = threading.RLock()
         self._deadline = None       # monotonic time to stop at (None = no limit)
         self._duration = 0.0        # the requested session length, for reports
@@ -1013,6 +1019,11 @@ class BeanEngine:
         if self._qpc_freq is None:
             self._qpc_freq = winenv.qpc_frequency()
         self._wait_sample_at = 0.0      # sample the first packet, then on the tick
+        # Cleared, not carried: a beat left over from the previous session is older
+        # than CAPTURE_STALL_S the moment this one starts, so an engine reused for
+        # a second run would fail-stop itself before its capture thread drew breath.
+        self._cap_waiting = False
+        self._cap_beat_at = None
         # always establish a concrete seed - this makes EVERY session reproducible
         self._effective_seed = self._seed if self._seed is not None else random.randrange(1, 2**31 - 1)
         self._rng = random.Random(self._effective_seed)
@@ -1529,11 +1540,66 @@ class BeanEngine:
                     self._fail_stop(RuntimeError(
                         f"worker thread {t.name} died unexpectedly"), blocking=False)
                     return
+            if self._capture_has_stalled():
+                # The other half of fail-open. The check above sees a thread that
+                # DIED. This one sees a thread that is perfectly alive and no
+                # longer doing anything, which produces the identical outcome for
+                # the user and used to produce no reaction at all.
+                self._fail_stop(RuntimeError(
+                    "capture thread stopped making progress"), blocking=False)
+                return
+
+    # How long the capture thread may spend between two `recv()` calls before the
+    # session is stopped. See `_capture_has_stalled` for why the number is this
+    # size and what it was measured against.
+    CAPTURE_STALL_S = 10.0
+
+    def _capture_has_stalled(self):
+        """Is the capture thread alive, out of `recv()`, and no longer moving?
+
+        The docstring at the top of this module says the dangerous state is a
+        process still ALIVE with an open divert and no working capture thread, and
+        until 2026-09-02 the watchdog only ever asked `is_alive()`. A thread
+        spinning in a regular expression, waiting on a deadlocked lock or blocked
+        on a driver that stopped answering is alive by that test, so the one state
+        the whole fail-open argument exists for was the one it could not see.
+
+        `_cap_waiting` is what makes this answerable at all. A stopped counter on
+        its own means either "blocked in recv on a quiet link", which is normal and
+        can last the whole session, or "stuck in our own code", which is the
+        failure - and they are indistinguishable without knowing WHICH side of
+        `recv()` the thread is on. Bumping a counter before `recv()` does not
+        separate them either: both look like a counter that stopped.
+
+        Ten seconds, and the size is deliberate rather than tuned, because the cost
+        of being wrong is not symmetric: a missed stall is the failure this exists
+        to catch, while a false one STOPS a running test on a machine that was
+        merely busy. MEASURED 2026-09-02 over healthy 20 s sessions
+        (`internal_tools/probe_capture_beat.py`), and run TWICE because a maximum
+        is the least repeatable thing a sample has: the median gap between two
+        beats came back at 1.075 and 1.061 ms, p99 at 8.679 and 2.573 ms, and the
+        WORST gap at 31.912 and 13.315 ms. The larger worst case is the one this
+        is set against, so ten seconds is 313 times a healthy session's worst
+        observed gap. That measurement is conservative in the right direction too:
+        the synthetic divert paces itself to ~900 packets/s while a real session
+        runs an order of magnitude faster, so it beats more often, not less.
+        """
+        if self._cap_beat_at is None or self._cap_waiting:
+            return False
+        t = self._t_cap
+        if t is None or not t.is_alive():
+            return False        # already reported by the liveness check above
+        return (time.monotonic() - self._cap_beat_at) > self.CAPTURE_STALL_S
 
     # -- worker threads -------------------------------------------------------- #
     def _capture_loop(self):
         rng = self._rng
         while self._running:
+            # Three stores per packet and not one allocation: `True`/`False` are
+            # singletons and `now` below is a float this loop already reads. That
+            # matters because this is the hot path - see the module's "What this
+            # actually sustains" section.
+            self._cap_waiting = True
             try:
                 packet = self._divert.recv()
             except Exception as e:
@@ -1545,6 +1611,17 @@ class BeanEngine:
                     self._fail_stop(e)
                 break
             now = time.monotonic()
+            # BEAT FIRST, then clear the flag, and the order is the whole safety of
+            # this pair. Written the other way round there is a window one bytecode
+            # wide where `_cap_waiting` is already False and `_cap_beat_at` is still
+            # the PREVIOUS beat - so a link that was quiet for a minute and then
+            # carried one packet would look, to a watchdog tick landing exactly
+            # there, like a thread that left recv() a minute ago and never came
+            # back. That is the expensive direction: it stops a healthy session.
+            # This way the flag only ever turns False after the beat behind it is
+            # already current.
+            self._cap_beat_at = now
+            self._cap_waiting = False
             # Sampled on TIME, not on a packet count. A count-based sample never
             # fires on a quiet link - 24 packets in 12 seconds would never reach
             # a 1-in-256 - and quiet links are exactly where a 2-second driver

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -1047,7 +1047,9 @@ class App:
         csv_export.export_stats(self)
 
     def export_connections_csv(self):
-        csv_export.export_connections(self)
+        # Returns the worker: the export runs off this thread now, and a caller
+        # that needs the file on disk before it goes on joins it.
+        return csv_export.export_connections(self)
 
     def mark_bug(self):
         if not self.running:

--- a/beantester/gui/app.py
+++ b/beantester/gui/app.py
@@ -51,7 +51,8 @@ from . import crash as gui_crash
 from . import dialogs
 from .icon import (apply_window_icon, make_gear_icon, show_idle_icon,
                    show_running_icon)
-from .pages import PAGES
+from .logview import LogView
+from .pages import PAGES, teardown as teardown_pages
 from .profiles import ProfileStore
 from .rates import PeakWindow
 from . import scope
@@ -121,11 +122,13 @@ class App:
         gui_crash.install(self)
         self._restore_geometry()
 
-        # Log lines are queued here and applied to the tkinter widget only from
-        # the main thread (in _tick): tkinter is NOT thread-safe and the
+        # Log lines are queued and applied to the tkinter widget only from the
+        # main thread (in _tick): tkinter is NOT thread-safe and the
         # engine/scenario/target-refresher threads all call self.log().
-        self._log_queue = queue.Queue()
-        self._log_lines = []
+        self._logview = LogView(self)
+        # Fingerprints of the faults that already opened a dialog this session, so
+        # a binding that fires in a series shows one window and not a stack of them.
+        self._ui_errors_shown = set()
         self.engine = BeanEngine(self.log)
         self.running = False
         self._applied_target = None     # last expression pushed to the engine
@@ -327,6 +330,10 @@ class App:
         # A Toplevel is a child of the root too, so destroying every child used to
         # take the open panel windows with it, leaving WindowManager to close
         # windows that were already gone (see WindowManager.toplevels).
+        # Before the destroy loop, not after: a page can only cancel a timer while
+        # the widget it was scheduled on still exists.
+        if getattr(self, "pages", None):
+            teardown_pages(self)
         owned = self.windows.toplevels()
         for widget in root.winfo_children():
             if widget in owned:
@@ -479,13 +486,13 @@ class App:
         self.log_wrap.pack(side="top", fill="x")
         log_sb = ttk.Scrollbar(self.log_wrap, orient="vertical")
         log_sb.pack(side="right", fill="y")
-        self.log_box = tk.Text(self.log_wrap, height=LOG_LINES, state="disabled",
-                               font=(MONO_FONT, 9), bg=FIELD, fg=MUT,
-                               insertbackground=FG, relief="flat", borderwidth=0,
-                               highlightthickness=0, wrap="none",
-                               yscrollcommand=log_sb.set)
-        self.log_box.pack(side="left", fill="both", expand=True)
-        log_sb.config(command=self.log_box.yview)
+        log_box = tk.Text(self.log_wrap, height=LOG_LINES, state="disabled",
+                          font=(MONO_FONT, 9), bg=FIELD, fg=MUT,
+                          insertbackground=FG, relief="flat", borderwidth=0,
+                          highlightthickness=0, wrap="none",
+                          yscrollcommand=log_sb.set)
+        log_box.pack(side="left", fill="both", expand=True)
+        log_sb.config(command=log_box.yview)
 
         # ...and only then the notebook, which takes whatever is left
         nb_holder = ttk.Frame(root)
@@ -508,12 +515,10 @@ class App:
         self.select_page(self._page_id)
         self._sync_running_ui()
 
-        if self._log_lines:                       # restore the log after a rebuild
-            self.log_box.config(state="normal")
-            tail = self._log_lines[-self.pref("log_lines"):]
-            self.log_box.insert("end", "\n".join(tail) + "\n")
-            self.log_box.config(state="disabled")
-            self.log_box.see("end")
+        # LAST, and after the notebook: attaching restores the log into the fresh
+        # widget, and it must be the widget this build made rather than the one the
+        # previous language left behind.
+        self._logview.attach(log_box)
         self._form_changed = True
 
     def _settings_for_form(self):
@@ -569,7 +574,7 @@ class App:
         self._filter_key = self._filter_cli_key()      # display names are localised
         self._lang = new
         self.ui.set("language", new)
-        self._log_lines = []          # the log starts fresh in the new language
+        self._logview.forget()        # the log starts fresh in the new language
         self._build_ui()
         # the open secondary windows are part of the UI: rebuild them in the new
         # language as well, or they sit there in the old one until reopened
@@ -1437,12 +1442,23 @@ class App:
         self._transition = kind
 
         def run():
+            # The `put` is in a `finally` and the catch is BaseException, and both
+            # halves are load-bearing. `_transition` is only ever cleared by
+            # `_poll_transition` reading this queue, so a `run()` that ends without
+            # putting leaves the flag on "starting" or "stopping" FOREVER: `_start`
+            # and `_stop` return immediately while a transition is in flight, and
+            # `_poll_transition` re-arms `root.after(30, ...)` in a loop. START and
+            # STOP are then dead for the life of the window, with a divert possibly
+            # still open - which is the one control a network tester must never
+            # take away. A one-line escape past a bare `except Exception` was all it
+            # took, so the queue is fed no matter how this ends.
+            err = None
             try:
                 work()
-                err = None
-            except Exception as e:      # carried to the main thread, never swallowed
+            except BaseException as e:  # carried to the main thread, never swallowed
                 err = e
-            self._ui_queue.put((kind, err))
+            finally:
+                self._ui_queue.put((kind, err))
 
         self._transition_thread = threading.Thread(target=run, daemon=True)
         self._transition_thread.start()
@@ -1506,13 +1522,33 @@ class App:
 
         It is also written to the CRASH LOG, with the seed, the settings and the
         counters attached - so "it broke" turns into a report somebody can act on.
+
+        ONE WINDOW PER FAULT, not one per occurrence. `crashlog.record` deduplicates
+        by fingerprint and counts the repeats. `dialogs.show_error` deduplicated
+        nothing, so an exception out of a binding that fires in a series - dragging
+        a window edge fires `<Configure>` continuously - buried the user under a
+        stack of modal windows to close one by one, on top of the original fault
+        and with the rest of the interface not responding. Every later occurrence
+        still reaches the log and the crash record, which is where the count lives.
         """
         import traceback
+        record = None
         if value is not None:
             value.__traceback__ = tb
-            crashlog.record(value, source="tk-callback")
+            record = crashlog.record(value, source="tk-callback")
         detail = "".join(traceback.format_exception_only(exc, value)).strip()
         self.log(T("log.ui_error", e=detail))
+        # The FINGERPRINT, never the message: `crashlog` builds it from the
+        # exception type and the frames, so it is the same for every repeat of one
+        # fault. Keying on the formatted detail instead would put the message in
+        # the key, and one varying number in it - a port, a path - would make every
+        # occurrence look new, which is the storm this is here to stop. The
+        # fallback for a fault carrying no exception object is its type, for the
+        # same reason.
+        key = record["fingerprint"] if record else getattr(exc, "__name__", str(exc))
+        if key in self._ui_errors_shown:
+            return
+        self._ui_errors_shown.add(key)
         try:
             dialogs.show_error(self.root, T("dialogs.internal_error_title"),
                                T("dialogs.internal_error", e=detail))
@@ -1751,7 +1787,7 @@ class App:
         try:
             self._drain_ui_queue()      # finished async start/stop (main thread only)
             gui_crash.leave_breadcrumb(self)   # state a NATIVE crash cannot write
-            self._drain_log()           # worker-thread log lines (main thread only)
+            self._logview.drain()       # worker-thread log lines (main thread only)
             self._drain_target_warning()   # render the target verdict (main thread)
             self._drain_engine_warning()   # "the tool itself is dropping packets"
             self._sample()
@@ -1779,51 +1815,14 @@ class App:
             self.root.after(TICK_MS, self._tick)
 
     # -- logging ------------------------------------------------------------------ #
+    # The box's own bookkeeping lives in gui/logview.py (see its docstring for why).
+    # These two stay because they are the surface everything else calls.
     def log(self, msg):
         """Thread-safe logging entry point (worker threads never touch widgets)."""
-        stamp = time.strftime("%H:%M:%S")
-        self._log_queue.put(f"[{stamp}] {msg}")
-        if threading.current_thread() is threading.main_thread():
-            self._drain_log()
+        self._logview.log(msg)
 
     def clear_log(self):
-        self._log_lines = []
-        try:
-            self.log_box.config(state="normal")
-            self.log_box.delete("1.0", "end")
-            self.log_box.config(state="disabled")
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.app")
-
-    def _drain_log(self):
-        """Apply queued log lines to the widget. Main thread only."""
-        if getattr(self, "log_box", None) is None:
-            return                      # UI not built yet; lines stay queued
-        while True:
-            try:
-                line = self._log_queue.get_nowait()
-            except queue.Empty:
-                break
-            self._append_log_line(line)
-
-    def _append_log_line(self, line):
-        # How many lines to keep is a saved preference. A little hysteresis (trim
-        # only past keep + 100) keeps this off the hot path: we do not reslice the
-        # whole list on every single line once the cap is reached.
-        keep = self.pref("log_lines")
-        self._log_lines.append(line)
-        if len(self._log_lines) > keep + 100:
-            self._log_lines = self._log_lines[-keep:]
-        self.log_box.config(state="normal")
-        self.log_box.insert("end", line + "\n")
-        try:            # keep the widget bounded too, not just the in-memory list
-            count = int(self.log_box.index("end-1c").split(".")[0])
-            if count > keep + 100:
-                self.log_box.delete("1.0", f"{count - keep}.0")
-        except Exception as _exc:
-            crashlog.note(_exc, "gui.app")
-        self.log_box.see("end")
-        self.log_box.config(state="disabled")
+        self._logview.clear()
 
 
 # -- backwards-compatible attribute names --------------------------------------- #
@@ -1845,6 +1844,19 @@ for _name, _key in (("loss_var", "loss"), ("corr_var", "corrupt"), ("dup_var", "
                     ("flap_period", "flap_period"), ("flap_downpct", "flap_down"),
                     ("filter_var", "filter")):
     setattr(App, _name, _var_property(_key))
+
+
+# The log's own state moved to gui/logview.py, but two of its names are read from
+# outside this class - `gui/crash.py` puts the tail into every crash report, and the
+# GUI tests read both - so they stay as names. Read-only on purpose: the widget is
+# handed over by `_build_ui` and the list is emptied through `LogView.forget()`, so
+# there is no caller that should be assigning to either.
+# Through setattr for the reason the block below spells out: a plain assignment
+# here is a type error, because a class does not grow attributes from outside its
+# own body.
+for _attr, _get in (("log_box", lambda self: self._logview.box),
+                    ("_log_lines", lambda self: self._logview.lines)):
+    setattr(App, _attr, property(_get))
 
 
 # Older private names kept working (docs, scripts, the GUI smoke). Written as a

--- a/beantester/gui/csv_export.py
+++ b/beantester/gui/csv_export.py
@@ -10,6 +10,7 @@ The column tables live here too, and they are the source the README guard reads.
 """
 import csv
 import os
+import threading
 import time
 
 from .. import crashlog
@@ -137,6 +138,12 @@ CONN_CSV_HEADER = ["process", "pid", "proto", "remote_ip", "remote_port",
                    "avg_bytes", "duration_s", "idle_s"]
 
 
+# One export at a time, and the thing being protected is the FILE, not the window:
+# `CONNECTIONS_CSV_FILE` is one fixed path, so two windows would collide on it as
+# surely as two clicks. Module scope is therefore right rather than lazy.
+_EXPORT_LOCK = threading.Lock()
+
+
 def export_connections(app):
     """Write the CURRENT connection view (search + sort) to a CSV snapshot.
 
@@ -145,7 +152,40 @@ def export_connections(app):
     table is. The file is overwritten atomically each time (tmp + os.replace):
     it is a snapshot of "the connections as they are now", not an append log
     like the stats CSV.
+
+    OFF THE UI THREAD, because everything after the snapshot is unbounded work on
+    a table that may hold 200 000 flows: a full filter and sort with no row cap,
+    then a row-by-row CSV write. This is the one path that stayed on the UI thread
+    after `gui/model_worker.py` moved the table's own rebuild off it, and its
+    docstring says why that matters - a frozen window is a STOP button the user
+    cannot press, on a machine whose networking they have deliberately broken.
+
+    What is read from the App is read HERE, on the UI thread, and handed over as
+    plain data - the same shape `ConnsPage.refresh` uses. The worker touches no
+    widget. It calls `app.log`, which is thread-safe by contract.
+
+    Returns the worker thread so a caller that needs the file on disk before it
+    goes on can join it. The GUI does not. ``None`` back means an export was
+    already running and this click was refused.
     """
+    if not _EXPORT_LOCK.acquire(blocking=False):
+        # Two clicks, one file. Refusing out loud beats two workers racing to
+        # `os.replace` the same path, where the winner is whichever finishes last.
+        app.log(T("log.conns_export_busy"))
+        return None
+    try:
+        payload = _connections_payload(app)
+    except BaseException:
+        _EXPORT_LOCK.release()
+        raise
+    worker = threading.Thread(target=_write_connections, args=(app, payload),
+                              name="conns-csv", daemon=True)
+    worker.start()
+    return worker
+
+
+def _connections_payload(app):
+    """UI thread: everything the writer needs, as plain data."""
     now = app.engine.now_ref()
     snapshot = app.engine.connections_snapshot(limit=None)
     # The export follows the view: what you exported and what you were looking
@@ -153,10 +193,24 @@ def export_connections(app):
     # that produced it.
     if app.scoped_view():
         snapshot = [c for c in snapshot if c.get("scoped")]
+    return {"now": now, "snapshot": snapshot, "query": app.conn_query,
+            "sort": dict(app.conn_sort), "proc_map": app.proc_map}
+
+
+def _write_connections(app, payload):
+    """Worker thread: filter, sort and write. Touches no widget."""
+    try:
+        _write_connections_now(app, payload)
+    finally:
+        _EXPORT_LOCK.release()
+
+
+def _write_connections_now(app, payload):
+    now, proc_map = payload["now"], payload["proc_map"]
     rows = filter_sort_connections(
-        snapshot, app.conn_query,
-        app.conn_sort["col"], app.conn_sort["reverse"],
-        now=now, proc_map=app.proc_map, limit=0)
+        payload["snapshot"], payload["query"],
+        payload["sort"]["col"], payload["sort"]["reverse"],
+        now=now, proc_map=proc_map, limit=0)
     path = CONNECTIONS_CSV_FILE
     tmp = path + ".tmp"
     try:
@@ -167,7 +221,7 @@ def export_connections(app):
                 last = c.get("last", now)
                 packets = c.get("packets", 0) or 0
                 writer.writerow([formula_safe(v) for v in (
-                    connection_proc(c, app.proc_map) or "?",
+                    connection_proc(c, proc_map) or "?",
                     c.get("pid") or "",
                     c.get("proto", "IP"), c.get("remote_ip", ""),
                     c.get("remote_port", ""), c.get("local_port", ""),

--- a/beantester/gui/form.py
+++ b/beantester/gui/form.py
@@ -364,6 +364,20 @@ class ControlForm:
             self._relayout_job = None
             self.set_columns(want)
 
+    def teardown(self):
+        """Put the pending relayout away before the host it is scheduled on goes.
+
+        Called by the page that owns this form, not by the page registry: a form is
+        not a page, and reaching it any other way would mean the registry knowing
+        about widgets one layer down.
+        """
+        if self._relayout_job is not None:
+            try:
+                self.host.after_cancel(self._relayout_job)
+            except Exception as _exc:
+                crashlog.note(_exc, "gui.form")
+            self._relayout_job = None
+
     def set_columns(self, columns):
         """Switch between one and two columns.
 

--- a/beantester/gui/logview.py
+++ b/beantester/gui/logview.py
@@ -1,0 +1,128 @@
+"""The message log at the bottom of the window: its queue, its cap, its widget.
+
+Everything the App used to do to that Text box, minus the box's construction,
+which stays in ``_build_ui`` because it is layout and a layout test asserts where
+it hangs. What moved is the BEHAVIOUR: the thread-safe hand-off, the two caps
+(the list in memory and the widget itself), and the guard that decides whether
+there is anything to write to at all.
+
+It lives here for the reason ``gui/crash.py`` gives at the top of its own
+docstring: ``gui/app.py`` sits ON the size ratchet in ``tests/test_code_shape.py``,
+and that guard's answer is to put code where it belongs rather than to raise the
+number. This is not App logic - it is one widget's own bookkeeping.
+
+``App.log`` / ``App.clear_log`` / ``App.log_box`` / ``App._log_lines`` all still
+work and mean what they meant. Two of those are read by things outside this
+package's control (``gui/crash.py`` takes the tail into every crash report, and
+the GUI tests read both), so they are kept as names rather than renamed away.
+"""
+import queue
+import threading
+import time
+
+from .. import crashlog
+
+# Trim only past ``keep + HYSTERESIS``, so a busy session does not reslice the
+# whole list on every single line once the cap is reached.
+HYSTERESIS = 100
+
+
+class LogView:
+    """The log box, and the state that outlives it.
+
+    ``lines`` outlives the widget on purpose: a language change destroys every
+    child of the root and builds new ones, and the log is expected to still be
+    there afterwards. The widget is therefore something this object is HANDED
+    (``attach``), not something it owns.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self.box = None             # the Text widget, once _build_ui has made one
+        self.lines = []             # survives a rebuild; the widget does not
+        self._queue = queue.Queue()
+
+    def attach(self, box):
+        """Take the widget ``_build_ui`` just made, and restore the log into it."""
+        self.box = box
+        if self.lines:
+            keep = self.app.pref("log_lines")
+            box.config(state="normal")
+            box.insert("end", "\n".join(self.lines[-keep:]) + "\n")
+            box.config(state="disabled")
+            box.see("end")
+        # Anything logged while there was no usable widget is still in the queue,
+        # and a rebuild is exactly such a window. `App.log` drains synchronously on
+        # the main thread, so without this those lines wait for the next tick to
+        # appear - which reads as the log having missed them.
+        self.drain()
+
+    def forget(self):
+        """Start the log empty (a language change does not keep mixed languages)."""
+        self.lines = []
+
+    # -- writing ------------------------------------------------------------- #
+    def log(self, msg):
+        """Thread-safe entry point. Worker threads never touch widgets."""
+        stamp = time.strftime("%H:%M:%S")
+        self._queue.put(f"[{stamp}] {msg}")
+        if threading.current_thread() is threading.main_thread():
+            self.drain()
+
+    def clear(self):
+        self.lines = []
+        if not self._usable():
+            return
+        try:
+            self.box.config(state="normal")
+            self.box.delete("1.0", "end")
+            self.box.config(state="disabled")
+        except Exception as _exc:
+            crashlog.note(_exc, "gui.logview")
+
+    def drain(self):
+        """Apply queued lines to the widget. Main thread only."""
+        if not self._usable():
+            return                  # UI not built yet; lines stay queued
+        while True:
+            try:
+                line = self._queue.get_nowait()
+            except queue.Empty:
+                break
+            self._append(line)
+
+    def _usable(self):
+        """Is there a widget, and does it still exist?
+
+        🔴 The second half is not paranoia. A DESTROYED Tk widget is not ``None``:
+        it is the same Python object, and only its Tcl path is gone, so a guard
+        written as ``if self.box is None`` passes and every call after it raises
+        ``TclError``. ``_build_ui`` destroys every child of the root and the
+        attribute keeps pointing at the corpse until a new widget is attached, so
+        anything logged inside that window - and ``App.log`` drains synchronously
+        on the main thread - went through exactly that hole.
+        """
+        box = self.box
+        if box is None:
+            return False
+        try:
+            return bool(box.winfo_exists())
+        except Exception as _exc:       # a half-torn-down interpreter, at shutdown
+            crashlog.note(_exc, "gui.logview")
+            return False
+
+    def _append(self, line):
+        keep = self.app.pref("log_lines")
+        self.lines.append(line)
+        if len(self.lines) > keep + HYSTERESIS:
+            self.lines = self.lines[-keep:]
+        self.box.config(state="normal")
+        self.box.insert("end", line + "\n")
+        try:            # keep the widget bounded too, not just the in-memory list
+            count = int(self.box.index("end-1c").split(".")[0])
+            if count > keep + HYSTERESIS:
+                self.box.delete("1.0", f"{count - keep}.0")
+        except Exception as _exc:
+            crashlog.note(_exc, "gui.logview")
+        self.box.see("end")
+        self.box.config(state="disabled")

--- a/beantester/gui/model_worker.py
+++ b/beantester/gui/model_worker.py
@@ -122,7 +122,15 @@ class AsyncModel:
     def _run(self, token, payload):
         try:
             rows = self._build(payload)
-        except Exception as exc:
+        except BaseException as exc:
+            # BaseException, not Exception, and it is the difference between "one
+            # rebuild failed" and "this table is finished". `_pending` is cleared
+            # HERE or by `poll()` reading a result, so a build that ends any other
+            # way leaves it set for ever: `busy()` stays True, the page's 40 ms
+            # catch-up poll re-arms itself indefinitely, and the table never
+            # rebuilds again for the rest of the session. REPRODUCED 2026-09-02 by
+            # raising KeyboardInterrupt out of `build`.
+            #
             # the old model stays on screen: a stale table beats a broken one
             crashlog.note(exc, "gui.model_worker")
             with self._lock:

--- a/beantester/gui/pages/__init__.py
+++ b/beantester/gui/pages/__init__.py
@@ -84,5 +84,33 @@ def pref_changed(app, key):
             handler(key)
 
 
+def teardown(app):
+    """The UI is about to be destroyed: let each page put its timers away.
+
+    ``_build_ui`` destroys every child of the root and builds new ones, which is
+    what a language change does. Nothing told the pages, so whatever they had
+    scheduled through ``after()`` was still queued against widgets that no longer
+    existed - the connection table's poll and search debounce, the chart's redraw,
+    the Control page's field search. Tk deletes a widget's registered commands when
+    it destroys the widget, so those timers fire into nothing.
+
+    Optional, exactly like ``on_pref_changed``: a page that schedules nothing
+    implements nothing. Broadcast rather than a name in the registry, for the
+    reason written above ``pref_changed`` - how a page is ADDRESSED belongs to the
+    page registry, and ``gui/app.py`` has no room for the alternative.
+
+    A page that raises must not stop the others being torn down, and must not stop
+    the rebuild either: the user asked for a different language, and refusing them
+    one because a timer would not cancel would be a worse answer than a log line.
+    """
+    from ... import crashlog
+    for page in app.pages.values():
+        handler = getattr(page, "teardown", None)
+        if handler is None:
+            continue
+        with crashlog.quiet("gui.pages"):
+            handler()
+
+
 __all__ = ["PAGES", "Page", "ControlPage", "StatsPage", "ConnsPage",
-           "focus_search", "pref_changed"]
+           "focus_search", "pref_changed", "teardown"]

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -29,8 +29,8 @@ from tkinter import ttk
 from ...i18n import T
 from ...matchers import add_term
 from ...utils import human_bytes
-from ...views import (avg_packet_bytes, connection_proc, filter_sort_connections,
-                      traffic_totals)
+from ...views import (avg_packet_bytes, connection_proc, filter_connections,
+                      sort_connections, sum_traffic)
 from .. import dialogs
 from ..model_worker import AsyncModel
 from ..labels import wrapping_label
@@ -674,15 +674,28 @@ class ConnsPage:
         # moment its port left the socket table; see engine._log_conn).
         if request.get("scoped_only"):
             conns = [c for c in conns if c.get("scoped")]
+        # ONE filtering pass for both answers. It used to be two - the sort filtered
+        # and then the footer's total filtered the whole table again, compiling the
+        # query a second time - which is a doubled pass on the thread that exists to
+        # keep the table cheap. MEASURED 2026-09-02 at 10k / 50k / 200k rows
+        # (internal_tools/bench_conn_model.py): 1.83x to 2.00x faster with something
+        # typed in the search box, and level with it empty, where the old second
+        # pass was only a list copy.
+        kept = filter_connections(conns, request["query"], request["proc_map"])
+        # SUMMED BEFORE THE SORT, and that order is measured rather than tidy: the
+        # sort reorders `kept` in place, and walking two hundred thousand dicts in
+        # sorted order instead of allocation order costs enough to turn the whole
+        # change NEGATIVE on an empty query (0.85x). Summing first, 1.04-1.14x.
+        # Order does not matter to a sum, so this costs nothing to obey.
+        #
+        # Summed over the FILTERED set and not the limited `shown`: the footer must
+        # count every matching flow, not only the rows the cap let through.
+        totals = sum_traffic(kept)
         # the limit is passed IN, so it can bound the sort itself instead of only
         # trimming its result (see views.filter_sort_connections)
-        shown = filter_sort_connections(
-            conns, request["query"],
-            request["sort"]["col"], request["sort"]["reverse"],
-            now=request["now"], proc_map=request["proc_map"], limit=request["limit"])
-        # summed over the FILTERED set (not the limited `shown`): the footer must
-        # count every matching flow, not only the rows the cap let through
-        totals = traffic_totals(conns, request["query"], request["proc_map"])
+        shown = sort_connections(kept, request["sort"]["col"],
+                                 request["sort"]["reverse"],
+                                 now=request["now"], limit=request["limit"])
         # Whether a target is narrowing at all. With no target every flow is in
         # scope, so the whole-table tint would mean nothing - it fires only when
         # targeting is on (per-row scope is then checked live in _tag_of). One

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -638,6 +638,20 @@ class ConnsPage:
         with crashlog.quiet("gui.pages.conns"):
             self._poll_job = self.frame.after(self.POLL_MS, self._drain_model)
 
+    def teardown(self):
+        """Put both timers away before the widgets they are scheduled on go.
+
+        The worker is deliberately left alone: it touches no widget and hands its
+        result to a queue nobody will read any more, so it finishes and is
+        collected. Cancelling it would need a second mechanism to prove it stopped.
+        """
+        for name in ("_poll_job", "_search_job"):
+            job = getattr(self, name, None)
+            if job is not None:
+                with crashlog.quiet("gui.pages.conns"):
+                    self.frame.after_cancel(job)
+                setattr(self, name, None)
+
     def _drain_model(self):
         self._poll_job = None
         result = self._model.poll()

--- a/beantester/gui/pages/control.py
+++ b/beantester/gui/pages/control.py
@@ -224,6 +224,21 @@ class ControlPage:
                 self.frame.after_cancel(self._job)
         self._job = self.frame.after(SEARCH_DEBOUNCE_MS, self._apply)
 
+    def teardown(self):
+        """Put the search debounce away, and the form's relayout with it.
+
+        The form belongs to this page (it is handed to ``app.form`` from here), so
+        this is where its timer is somebody's responsibility.
+        """
+        if self._job is not None:
+            with crashlog.quiet("gui.pages.control"):
+                self.frame.after_cancel(self._job)
+            self._job = None
+        form = getattr(self, "form", None)
+        if form is not None:
+            with crashlog.quiet("gui.pages.control"):
+                form.teardown()
+
     def clear(self):
         self.query_var.set("")
         self._apply()

--- a/beantester/gui/pages/stats.py
+++ b/beantester/gui/pages/stats.py
@@ -395,6 +395,13 @@ class StatsPage:
             except Exception as _exc:
                 crashlog.note(_exc, "gui.pages.stats")
 
+    def teardown(self):
+        """Put the pending redraw away before the canvas it would draw on goes."""
+        if self._chart_job is not None:
+            with crashlog.quiet("gui.pages.stats"):
+                self.frame.after_cancel(self._chart_job)
+            self._chart_job = None
+
     # -- chart --------------------------------------------------------------- #
     def _on_canvas_configure(self, _=None):
         if self._chart_job is not None:

--- a/beantester/gui/panels/event_log.py
+++ b/beantester/gui/panels/event_log.py
@@ -175,6 +175,13 @@ class EventLogWindow(PanelWindow):
                 self.win.after_cancel(self._search_job)
         self._search_job = self.win.after(SEARCH_DEBOUNCE_MS, self._run_search)
 
+    def teardown(self):
+        """Put the search debounce away before the window it is scheduled on goes."""
+        if self._search_job is not None:
+            with crashlog.quiet("gui.windows.event_log"):
+                self.win.after_cancel(self._search_job)
+            self._search_job = None
+
     def _run_search(self):
         self._search_job = None
         self._query = self.search_var.get().strip()

--- a/beantester/gui/windows.py
+++ b/beantester/gui/windows.py
@@ -129,6 +129,14 @@ class PanelWindow:
 
     def close(self):
         self._save_geometry()
+        # The same hook the pages got, for the same reason: a window is destroyed
+        # here, and a timer scheduled on it fires into a command Tk has deleted.
+        # Optional - a panel that schedules nothing implements nothing - and it must
+        # not be able to stop the window closing.
+        handler = getattr(self, "teardown", None)
+        if handler is not None:
+            with crashlog.quiet("gui.windows"):
+                handler()
         win, self.win, self.body = self.win, None, None
         if win is None:
             return

--- a/beantester/i18n.py
+++ b/beantester/i18n.py
@@ -7,6 +7,7 @@ no code changes are needed.
 """
 import os
 import string
+import threading
 
 from .jsonfile import load_json
 from .paths import lang_dir
@@ -39,6 +40,10 @@ LABEL_COLONS = ":" + chr(0xFF1A)
 _translations: dict[str, dict[str, str]] = {}   # language code -> {key: text}
 _language_names: dict[str, str] = {}            # code -> name (from "_meta")
 _LANG = None    # resolved lazily on first use (see _resolve_language)
+
+# Guards the LAZY load only - never a lookup, and never load_languages() itself.
+# See _ensure_loaded for both halves of why.
+_load_lock = threading.Lock()
 
 
 def load_languages(directory=None):
@@ -86,21 +91,59 @@ def load_languages(directory=None):
             continue
         names[code] = str(meta.get("name") or code)
         translations[code] = {str(k): str(v) for k, v in data.items()}
-    _translations, _language_names = translations, names
+    # NAMES first, translations second, and the order is the point: `_translations`
+    # is what every "have we loaded yet" check reads, so it has to be the LAST
+    # thing published. Assigned the other way round, a reader that arrived between
+    # the two stores saw a loaded catalogue beside an empty name map, and
+    # available_languages() answered with codes where names belong.
+    #
+    # 🔴 NOT guarded by a test, and said out loud rather than left to look proven:
+    # the window is two adjacent stores, so observing it needs a reader racing a
+    # loader in a loop - a guard that would be slow, flaky, and green most of the
+    # time for the wrong reason. The line above is cheap and correct; the claim
+    # that it is TESTED would not be.
+    _language_names = names
+    _translations = translations
     return set(translations)
+
+
+def _ensure_loaded():
+    """Load the catalogue once, however many threads ask at the same time.
+
+    The lazy branch used to be five copies of ``if not _translations:
+    load_languages()``, unguarded, with readers on the engine's worker threads and
+    the UI thread. Two of them would both scan ``lang/`` and both publish - the
+    same answer twice over, at the cost of a second pass over every file.
+
+    Both entry points happen to load eagerly today (``run_cli`` and
+    ``App._build_ui`` each call ``set_language`` as one of their first statements,
+    before any worker thread exists), so this is hardening rather than a bug being
+    fixed. That is exactly the argument this project refuses to accept on its own:
+    "nobody reaches it today" is a fact about the callers, not a property of the
+    module.
+
+    The fast path is unchanged - one truthiness test on a global - so ``T()`` pays
+    nothing for this. The lock is taken only when there is nothing loaded yet, and
+    it deliberately does NOT wrap ``load_languages`` itself: that one is public,
+    tests call it directly to reload, and a lock around it would be a lock held
+    across disk I/O for callers who are not racing anybody.
+    """
+    if _translations:
+        return
+    with _load_lock:
+        if not _translations:       # somebody else may have loaded it while we
+            load_languages()        # waited - checked again inside the lock
 
 
 def loaded_language_codes():
     """Codes of the currently loaded languages (loads them on first use)."""
-    if not _translations:
-        load_languages()
+    _ensure_loaded()
     return list(_translations)
 
 
 def available_languages():
     """``[(code, display name), ...]`` with the fallback (English) listed first."""
-    if not _translations:
-        load_languages()
+    _ensure_loaded()
     codes = sorted(_translations, key=lambda c: (c != FALLBACK_LANGUAGE, c))
     return [(c, _language_names.get(c, c)) for c in codes]
 
@@ -117,8 +160,7 @@ def detect_language():
             loc = locale.getlocale()[0] or ""
         except Exception:
             loc = ""
-    if not _translations:
-        load_languages()
+    _ensure_loaded()
     text = str(loc).lower().replace("-", "_")
     code = text.split(".")[0].split("_")[0]
     tag = text
@@ -167,8 +209,7 @@ def _resolve_language():
 def set_language(lang):
     """Switch the UI language; unknown codes fall back to English."""
     global _LANG
-    if not _translations:
-        load_languages()
+    _ensure_loaded()
     lang = str(lang or "").strip().lower()
     _LANG = lang if lang in _translations else FALLBACK_LANGUAGE
 
@@ -216,8 +257,7 @@ def translate(key, lang=None, **fmt):
     """
     if not isinstance(key, str):
         return key
-    if not _translations:
-        load_languages()
+    _ensure_loaded()
     text = _translations.get(lang or _resolve_language(), {}).get(key)
     if text is None:
         text = _translations.get(FALLBACK_LANGUAGE, {}).get(key, key)

--- a/beantester/jsonfile.py
+++ b/beantester/jsonfile.py
@@ -8,7 +8,10 @@ silently:
 
 * **atomic writes** - the new content is written to a temporary file and then
   ``os.replace``d over the target, which is atomic on Windows and POSIX alike.
-  A crash halfway through can no longer leave a half-written profile file.
+  A crash halfway through can no longer leave a half-written profile file. The
+  temporary file is unique per writer (``paths.temp_beside``), because two copies
+  of the program saving at once used to share one, and the name it shared was
+  derived from the target.
 * **quarantine instead of overwrite** - a file that cannot be parsed is renamed
   to ``<name>.corrupt-<timestamp>`` before the app starts fresh, so a broken
   file is recoverable rather than clobbered by the first save.
@@ -19,6 +22,7 @@ import json
 import os
 import time
 from . import crashlog
+from .paths import temp_beside
 
 # The biggest file any of these formats produces, with room to grow. MEASURED on
 # this repository 2026-08-26: the largest JSON the program reads is `lang/pl.json`
@@ -134,21 +138,33 @@ def write_json(path, data, indent=2):
     default writes ``Infinity`` and ``NaN`` happily, which would let this program
     produce a file that ``load_json`` then rejects - a corrupt-file report about a
     file we wrote ourselves, which is the worst kind of bug report to receive.
+
+    ``TypeError`` is caught alongside the other two because it is the SAME event
+    from the caller's side: a value ``json`` will not write. ``allow_nan=False``
+    raises ``ValueError`` for a non-finite float, and anything json has no rule
+    for at all (a set, a widget, a ``datetime``) raises ``TypeError`` - which used
+    to walk straight out of here, past the temp-file cleanup, and take down
+    whatever was saving. The reader's half already made this decision (see
+    ``load_json``); this is the writer catching up with it.
     """
-    tmp = f"{path}.tmp"
+    tmp = None
     try:
         # No makedirs(): a path whose directory does not exist is an ERROR, and the
         # CLI contract says so (exit code IO). Inventing the directory would turn a
-        # typo in --save-config into a silent success.
+        # typo in --save-config into a silent success. `temp_beside` does not
+        # create it either, so a bad path still fails here rather than succeeding.
+        tmp = temp_beside(path)
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=indent, allow_nan=False)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp, path)
         return None
-    except (OSError, ValueError) as e:
+    except (OSError, TypeError, ValueError) as e:
         try:
-            if os.path.exists(tmp):
+            # `tmp` can still be None: temp_beside is the first thing that can
+            # fail, and it fails for the commonest reason of all - no directory.
+            if tmp and os.path.exists(tmp):
                 os.remove(tmp)
         except OSError as _exc:
             crashlog.note(_exc, "jsonfile")

--- a/beantester/matchers.py
+++ b/beantester/matchers.py
@@ -44,6 +44,7 @@ the GUI can show it and the CLI can turn it into a clean error message.
 import fnmatch
 import ipaddress
 import re
+import time
 import warnings
 
 from .i18n import field_name, translate
@@ -464,6 +465,101 @@ def _compare_predicate(op, number):
     return lambda c: c is not None and c <= number
 
 
+# -- refusing a pattern that cannot be run per packet ---------------------------- #
+#
+# `re.compile` answers "does this parse", never "will this ever finish". A pattern
+# that parses can still backtrack catastrophically, and the compiled matcher is
+# then called ON EVERY PACKET, on the capture thread, inside `core._lock`. The
+# consequences do not stop at a slow filter: the capture thread stops draining the
+# divert, so WinDivert queues the user's traffic and the machine quietly loses its
+# network, while the UI thread blocks on the same lock the moment any page asks
+# `App.coverage()`. Task Manager becomes the only way out. Reproduced 2026-09-02
+# with `re:^([1:]+)+x$` against an ordinary IPv6 address.
+#
+# So the pattern is TRIED here, at parse time, on the UI or CLI thread, where
+# taking a few milliseconds costs nothing and refusing is still possible.
+#
+# CPython has no timeout to lean on: `re` exposes none, and `Pattern.search` takes
+# only `pos`/`endpos` (checked on 3.14.7, not remembered). What makes a wall-clock
+# probe bounded instead is the LADDER: catastrophic backtracking grows with input
+# length, so the probe walks lengths upward and stops at the first one over budget.
+# The worst case is therefore one growth step past the budget, not forever.
+#
+# MEASURED 2026-09-02, milliseconds per search at 8 / 12 / 16 / 20 / 24 characters:
+#   ^([1:]+)+x$    0.016  0.132  2.076  37.4  684
+#   ^((a*)*)*b$    7.6    1254
+#   ^chrome|firefox   and   ^10\.0\.\d+        0.001 flat at every length
+# The margin between "fine" and "not fine" is four orders of magnitude, which is
+# why a clock is a fair judge here and why this does not flake on a slow runner.
+#
+# 🔴 The textbook example does NOT work: `^(a+)+$` is 0.001 ms at every length,
+# because CPython optimises it away. A guard tested with it would prove nothing
+# and look thorough. The two patterns above are the ones that actually blow up.
+# The budget covers the WHOLE trial, not each search in it, which is what keeps
+# the cost of a refusal small: the ladder stops at the first length that has spent
+# it, so a pattern is refused after roughly one growth step rather than after
+# finishing the step it exploded on.
+#
+# 5 ms is chosen against the other side of the gap, not against the attack.
+# MEASURED 2026-09-02, worst single search over this whole ladder, for patterns a
+# user might reasonably write: 50 alternations 0.0046 ms, a long character class
+# with an extension list 0.0036 ms, lookahead plus negative lookahead 0.0011 ms,
+# the full IPv6 form 0.0021 ms, a backreference 0.0010 ms, nested groups with
+# alternation 0.0049 ms. The heaviest legitimate pattern measured is a THOUSAND
+# times under this budget, and the whole ladder costs it 0.03 ms.
+REGEX_BUDGET_S = 0.005
+# Repeating units, not sentences: what makes a pattern explode is a long run of
+# characters it can consume. One per alphabet these fields really carry - ports and
+# IPv4 (digits), process names (letters), IPv6 text (hex and colons, the shape the
+# reproduction used), dotted names.
+_REGEX_PROBE_UNITS = ("1", "a", "1:", "a.")
+# Up to 45, the longest IPv6 address in text form, which is the longest value an
+# IP matcher is ever handed. A process name can be longer, and that is said out
+# loud rather than covered badly: a pattern that is still fast at 45 characters
+# and slow at 300 exists, and the capture-thread heartbeat in `engine.py` is what
+# catches it.
+#
+# Close steps at the bottom on purpose. The cost of a refusal is whatever the
+# first over-budget length cost, so the rungs have to be near each other exactly
+# where the explosion starts - `^((a*)*)*b$` is 7.6 ms at 8 characters and 1254 ms
+# at 12, and a ladder that stepped straight from 8 to 12 would pay the second
+# number to learn what the first already showed.
+_REGEX_PROBE_LENGTHS = (6, 8, 10, 12, 14, 16, 20, 24, 32, 45)
+
+
+def _blows_the_budget(rx):
+    """True when climbing the ladder spends more than the budget.
+
+    Lengths outer, alphabets inner: the ladder climbs for every alphabet at once,
+    so a pattern that explodes on letters but not on digits is caught at the
+    shortest length that shows it rather than after a full pass over the other.
+    """
+    deadline = time.perf_counter() + REGEX_BUDGET_S
+    for length in _REGEX_PROBE_LENGTHS:
+        for unit in _REGEX_PROBE_UNITS:
+            rx.search((unit * length)[:length])
+            if time.perf_counter() > deadline:
+                return True
+    return False
+
+
+def _refuse_if_too_slow(rx, field, term):
+    """Raise when a compiled pattern is too slow to sit on the packet path.
+
+    TWICE, and the second run is the one that decides, because a wall clock cannot
+    tell "this pattern burned five milliseconds" from "this thread lost the CPU for
+    five milliseconds". The obvious answer to that is a CPU clock, and it does not
+    work here: `time.get_clock_info("thread_time")` REPORTS a resolution of 1e-07
+    on this platform and MEASURES 15.625 ms (200 000 reads returned six distinct
+    values, 2026-09-02), which cannot see a 5 ms budget at all. A second run can:
+    a scheduling hiccup does not repeat in the same place, and backtracking does,
+    every time, deterministically. A good pattern never pays for this - it takes
+    the first run only, at 0.04 ms.
+    """
+    if _blows_the_budget(rx) and _blows_the_budget(rx):
+        raise _err("errors.filter_regex_too_slow", field, term)
+
+
 def _compile_regex(pattern, field, term):
     pattern = pattern.strip()
     if not pattern:
@@ -478,9 +574,11 @@ def _compile_regex(pattern, field, term):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
             warnings.simplefilter("ignore", DeprecationWarning)
-            return re.compile(pattern, re.IGNORECASE)
+            rx = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
         raise _err("errors.bad_filter_regex", field, term) from exc
+    _refuse_if_too_slow(rx, field, term)
+    return rx
 
 
 def _is_glob(body):

--- a/beantester/paths.py
+++ b/beantester/paths.py
@@ -12,6 +12,7 @@ reason is package managers - see ``user_data_dir``.
 import os
 import shutil
 import sys
+import tempfile
 
 PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.dirname(PACKAGE_DIR)
@@ -127,6 +128,45 @@ def directory_is_writable(path):
     return True
 
 
+def temp_beside(path):
+    """A temp file NO other writer will pick, in the same directory as ``path``.
+
+    Every atomic write in this program is "write a temp file, then ``os.replace``
+    it over the target", and the temp name was ``<target>.tmp`` in all three
+    places that do it. That name is a FUNCTION OF THE TARGET, so two writers of
+    one file are two writers of one temp file: the second truncates what the
+    first is still writing, and the first then publishes the result as the user's
+    profiles, settings or window state. Nothing stops that - the program has no
+    single-instance lock, and the mutex in ``driver.py`` guards the DRIVER, not
+    these files. Two copies running at once is an ordinary thing to do.
+
+    The same DIRECTORY, not the system temp dir: ``os.replace`` is only atomic
+    within one filesystem, and that is the whole point of the dance.
+
+    What it costs, said out loud because it is a real trade and not a free win:
+    the old name healed itself, since the next write reused it. A unique one
+    cannot, so a process killed between the create and the replace leaves a stray
+    ``.tmp`` behind for good. That is a corrupt user file traded for a stray one,
+    which is the right way round - and where a leftover would do more than sit
+    there (``crashes/``, which has to be EMPTY before it can be removed), the
+    caller sweeps by prefix instead of relying on one known name.
+
+    One more consequence, decided rather than overlooked: on POSIX ``mkstemp``
+    creates the file 0600, and ``os.replace`` carries that mode onto the target, so
+    a config file that used to be 0644 becomes owner-only. On Windows - where a
+    real capture session can only run - the mode is not what decides access at all,
+    and everywhere else these files sit in the user's own data directory, so the
+    change is a tightening in a private place. Copying the old file's mode across
+    would buy nothing and add a failure path to a function that must not have one.
+    """
+    directory, name = os.path.split(path)
+    # No makedirs: a missing directory is the CALLER's error to report, and
+    # mkstemp raising OSError here is how it finds out (see jsonfile.write_json).
+    fd, tmp = tempfile.mkstemp(dir=directory or ".", prefix=name + ".", suffix=".tmp")
+    os.close(fd)
+    return tmp
+
+
 def _same_directory(a, b):
     return os.path.normcase(os.path.abspath(a)) == os.path.normcase(os.path.abspath(b))
 
@@ -165,14 +205,18 @@ def migrate_user_files(source=None, target=None):
         # Scoop's persist leaves behind, and it must be skipped rather than copied.
         if os.path.exists(dst) or not os.path.isfile(src):
             continue
-        tmp = dst + ".tmp"
+        # Two copies of the program launched together both migrate, and they used
+        # to do it through one `<dst>.tmp`: the loser's half-copy became the
+        # user's adopted profile file. See temp_beside.
+        tmp = None
         try:
+            tmp = temp_beside(dst)
             shutil.copyfile(src, tmp)
             os.replace(tmp, dst)        # atomic, so a half-copy is never readable
         except OSError as e:
             problems.append(f"{name}: {e}")
             try:
-                if os.path.exists(tmp):
+                if tmp and os.path.exists(tmp):
                     os.remove(tmp)
             except OSError as _exc:
                 # The leftover is harmless, the silence would not be (convention 30).

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -701,7 +701,29 @@ class PortTable:
             return True
 
     def refresh_if_stale(self, now=None, miss=False):
-        """Refresh when the map is older than the (miss) interval."""
+        """Refresh when the map is older than the (miss) interval.
+
+        **Reads ``_last`` and ``_ports`` WITHOUT ``_lock``, deliberately** - every
+        neighbour here takes it (``snapshot``, ``shared_ports``, ``collected``),
+        and the one other exception, ``pid_for``, carries its reason in writing.
+        This one had none, which is the silence this project treats as a defect in
+        its own right. Three things make it safe, and they are the reason rather
+        than a rationalisation for one that was missing:
+
+        * **Nothing here can be read half-written.** ``_ports`` is only ever
+          REPLACED (one assignment in ``refresh``, under the lock), never mutated
+          in place, and every write to ``_last`` is under the lock too. A reader
+          without the lock therefore sees the old value or the new one, never a
+          torn one.
+        * **The answer is ADVISORY.** All it decides is whether to ASK for a
+          refresh; ``refresh`` itself re-decides under the lock, behind the
+          generation guard that discards an older collection. Being wrong here
+          costs one extra collection, or one cycle's delay - never a wrong map.
+        * **The capture thread walks this path.** ``process_for_port`` calls it for
+          every unknown port. Taking the lock here would put an acquire back on the
+          path that the measurement in ``refresh`` (0.495 ms -> 0.018 ms, by moving
+          work OUT from under the lock) exists to keep clear.
+        """
         now = self.clock() if now is None else now
         limit = self.miss_interval if miss else self.interval
         if (now - self._last) >= limit or not self._ports:

--- a/beantester/scenario_runner.py
+++ b/beantester/scenario_runner.py
@@ -18,10 +18,24 @@ from .summary import settings_summary
 class ScenarioRunner:
     """Runs one scenario against an engine in a background thread."""
 
+    # Long enough that a runner between two steps is always joined (it waits on
+    # the doorbell below, so it exits in microseconds), short enough that one
+    # inside ``apply_settings`` can never hold STOP up. The same number and the
+    # same reason as ``TargetResolver.JOIN_S``: STOP is how the user undoes the
+    # damage they just did to their own network, so it is the one control this
+    # tool may never make slow.
+    JOIN_S = 0.25
+
     def __init__(self, engine):
         self.engine = engine
         self._stop = True
         self._thread = None
+        # The doorbell that makes the join in stop() cheap. The loop used to sleep
+        # in 0.1 s steps, so joining it would have meant waiting up to that long
+        # for a runner with nothing left to do - on a path ``BeanEngine.stop()``
+        # walks. Set by stop(), cleared by start(); nothing else touches it, which
+        # is why it can never be left set while the loop is meant to run.
+        self._wake = threading.Event()
         # Set by the runner thread, read by whoever owns the session. A plain
         # bool on purpose (like ``_stop``): one writer, one transition, never
         # back. It means ONE thing - the timeline ran out - and deliberately not
@@ -30,6 +44,19 @@ class ScenarioRunner:
         self.finished = False
 
     def start(self, scenario, base_settings, log=lambda *_: None):
+        """Start the timeline, after stopping any thread this runner still owns.
+
+        It used to set ``_stop`` back to False and overwrite ``_thread``, which is
+        how a runner could leave an orphan behind: the previous thread kept
+        running with its own stop flag freshly CLEARED, applying its timeline to
+        the same engine, and unreachable through ``stop()`` because that only ever
+        knew about the current thread. ``BeanEngine.start_scenario`` builds a fresh
+        runner every time, so nothing in the program reaches this today - which is
+        the same "nobody calls it twice today is not a property of the object" the
+        engine-side docstring already argues for its own half of this.
+        """
+        self.stop()
+        self._wake.clear()
         self._stop = False
         self.finished = False
         self._thread = threading.Thread(
@@ -37,8 +64,35 @@ class ScenarioRunner:
             daemon=True)
         self._thread.start()
 
-    def stop(self):
+    def stop(self, timeout=JOIN_S):
+        """End the timeline, and wait briefly for the thread to actually be gone.
+
+        A flag on its own let ``stop()`` return while the thread was still between
+        two steps, so up to one more ``apply_settings`` landed on the engine AFTER
+        the caller believed the scenario was over - and on a restart, the old
+        timeline's last step could overwrite the new one's first.
+
+        It never joins the CALLING thread, and that is not defensive coding: the
+        runner thread reaches here on its own failure path. ``_loop`` catches, calls
+        ``engine.worker_failed``, which is ``_fail_stop`` -> ``_worker_stop`` ->
+        ``_stop_locked`` -> ``stop_scenario()`` -> here. Joining yourself raises,
+        and it would raise inside the net that exists to handle a failure.
+
+        No deadlock against ``BeanEngine.stop()``, which holds ``_stop_lock`` while
+        calling this: the runner thread never BLOCKS on that lock (its only route
+        to it is ``_fail_stop(blocking=False)``, which bows out under contention),
+        and ``apply_settings`` reaches no further than ``core._lock``.
+        """
         self._stop = True
+        self._wake.set()
+        # A local reference: a concurrent start() may put a new thread in place,
+        # and this join belongs to the old one. `_thread` is deliberately NOT
+        # cleared - a stopped runner that can still be asked whether its thread is
+        # gone is what the guards on this class read.
+        thread = self._thread
+        if (thread is not None and thread.is_alive()
+                and thread is not threading.current_thread()):
+            thread.join(timeout=timeout)
 
     def _loop(self, scenario, base, log):
         """The thread body: run the timeline, and never die in silence.
@@ -98,4 +152,7 @@ class ScenarioRunner:
                 self.finished = True
                 log(T("log.scenario_finished"))
                 break
-            time.sleep(0.1)
+            # The doorbell, not a plain sleep: the step interval is unchanged, but
+            # stop() can now end this wait at once instead of leaving whoever
+            # called it to wait out the rest of a tick. See ScenarioRunner.stop.
+            self._wake.wait(0.1)

--- a/beantester/settings.py
+++ b/beantester/settings.py
@@ -6,11 +6,12 @@ settings dict and applies it to an engine.
 """
 import difflib
 import socket
+from contextlib import nullcontext
 
 from . import crashlog
 from . import fields as F
 from . import portmap
-from .core import burst_loss_params
+from .core import burst_loss_params, compile_endpoint
 from .jsonfile import load_json, write_json
 from .fields import FIELD_DEFS, FIELDS
 from .i18n import T, translate
@@ -537,8 +538,27 @@ def _say_what_the_burst_loss_will_do(loss_pct, mean_burst, log):
           gap=number_string(round(to_number(mean_burst) / achievable))))
 
 
+def _batch(engine):
+    """Hold the core's lock across a whole apply - when there is a core to ask.
+
+    ``getattr`` for the same reason ``_destination_is_frozen`` below uses it, and
+    it is not defensive habit: ``apply_settings`` is handed engine doubles by the
+    tests and by ``ScenarioRunner``'s fakes, and an object without a ``core`` is
+    simply not running one. A passthrough on ``BeanEngine`` instead would have to
+    be mirrored by every one of those doubles to keep them working.
+    """
+    batch = getattr(getattr(engine, "core", None), "batch", None)
+    return batch() if callable(batch) else nullcontext()
+
+
 def apply_settings(engine, s, log=lambda *_: None):
     """Configure the engine from a flat settings dict (shared by GUI and CLI).
+
+    Applied as ONE batch, under a single hold of the core's lock: the setters used
+    to take and release it one at a time, so a packet decided in the middle was
+    judged by a mixture of the old configuration and the new. See
+    :meth:`BeanCore.batch` - including what that batch deliberately does NOT
+    cover, which is process targeting.
 
     ``filter`` and ``duration`` are deliberately NOT applied here: both belong to
     the session and are consumed by ``BeanEngine.start()``. Applying them live
@@ -546,10 +566,13 @@ def apply_settings(engine, s, log=lambda *_: None):
     move a deadline the engine is already counting against.
     """
     g = lambda k: s.get(k, DEFAULT_SETTINGS[k])
-    engine.set_params(g("loss"), g("corrupt"), g("dup"),
-                      g("latency"), g("jitter"), g("down"), g("up"))
-    engine.set_buffer(g("buffer"))
-    engine.set_loss_burst(g("loss_burst"))
+    # -- prepare: everything that can take time, or say something ------------- #
+    # Nothing below this comment touches the engine, and that is the shape of the
+    # fix. Compiling an expression, parsing a schedule and writing a log line all
+    # happen BEFORE the batch opens, so what the batch holds `core._lock` for is
+    # assignments and nothing else. The log lines come out in the order they
+    # always did - only their interleaving with the setters is gone, and setters
+    # do not log.
     _say_what_the_burst_loss_will_do(g("loss"), g("loss_burst"), log)
     dst_ip = setting_expression("dst_ip", g("dst_ip"))
     dst_port = setting_expression("dst_port", g("dst_port"))
@@ -560,26 +583,24 @@ def apply_settings(engine, s, log=lambda *_: None):
     # user just asked to impair would never arrive, and every counter would read
     # healthy. Refusing out loud is the only honest option - silently applying half
     # of it is the failure mode this whole audit exists to remove.
+    dest = None                                 # None = leave the destination alone
     if _destination_is_frozen(engine, dst_ip, dst_port):
         log(T("log.dest_frozen_while_narrowed"))
     else:
         try:
-            engine.set_dest(bool(dst_ip or dst_port), dst_ip, dst_port)
+            dest = (bool(dst_ip or dst_port), *compile_endpoint(dst_ip, dst_port))
         except ValueError as e:
             # Tolerant like the schedule below: a bad expression disables destination
             # targeting instead of killing a scenario thread. The GUI and the CLI
             # validate up front (validate_settings), so a user never reaches this.
             log(f"{T('log.filter_skipped')}: {e}")
-            engine.set_dest(False)
-    engine.set_ip_family(bool(g("ipv4_only")), bool(g("ipv6_only")))
+            dest = (False, *compile_endpoint(None, None))
     # The same shape as the pair below, and said for the same reason: two "only"
     # switches that exclude each other leave nothing to aim at, the symptom is a
     # session that changes nothing, and that looks like a broken tool rather than
     # like the tool doing what it was told.
     if g("ipv4_only") and g("ipv6_only"):
         log(T("log.ipv4_and_ipv6_only"))
-    engine.set_lan(bool(g("lan_mode")))
-    engine.set_internet_only(bool(g("internet_only")))
     # Both at once is a legal request - it is the union of two impairments, the
     # same as --loss 100 - but it is far more likely to be a mistake, and the
     # symptom (nothing but loopback moves) looks like the tool is broken rather
@@ -590,22 +611,45 @@ def apply_settings(engine, s, log=lambda *_: None):
     block_ip = setting_expression("block_ip", g("block_ip"))
     block_port = setting_expression("block_port", g("block_port"))
     try:
-        engine.set_block(bool(block_ip or block_port), block_ip, block_port)
+        block = (bool(block_ip or block_port), *compile_endpoint(block_ip, block_port))
     except ValueError as e:
         # Tolerant like destination above: a bad expression disables blocking
         # instead of killing a scenario thread. GUI and CLI validate up front.
         log(f"{T('log.filter_skipped')}: {e}")
-        engine.set_block(False)
-    engine.set_advanced(g("syn_drop"), g("max_size"))
-    engine.set_spike(g("spike_prob"), g("spike_ms"))
-    engine.set_nat(g("nat_timeout"))
-    engine.set_rst(g("rst_prob"), g("rst_cooldown"))
-    engine.set_flap(g("flap_period") > 0, g("flap_period"), g("flap_down"))
+        block = (False, *compile_endpoint(None, None))
     try:
-        engine.set_schedule(parse_schedule(g("rate_schedule")))
+        schedule = parse_schedule(g("rate_schedule"))
     except ValueError as e:
         log(f"{T('log.schedule_skipped')}: {e}")
-        engine.set_schedule([])
+        schedule = []
+
+    # -- apply: one lock hold, so no packet sees half of this ----------------- #
+    with _batch(engine):
+        engine.set_params(g("loss"), g("corrupt"), g("dup"),
+                          g("latency"), g("jitter"), g("down"), g("up"))
+        engine.set_buffer(g("buffer"))
+        engine.set_loss_burst(g("loss_burst"))
+        if dest is not None:
+            engine.set_dest(*dest)
+        engine.set_ip_family(bool(g("ipv4_only")), bool(g("ipv6_only")))
+        engine.set_lan(bool(g("lan_mode")))
+        engine.set_internet_only(bool(g("internet_only")))
+        engine.set_block(*block)
+        engine.set_advanced(g("syn_drop"), g("max_size"))
+        engine.set_spike(g("spike_prob"), g("spike_ms"))
+        engine.set_nat(g("nat_timeout"))
+        engine.set_rst(g("rst_prob"), g("rst_cooldown"))
+        engine.set_flap(g("flap_period") > 0, g("flap_period"), g("flap_down"))
+        engine.set_schedule(schedule)
+
+    # OUTSIDE the batch, deliberately, and this is the boundary of what "atomic"
+    # means here: resolving a target walks the socket table, which this project
+    # has measured at 1.7 s cold, and the capture thread waits for whatever the
+    # core's lock is holding. So the impairment parameters and the gates change
+    # as one, and process targeting follows a moment later. A scenario step may
+    # legally carry `target`, so that window is real rather than theoretical -
+    # closing it would mean holding the packet path across an OS walk, which is
+    # the trade this refuses to make. See BeanCore.batch.
     apply_targeting(engine, str(g("target")).strip(), log)
 
 

--- a/beantester/target_resolver.py
+++ b/beantester/target_resolver.py
@@ -158,7 +158,7 @@ class TargetResolver:
             try:
                 targeting.adopt_new_pids()
             except Exception as exc:
-                crashlog.once("targeting.adopt", exc)
+                crashlog.note(exc, "targeting.adopt")   # note, not once: see below
 
             # THE FLOOR, and it is not optional. Targeting narrows traffic to one
             # application, so every packet from every OTHER application is a miss:
@@ -200,6 +200,16 @@ class TargetResolver:
                 # The session must not die because a socket table hiccupped; the
                 # port set simply goes stale until the next pass. But it stops
                 # being invisible.
-                crashlog.once("targeting.resolver", exc)
+                #
+                # `note`, not `once`, and the difference is not stylistic. `once`
+                # keys on the SUBSYSTEM NAME alone, so the first failure here would
+                # silence every LATER one - including a different fault entirely,
+                # which is the one worth reading. The cost argument that puts
+                # `once` in the packet path does not apply: this line runs only
+                # when something has ALREADY failed, at most once per
+                # `min_interval`, so the traceback it builds is paid for out of a
+                # budget that is otherwise unspent. Repeats stay cheap on disk
+                # because `record` de-duplicates them by fingerprint.
+                crashlog.note(exc, "targeting.resolver")
             self._last_rebuild = time.monotonic()
             self._wake.wait(timeout=self.interval)

--- a/beantester/targeting.py
+++ b/beantester/targeting.py
@@ -157,6 +157,28 @@ class ProcessTargeting:
         """Rebuild the port set from the current socket table."""
         now = self.clock() if now is None else now
         with self._lock:
+            # Emptied HERE, before the walk, and it used to be emptied at the end
+            # of it. Two things follow, and both matter:
+            #
+            # * a walk that FAILS no longer leaves the dict behind. It is only ever
+            #   cleared on success, so a socket table that kept hiccupping left
+            #   this growing - and worse than growing, growing STALE: the rescue
+            #   below keeps a port whose recorded owner is still targeted, so once
+            #   a refresh finally succeeded it could put a port back in scope whose
+            #   socket had closed long before, and which the OS may since have
+            #   handed to somebody else. That breaks the "until the next rebuild"
+            #   bound this class documents and that the recycled-pid guard pins.
+            # * what survives the walk is now exactly what the walk could not have
+            #   seen - a port noted BEFORE the collection started is in the fresh
+            #   snapshot already if its socket is still open, and if it is not, it
+            #   has no business being rescued.
+            #
+            # The bound is therefore TEMPORAL (one walk) rather than numeric, which
+            # is what a ceiling like MAX_PENDING_PIDS below is approximating: the
+            # dict is keyed by PORT, so it could never exceed the port space, and
+            # a count would only start dropping legitimate rescues in a burst.
+            with self._ports_lock:
+                self._late_owners = {}
             self.table.refresh(force=force)
             port_pid = self.table.snapshot()
             pids, names = set(), set()
@@ -195,10 +217,9 @@ class ProcessTargeting:
                 self._pids = frozenset(pids)
                 # ...but a port the live map handed us WHILE this walk was running is
                 # newer than the walk, so it survives it - if it is still ours (see
-                # `late` above). Cleared afterwards: it is part of _ports now, and the
-                # next snapshot judges it like any other.
+                # `late` above). It is part of _ports from here on, and the next
+                # walk empties the dict again before it starts.
                 self._ports = resolved | late
-                self._late_owners = {}
                 self._pending_pids = frozenset()
                 self._not_ours = frozenset()
             self._names = tuple(sorted(n for n in names if n))

--- a/beantester/views.py
+++ b/beantester/views.py
@@ -54,62 +54,6 @@ FALSE_WORDS = {"no", "n", "false", "0", "nie"}
 _BOUNDS = {"port": PORT_BOUNDS, "lport": PORT_BOUNDS}
 
 
-class SearchIndex:
-    """Cached lowercase search text, one entry per row.
-
-    Searching a table means matching the query against every column of every row.
-    That is fine for the four columns the connection log has today. It is not fine
-    for the tables this tool is heading towards: measured over **30 columns**, a
-    plain scan costs 307 ms at 100 000 rows, **1.6 s at 500 000** and 3.5 s at a
-    million - per keystroke, on the UI thread.
-
-    Nearly all of that is rebuilding the same strings over and over: the fields a
-    search looks at (process, protocol, addresses, ports) do not change over a
-    flow's life. So join and lowercase them ONCE, keep the result, and a search
-    becomes a substring test - which is ~25x cheaper and, more importantly, flat in
-    the number of columns.
-
-    The cache is owned by the PAGE, not written into the engine's rows. The capture
-    thread writes to those dicts continuously; adding a key to one from the UI
-    thread can resize it under a reader's feet ("dictionary changed size during
-    iteration"), and a caching layer that corrupts the thing it is caching is not a
-    good trade.
-    """
-
-    def __init__(self, blob_of, key_of, limit=250_000):
-        self._blob_of = blob_of         # item -> the text to search (uncached)
-        self._key_of = key_of           # item -> stable identity
-        self._limit = int(limit)
-        self._cache = {}                # key -> (stamp, blob)
-
-    def blob(self, item, stamp=None):
-        """The search text for ``item``, built at most once per ``stamp``.
-
-        ``stamp`` is whatever makes the text stale - for a connection that is the
-        process name, which starts out unknown and is filled in later.
-        """
-        key = self._key_of(item)
-        hit = self._cache.get(key)
-        if hit is not None and hit[0] == stamp:
-            return hit[1]
-        blob = self._blob_of(item).lower()
-        if len(self._cache) >= self._limit:
-            self._cache.clear()         # bounded: a table this size churns anyway
-        self._cache[key] = (stamp, blob)
-        return blob
-
-    def filter(self, items, query, stamp_of=None):
-        q = (query or "").strip().lower()
-        if not q:
-            return list(items)
-        if stamp_of is None:
-            return [it for it in items if q in self.blob(it)]
-        return [it for it in items if q in self.blob(it, stamp_of(it))]
-
-    def clear(self):
-        self._cache.clear()
-
-
 def sort_events(events, sort_col="t", reverse=False):
     """Sort events (tuples: t, iso, type, description) by the chosen column."""
     idx = {"t": 0, "time": 1, "type": 2, "desc": 3}.get(sort_col, 0)
@@ -186,9 +130,18 @@ def compile_query(query):
     """Turn a search string into a list of predicates, ONCE per query.
 
     Compiling per row would put the expression parser on the path of every one of
-    a hundred thousand rows on every keystroke, which is the shape of the problem
-    ``SearchIndex`` exists to solve, reintroduced one layer up. So parse here and
-    return closures; the row loop then only calls them.
+    a hundred thousand rows on every search, so parse here and return closures.
+    The row loop then only calls them.
+
+    🔴 The row text itself is built fresh every time and deliberately NOT cached.
+    A cache was written for exactly that (``SearchIndex``, removed 2026-09-02) and
+    it cannot be correct here: ``_connection_blob`` reads ``dir`` and ``proto``,
+    and ``engine._log_conn`` rewrites BOTH on every packet of a flow - ``dir``
+    holds the direction of the last one, so it flips continuously on anything
+    two-way. A cache keyed on the process name, which is what that class was built
+    around, would serve a stale direction and quietly return the wrong rows. Keyed
+    on everything that moves, it missed 7 of 12 active flows per second (measured
+    2026-09-02), and a miss costs more than not caching at all. See the ADR.
 
     A term is either ``field:value`` or bare text. Terms are ANDed, because that is
     what narrowing means and what every search box a tester has used does.

--- a/beantester/views.py
+++ b/beantester/views.py
@@ -249,14 +249,21 @@ def _filter_connections(conns, query, proc_map):
     return [c for c in conns if all(t(c, proc_map) for t in tests)]
 
 
-def traffic_totals(conns, query="", proc_map=None):
-    """Summed download / upload / total BYTES over the FILTERED rows.
+def filter_connections(conns, query="", proc_map=None):
+    """The rows a query selects, unsorted, as a NEW list.
 
-    Feeds the connection table's footer. It sums every matching flow, not only the
-    rows that fit under the display limit, so the footer is a true total of what the
-    search selects - which is exactly the number the display cap hides."""
+    The filtering half on its own, so a caller that needs both the sorted view and
+    a total over the whole match can pay for the pass once. ``filter_sort_connections``
+    and ``traffic_totals`` are this plus their own half, and both keep their
+    signatures - they are the surface the facade exports and the tests pin.
+    """
+    return _filter_connections(conns, query, proc_map)
+
+
+def sum_traffic(rows):
+    """Summed download / upload / total DELIVERED bytes over rows already chosen."""
     down = up = total = 0
-    for c in _filter_connections(conns, query, proc_map):
+    for c in rows:
         # DELIVERED, because the footer uses the same three words as the columns
         # above it ("down / up / total") and those are delivered now. A footer
         # summing captured under headings that mean delivered is the same mismatch
@@ -265,6 +272,15 @@ def traffic_totals(conns, query="", proc_map=None):
         up += c.get("sent_out", 0)
         total += c.get("sent", 0)
     return {"down": down, "up": up, "total": total}
+
+
+def traffic_totals(conns, query="", proc_map=None):
+    """Summed download / upload / total BYTES over the FILTERED rows.
+
+    Feeds the connection table's footer. It sums every matching flow, not only the
+    rows that fit under the display limit, so the footer is a true total of what the
+    search selects - which is exactly the number the display cap hides."""
+    return sum_traffic(_filter_connections(conns, query, proc_map))
 
 
 def filter_sort_connections(conns, query="", sort_col="bytes", reverse=True,
@@ -296,7 +312,23 @@ def filter_sort_connections(conns, query="", sort_col="bytes", reverse=True,
     also of benchmarking this with keys drawn from a tiny range: Timsort exploits
     the resulting runs and the sort column comes out artificially fast.)
     """
-    out = _filter_connections(conns, query, proc_map)
+    return sort_connections(_filter_connections(conns, query, proc_map),
+                            sort_col, reverse, now, limit)
+
+
+def sort_connections(out, sort_col="bytes", reverse=True, now=None, limit=0):
+    """The sorting half of :func:`filter_sort_connections`, on rows already chosen.
+
+    🔴 MAY REORDER ``out`` IN PLACE. That is deliberate and it is what makes the
+    split worth making: the caller that needs both a sorted view and a total over
+    the whole match hands the same list to this and to ``sum_traffic``, and pays
+    for neither a second filtering pass nor a second copy of two hundred thousand
+    rows. Order does not matter to a sum. Every caller today owns the list it
+    passes, because it came out of ``filter_connections``.
+
+    See ``filter_sort_connections`` above for what ``limit`` buys and the
+    measurement behind the crossover.
+    """
     numeric = sort_col in ("remote_port", "local_port", "packets", "bytes",
                            "bytes_in", "bytes_out", "sent", "sent_in", "sent_out",
                            "down", "up", "kb", "down_seen", "up_seen", "avg",

--- a/lang/en.json
+++ b/lang/en.json
@@ -138,6 +138,7 @@
   "errors.config_unknown_setting_hint": "Unknown setting in the config file: {field}. Did you mean '{suggestion}'?",
   "errors.field_number": "The '{name}' field must be a number.",
   "errors.field_range": "Field '{name}' must be between {min} and {max}.",
+  "errors.filter_regex_too_slow": "Field '{field}': '{term}' is a valid regular expression, but it is too slow to run on every packet. A repeat inside another repeat, like ([0-9]+)+, is the usual cause.",
   "errors.scenario_bad_json": "Not a valid JSON file: {error}.",
   "errors.scenario_duration_without_action": "Scenario, step {step}: \"duration\" only applies to an \"action\" - this step has none.",
   "errors.scenario_empty": "Scenario: the step list is empty.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -264,6 +264,7 @@
   "log.bug_marked": "BUG MARKED",
   "log.config_loaded_from": "Config loaded from",
   "log.config_saved_to": "Config saved to",
+  "log.conns_export_busy": "An export is already running. Wait for it to finish before starting another.",
   "log.conns_saved_to": "Connections saved to",
   "log.copied": "Copied to clipboard",
   "log.csv_error": "CSV save error",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -264,6 +264,7 @@
   "log.bug_marked": "ZAZNACZONO BŁĄD",
   "log.config_loaded_from": "Wczytano konfigurację z",
   "log.config_saved_to": "Zapisano konfigurację do",
+  "log.conns_export_busy": "Eksport już trwa. Poczekaj, aż się skończy, zanim uruchomisz kolejny.",
   "log.conns_saved_to": "Zapisano połączenia do",
   "log.copied": "Skopiowano do schowka",
   "log.csv_error": "Błąd zapisu CSV",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -138,6 +138,7 @@
   "errors.config_unknown_setting_hint": "Nieznane ustawienie w pliku konfiguracji: {field}. Czy chodziło o '{suggestion}'?",
   "errors.field_number": "Pole '{name}' musi być liczbą.",
   "errors.field_range": "Pole '{name}' musi mieścić się w zakresie od {min} do {max}.",
+  "errors.filter_regex_too_slow": "Pole '{field}': '{term}' to poprawne wyrażenie regularne, ale jest za wolne, żeby uruchamiać je na każdym pakiecie. Najczęstsza przyczyna to powtórzenie wewnątrz powtórzenia, na przykład ([0-9]+)+.",
   "errors.scenario_bad_json": "To nie jest poprawny plik JSON: {error}.",
   "errors.scenario_duration_without_action": "Scenariusz, krok {step}: \"duration\" dotyczy tylko \"action\", a ten krok jej nie ma.",
   "errors.scenario_empty": "Scenariusz: lista kroków jest pusta.",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -264,6 +264,7 @@
   "log.bug_marked": "已标记故障",
   "log.config_loaded_from": "配置已加载自",
   "log.config_saved_to": "配置已保存至",
+  "log.conns_export_busy": "导出已在进行中。请等待其完成后再开始新的导出。",
   "log.conns_saved_to": "连接列表已保存至",
   "log.copied": "已复制到剪贴板",
   "log.csv_error": "保存 CSV 时出错",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -138,6 +138,7 @@
   "errors.config_unknown_setting_hint": "配置文件中存在未知设置：{field}。你是不是想写“{suggestion}”？",
   "errors.field_number": "“{name}”字段必须是数字。",
   "errors.field_range": "字段“{name}”必须介于 {min} 和 {max} 之间。",
+  "errors.filter_regex_too_slow": "字段“{field}”：“{term}”是有效的正则表达式，但对每个数据包运行都太慢。最常见的原因是重复中嵌套重复，例如 ([0-9]+)+。",
   "errors.scenario_bad_json": "不是有效的 JSON 文件：{error}。",
   "errors.scenario_duration_without_action": "场景第 {step} 步：“duration”只能与“action”一起使用，但此步骤没有 action。",
   "errors.scenario_empty": "场景：步骤列表为空。",

--- a/tests/test_cli_runtime.py
+++ b/tests/test_cli_runtime.py
@@ -91,12 +91,60 @@ def test_exit_code_config_for_bad_input():
         "out of range": ["--loss", "250", "--simulate"],
         "negative duration": ["--duration", "-5", "--simulate"],
         "zero interval": ["--interval", "0", "--simulate"],
+        "nan interval": ["--interval", "nan", "--simulate"],
+        "infinite interval": ["--interval", "inf", "--simulate"],
+        "interval past the ceiling": ["--interval", "86401", "--simulate"],
     }
     for name, argv in cases.items():
         code, out, err = cli(argv)
         check(f"exit: {name} -> CONFIG(3)", code == exitcodes.CONFIG, f"(code={code})")
         check(f"exit: {name} explains itself on stderr", "error:" in err, f"({err!r})")
         check(f"exit: {name} keeps stdout clean", out == "", f"({out!r})")
+
+
+def test_the_report_interval_is_refused_while_it_is_still_a_number_on_a_command_line():
+    """Every rejected interval is rejected by CONFIGURATION, never by the loop.
+
+    ``--interval`` is the only ``type=float`` flag that does not reach
+    ``range_errors``: a reporting cadence is not a field in ``fields.py``, because
+    it changes nothing about the traffic and belongs in no profile. So it was the
+    one numeric door in the program that accepted NaN and infinity, and each of
+    them failed differently once the loop had them (measured 2026-09-02):
+
+    * ``nan``  - ``wake > now`` is false forever, so the loop never sleeps. At
+      100% of a core, printing nothing, and with no ``--duration`` it never
+      returns. Exit code 0.
+    * ``inf``  - ``time.sleep`` raises ``OverflowError`` and the session ends as
+      a fault.
+    * ``1e18`` - the SAME ``OverflowError``, because ``time.sleep`` is int64
+      nanoseconds and gives up above ~9.223e9 s. A finiteness test alone would
+      have closed two values out of that class, which is why the check is a
+      RANGE.
+
+    Asked of ``config_from_args`` rather than of a run, because that is the claim:
+    the value dies before anything is started. It also means a regression here
+    reports a failure instead of hanging the suite on the loop it describes - on
+    virtual time, a NaN interval spins without ever advancing the clock.
+    """
+    # ``--interval=<value>``, not two tokens: argparse reads a leading "-" as the
+    # start of another option, so "-inf" as a separate word never reaches the
+    # check this test is about.
+    for value in ("nan", "inf", "-inf", "1e18", "86400.5"):
+        args = build_arg_parser().parse_args(["--simulate", f"--interval={value}"])
+        try:
+            config_from_args(args)
+        except SystemExit as exc:
+            check(f"interval {value}: refused with CONFIG(3)",
+                  getattr(exc, "code", None) == exitcodes.CONFIG,
+                  f"(code={getattr(exc, 'code', None)})")
+        else:
+            check(f"interval {value}: refused at all", False, "(it was accepted)")
+
+    # The ceiling itself is a legal cadence, not the first illegal one. Without
+    # this the guard could tighten by a second and nothing would notice.
+    args = build_arg_parser().parse_args(["--simulate", "--interval", "86400"])
+    check("interval 86400: the ceiling itself is accepted",
+          config_from_args(args)["interval"] == 86400.0)
 
 
 def test_exit_code_scenario_when_the_scenario_file_is_missing():

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -133,6 +133,20 @@ def test_the_decision_core_never_swallows_an_exception_silently():
 # against. Measured 2026-08-21: no name in the package is used only from a rig
 # today, so this costs nothing now and stops costing something later.
 USAGE_TREES = ("beantester", "tests", "tools", "lang", "scenarios")
+# 🔴 ...but a mention from the TEST tree is not LIFE. The trees above decide what
+# gets READ. This decides what counts as a consumer, and they are different
+# questions. A definition whose only callers are its own tests is dead code with a
+# test suite attached: it passes, it reads as maintained, and nothing in the
+# program would notice if it vanished.
+#
+# MEASURED, and it is why this line exists: `views.SearchIndex` was ~90 lines of
+# search cache with five tests, a docstring pricing its benefit, and ZERO
+# consumers - and this guard called it alive for months because `test_views.py`
+# named it. Removing the tests from the walk instead would blind the scan to the
+# GUI tests, which are Python source inside `run_gui("""...""")` strings and are
+# the only place several live names appear (see the block below). So the mentions
+# are still collected, and marked.
+TEST_TREES = ("tests/",)
 USAGE_FILES = ("bean_network_tester.py", "smoke_gui.py", "build.py",
                "BeanNetworkTester.spec")
 USAGE_EXTS = (".py", ".json", ".spec")
@@ -172,6 +186,38 @@ KNOWN_UNUSED = {
     "get_field": "an OVERRIDE of string.Formatter.get_field - the base class calls "
                  "it, so no line in this package ever names it. Deleting it would "
                  "restore attribute access inside translation templates",
+
+    # The nine this guard could not see until TEST_TREES stopped counting as life
+    # (2026-09-02). Each one is here with what it actually is, not with a shrug:
+    # the point of this dict is that an unused name carries a REASON, and "nobody
+    # has decided yet" is a reason as long as it says so. Tracked as B-16.
+    "_settle_transition": "EXISTS for the tests and says so in its own docstring: "
+                          "the live UI drains _ui_queue from _tick and never needs "
+                          "it, so a headless test can drive the async start/stop "
+                          "deterministically. Deleting it deletes those tests",
+    "reset_default_table": "the same, and its docstring is one word long: (tests). "
+                           "Drops the shared port table so one test cannot inherit "
+                           "another's",
+    "install_tk": "SUPERSEDED by App._on_ui_exception, which does strictly more "
+                  "(records, logs, and shows one dialog per fingerprint) and owns "
+                  "report_callback_exception. Not deleted yet for one reason: its "
+                  "two tests are the ONLY guard on the source=\"tk-callback\" tag "
+                  "reaching the file, and the live path has none. The tag needs a "
+                  "test on App._on_ui_exception before this can go - B-16",
+    "recent": "reads the crash log back 'for the UI', and there is no crash panel. "
+              "No consumer, no decision taken - B-16",
+    "set_enabled": "the global off switch for crash recording. Nothing turns it "
+                   "off. No consumer, no decision taken - B-16",
+    "driver_used": "an accessor for _DRIVER_USED[0], which driver.py reads "
+                   "directly at the one place that cares. Redundant wrapper - B-16",
+    "notices_text": "reads THIRD-PARTY-NOTICES.md. The About window shows the "
+                    "about.third_party LABEL and never the file. Either the window "
+                    "is missing something or this is - B-16",
+    "show_info": "the third of show_error / show_warning / show_info. The family is "
+                 "complete and only two members are called. Deleting it is a "
+                 "decision about that symmetry - B-16",
+    "time_left": "seconds until the deadline. Nothing asks. No consumer, no "
+                 "decision taken - B-16",
 }
 
 
@@ -245,8 +291,9 @@ def _unreferenced():
             if not found:
                 continue
             site = enclosing(rel, number) if in_package else None
+            outside = "TESTS" if rel.startswith(TEST_TREES) else "EXTERNAL"
             for word in found:
-                mentions.setdefault(word, set()).add(site or "EXTERNAL")
+                mentions.setdefault(word, set()).add(site or outside)
 
     dead = set()
     while True:
@@ -259,13 +306,38 @@ def _unreferenced():
                 continue
             # A mention from a dead site is not life, and neither is a function
             # naming itself - recursion keeps nothing alive.
+            # "TESTS" is deliberately absent from this list: a test is not a
+            # consumer. A definition that genuinely exists FOR the tests says so in
+            # KNOWN_UNUSED, where the reason is written down and read.
             living = [s for s in mentions.get(name, ())
-                      if s == "EXTERNAL" or (s not in dead and s != key)]
+                      if s == "EXTERNAL"
+                      or (s != "TESTS" and s not in dead and s != key)]
             if not living:
                 dead.add(key)
                 grew = True
         if not grew:
             return sorted(dead), files, len(definitions)
+
+
+def test_a_definition_only_its_own_tests_name_is_not_counted_as_alive():
+    """The guard for the guard: without this, TEST_TREES could be reverted silently.
+
+    Filling KNOWN_UNUSED makes the scan green again, so the test above passes just
+    as happily whether a test mention counts as life or not - and the whole point of
+    that distinction is that `views.SearchIndex` was ~90 lines with five tests, a
+    docstring pricing its benefit and no consumers, and this file called it alive
+    for months.
+
+    `_settle_transition` is the probe because it is the clearest case in the tree:
+    its own docstring says the live UI never needs it and it exists so a headless
+    test can drive the async start/stop. If it is ever called from the package, this
+    goes red and says so, which is the right kind of red.
+    """
+    dead, _, _ = _unreferenced()
+    names = {name for name, _rel, _line in dead}
+    check("a definition whose only callers are tests is reported unused",
+          "_settle_transition" in names,
+          "(a test mention is being counted as a consumer again)")
 
 
 def test_no_definition_in_the_package_is_unreferenced():

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -61,6 +61,14 @@ from fakes import ROOT, check
 # there for a week and were found only because somebody printed the numbers. That is
 # the same defect the crowd counts below exist to catch, one level up.
 FUNCTION_CEILING = 133          # beantester/cli.py::_run_session
+# Lowered 2026-09-02 from 1192, the routine door again: the four GUI lifecycle fixes
+# needed room in `app.py`, which was pinned to the ceiling exactly, so the log box's
+# own bookkeeping moved to `gui/logview.py` and the fixes went in under the number
+# instead of over it. 🔴 The band matters more than usual now: at 1166 it sits at
+# 816, and `engine.py` is 808 after gaining the capture-thread pulse, so there are
+# EIGHT lines between it and joining `FILES_NEAR_CEILING`. Carving more out of
+# `app.py` from here does not buy room - it lowers the band onto `engine.py` and
+# forces the crowd count up, which is the one direction these numbers may not go.
 # Lowered 2026-08-19 from 1202: fifteen compatibility aliases assigned one per line
 # became a loop over their names, which is also what mypy asked for (a class does not
 # grow attributes from outside its own body). Ten lines out, ten lines off the ceiling.
@@ -69,7 +77,7 @@ FUNCTION_CEILING = 133          # beantester/cli.py::_run_session
 # ceiling exactly, so the two CSV exports moved to `gui/csv_export.py` instead of the
 # number moving up. The crowd band below was re-measured after the drop (`engine.py`
 # is 779, still clear of it) - lowering a ceiling tightens that band too.
-FILE_CEILING = 1192             # beantester/gui/app.py
+FILE_CEILING = 1166             # beantester/gui/app.py
 
 # 🔴 THE SECOND KNOB. A ceiling on the worst single item sees one thing growing
 # to a record and is blind to everything creeping upward together: five files at

--- a/tests/test_conns_export.py
+++ b/tests/test_conns_export.py
@@ -32,7 +32,8 @@ def test_export_connections_csv_writes_the_current_view():
         ]
         app.conn_query = ""
         app.conn_sort = {"col": "up", "reverse": True}     # sort by upload, desc
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
         # the header mirrors the table's columns
@@ -89,7 +90,8 @@ def test_a_failed_connections_export_leaves_no_tmp_file_behind():
         ]
         app.conn_query = ""
         app.conn_sort = {"col": "packets", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         assert not os.path.exists(path + ".tmp"), "a half-written .tmp was left behind"
         assert not os.path.exists(path), "a failed export must not create the real file"
@@ -115,7 +117,8 @@ def test_export_connections_csv_writes_a_portless_row_with_empty_port_cells():
         ]
         app.conn_query = ""
         app.conn_sort = {"col": "packets", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
         assert len(rows) == 2, rows
@@ -146,7 +149,8 @@ def test_export_connections_csv_honours_the_search():
         ]
         app.conn_query = "chrome"                          # only one row matches
         app.conn_sort = {"col": "up", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
         assert len(rows) == 2, rows            # header + the single matching row
@@ -174,7 +178,8 @@ def test_export_connections_csv_avg_matches_the_table_rounding():
         app.engine.connections_snapshot = lambda limit=None: [row]
         app.conn_query = ""
         app.conn_sort = {"col": "bytes", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
         avg = rows[0].index("avg_bytes")
@@ -239,7 +244,8 @@ def test_both_exports_tell_the_user_the_whole_path():
         app.engine.connections_snapshot = lambda limit=None: []
         app.conn_query = ""
         app.conn_sort = {"col": "up", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         for name in ("stats.csv", "conns.csv"):
             said = [l for l in lines if name in l]
@@ -278,7 +284,8 @@ def test_a_process_name_cannot_arrive_as_a_spreadsheet_formula():
         ]
         app.conn_query = ""
         app.conn_sort = {"col": "up", "reverse": True}
-        app.export_connections_csv()
+        app.export_connections_csv().join(20)   # the export runs off-thread now
+        app._logview.drain()   # ...and a worker's log line lands on the next tick
 
         rows = list(csv.reader(open(path, newline="", encoding="utf-8")))
         name = rows[1][0]
@@ -286,4 +293,85 @@ def test_a_process_name_cannot_arrive_as_a_spreadsheet_formula():
         assert "HYPERLINK" in name, "the name itself must survive: %r" % name
         assert rows[1][6] == "4", "packets stopped being a number: %r" % rows[1][6]
         assert rows[1][8] == "3", "dropped stopped being a number: %r" % rows[1][8]
+    ''')
+
+
+def test_a_second_export_is_refused_while_the_first_is_still_writing():
+    """Two clicks, one file - definition of done, point 9.
+
+    `CONNECTIONS_CSV_FILE` is a single fixed path, so two workers racing to
+    `os.replace` it would publish whichever finished last and silently discard the
+    other. Now that the write is off the UI thread the window stays responsive
+    during it, which makes the second click EASIER than it used to be.
+
+    The lock is held by the test rather than by a real first export, so this asks
+    the question without racing to ask it.
+    """
+    run_gui('''
+        import os, tempfile
+        import beantester.gui.csv_export as m
+        # Redirected BEFORE anything runs: the second half of this test does a real
+        # export, and without this it writes to the shipped default path - which
+        # left a stray CSV in the repository the first time it ran.
+        m.CONNECTIONS_CSV_FILE = os.path.join(tempfile.mkdtemp(), "conns.csv")
+
+        assert m._EXPORT_LOCK.acquire(blocking=False), "the lock must start free"
+        try:
+            worker = app.export_connections_csv()
+        finally:
+            m._EXPORT_LOCK.release()
+        app._logview.drain()
+
+        assert worker is None, "a refused export must not start a second worker"
+        assert any(bnt.T("log.conns_export_busy") in line
+                   for line in app._log_lines), app._log_lines[-3:]
+
+        # ...and the refusal does not poison the next one.
+        again = app.export_connections_csv()
+        assert again is not None, "the export must work again once the first is done"
+        again.join(20)
+    ''')
+
+
+def test_the_connection_export_does_not_run_on_the_ui_thread():
+    """The whole point of S-08, asked directly rather than through a stopwatch.
+
+    Everything after the snapshot is unbounded work on a table that may hold
+    200 000 flows: a full filter and sort with NO row cap, then a row-by-row CSV
+    write. On the UI thread that is a frozen window, and a frozen window is a STOP
+    button the user cannot press on a machine whose networking they deliberately
+    broke. `gui/model_worker.py` moved the table's own rebuild off that thread for
+    exactly this reason and this path was left behind.
+
+    A timing assertion would be the flaky way to ask the same thing.
+    """
+    run_gui('''
+        import os, tempfile, threading
+        import beantester.gui.csv_export as m
+        path = os.path.join(tempfile.mkdtemp(), "conns.csv")
+        m.CONNECTIONS_CSV_FILE = path
+
+        where = {}
+        real = m.filter_sort_connections
+        def spy(*a, **k):
+            where["thread"] = threading.current_thread()
+            return real(*a, **k)
+        m.filter_sort_connections = spy
+
+        app.engine.now_ref = lambda: 10.0
+        app.engine.connections_snapshot = lambda limit=None: [
+            dict(local_port=51000, remote_ip="1.1.1.1", remote_port=443, proto="TCP",
+                 packets=4, bytes=3072, bytes_in=2048, bytes_out=1024, dropped=0,
+                 scoped=True, pid=7, first=0.0, last=5.0, dir="in", proc="chrome.exe",
+                 sent=3072, sent_in=2048, sent_out=1024),
+        ]
+        app.conn_query = ""
+        app.conn_sort = {"col": "packets", "reverse": True}
+
+        app.export_connections_csv().join(20)
+
+        assert where.get("thread") is not None, "the writer never ran"
+        assert where["thread"] is not threading.main_thread(), \
+            "the export is back on the UI thread"
+        assert os.path.exists(path), "and it still has to produce the file"
     ''')

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -16,6 +16,7 @@ already failing, so:
 
 This tests all four.
 """
+import faulthandler
 import json
 import os
 import sys
@@ -248,6 +249,23 @@ def test_once_records_the_first_occurrence_only(isolated):
 
 
 # -- 6) it is bounded ---------------------------------------------------------- #
+def _distinct_fault(i):
+    """A fault with a fingerprint of its OWN: raised from its own generated line.
+
+    The fingerprint is the exception type plus the top frames, so a loop raising
+    the same ValueError over and over produces one record however many times it
+    runs. Loading the table needs faults that differ, and this is the cheapest way
+    to make them differ the way real ones do.
+    """
+    namespace = {}
+    exec(f"def f{i}():\n    raise ValueError('distinct fault {i}')", namespace)
+    try:
+        namespace[f"f{i}"]()
+    except ValueError as exc:
+        return exc
+    return None
+
+
 def test_the_in_memory_table_is_bounded(isolated):
     """A program with thousands of DISTINCT faults must not be memory-bombed by the
     thing that is supposed to be diagnosing it.
@@ -257,18 +275,76 @@ def test_the_in_memory_table_is_bounded(isolated):
     each gets its own fingerprint - which is what actually loads the table.
     """
     for i in range(crashlog.MAX_RECORDS + 200):
-        namespace = {}
-        exec(f"def f{i}():\n    raise ValueError('distinct fault {i}')", namespace)
-        try:
-            namespace[f"f{i}"]()
-        except ValueError as exc:
-            crashlog.record(exc, source="test")
+        crashlog.record(_distinct_fault(i), source="test")
 
     prints = {e["fingerprint"] for e in _entries(isolated)}
     assert len(prints) > 100, f"the faults were not distinct ({len(prints)})"
     assert len(crashlog._seen) <= crashlog.MAX_RECORDS, (
         f"the crash table grew to {len(crashlog._seen)} "
         f"(ceiling {crashlog.MAX_RECORDS})")
+
+
+def test_a_repeating_fault_is_still_deduplicated_when_the_table_is_full(isolated,
+                                                                       monkeypatch):
+    """The ceiling used to be a cliff, and it fell exactly where it hurts.
+
+    Past MAX_RECORDS the table REFUSED new fingerprints, so a fault that started
+    after the table filled never got a slot - every occurrence looked new, built a
+    full context and wrote to disk again. MEASURED before the fix, the same
+    repeating fault: 137 us and zero writes with a slot, 1926 us and a write per
+    occurrence without one. The de-duplication this module is built around
+    switched itself off for whatever broke last.
+
+    MAX_RECORDS is lowered here rather than filled for real: the true 2000 takes
+    about three seconds to load, and the behaviour under test is the same at four.
+    """
+    monkeypatch.setattr(crashlog, "MAX_RECORDS", 4)
+    for i in range(4):
+        crashlog.record(_distinct_fault(i), source="fill")
+
+    late = _boom("a fault that started after the table was full")
+    crashlog.record(late, source="late")            # one record, one disk write
+    written = len(_entries(isolated))
+    for _ in range(20):
+        crashlog.record(late, source="late")
+
+    assert len(_entries(isolated)) == written, (
+        "a repeating fault wrote to disk again on every occurrence once the "
+        f"table was full ({len(_entries(isolated)) - written} extra writes)")
+    assert len(crashlog._seen) <= 4, (
+        f"the table grew past its own ceiling ({len(crashlog._seen)})")
+    busiest = crashlog.recent(1)[0]
+    assert busiest["count"] == 21, (
+        f"the repeating fault lost its counter (counted {busiest['count']} of 21)")
+
+
+def test_the_table_makes_room_by_dropping_the_coldest_fault_not_the_busiest(
+        isolated, monkeypatch):
+    """Which end the table drops is the whole design, so it gets its own guard.
+
+    A bounded table that evicts by ARRIVAL would throw out the fault that is
+    firing right now to make room for four one-off ones - and the fault firing
+    right now is the one whose de-duplication is worth having. Every occurrence
+    moves its record to the fresh end, so eviction always takes the fault nobody
+    has seen for longest.
+    """
+    monkeypatch.setattr(crashlog, "MAX_RECORDS", 4)
+    for i in range(4):
+        crashlog.record(_distinct_fault(i), source="fill")
+
+    busy = _boom("the fault that keeps firing")
+    crashlog.record(busy, source="busy")
+    for i in range(100, 103):                       # newcomers arrive
+        crashlog.record(_distinct_fault(i), source="fill")
+    crashlog.record(busy, source="busy")            # it fires again: freshest now
+    written = len(_entries(isolated))
+    for i in range(200, 203):                       # three more push it back
+        crashlog.record(_distinct_fault(i), source="fill")
+
+    crashlog.record(busy, source="busy")
+    assert len(_entries(isolated)) == written + 3, (
+        "the busiest fault was evicted by faults seen once each, so it wrote to "
+        f"disk again ({len(_entries(isolated)) - written} writes, expected 3)")
 
 
 def test_disabled_records_nothing(isolated):
@@ -393,6 +469,45 @@ def test_cleanup_removes_the_empty_native_file_and_dir(isolated):
 
     assert not os.path.exists(path), "the empty native-crash file was left behind"
     assert not os.path.isdir(directory), "the now-empty crashes dir was left behind"
+
+
+def test_the_diverts_are_closed_while_the_native_handler_is_still_armed(isolated):
+    """The order of two atexit handlers, and the reason the whole module exists.
+
+    `atexit` is LIFO. `engine.py` registers `_stop_live_engines` at IMPORT and
+    `install()` registers `_cleanup_native` later, so the cleanup runs FIRST - and
+    it used to disable faulthandler while a ctypes call into the WinDivert kernel
+    driver was still to come. A segfault inside `divert.close()` at exit would then
+    have left nothing at all: no Python traceback, because there is none for a hard
+    crash, and no native report, because the handler that writes one was already
+    off.
+
+    A stand-in engine in `_LIVE_ENGINES` answers the question directly, and it is
+    the only half that can be answered without a real segfault: was the handler
+    still armed at the moment the divert was closed?
+    """
+    from beantester import engine
+
+    armed = []
+
+    class StandInEngine:
+        """Holds no divert; only reports what the handler state was when asked."""
+
+        def stop(self, reason=""):
+            armed.append(faulthandler.is_enabled())
+
+    held = StandInEngine()                  # a strong reference: _LIVE_ENGINES is weak
+    engine._LIVE_ENGINES.add(held)
+    crashlog._arm_wanted[0] = True
+    crashlog.arm_native()
+    try:
+        crashlog._cleanup_native()
+    finally:
+        engine._LIVE_ENGINES.discard(held)
+
+    assert armed == [True], (
+        "the divert was closed with the native crash handler already off, so a "
+        f"hard crash in it would have gone unrecorded (saw {armed})")
 
 
 def test_cleanup_keeps_a_non_empty_native_file(isolated):

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -490,15 +490,87 @@ def test_a_breadcrumb_that_cannot_be_serialised_is_swallowed(isolated):
     """The state comes from the UI. A value json cannot write must not take the
     process down ON THE WAY TO DESCRIBING A CRASH - and must not leave the half
     written temp file behind either, because a stray .tmp keeps the directory from
-    ever being cleaned up again."""
+    ever being cleaned up again.
+
+    The leftover is looked for by SCANNING, not by name: the temp file is unique
+    per writer now (``paths.temp_beside``), so a check for one known name would
+    pass without looking at anything - green, and blind to the very leftover it
+    was written to catch.
+    """
     crashlog._arm_wanted[0] = True
     crashlog.arm_native()
     try:
         assert not crashlog.breadcrumb(page=object(), running=False, windows=[])
-        tmp = os.path.join(crashlog.crash_dir(), crashlog.BREADCRUMB_NAME + ".tmp")
-        assert not os.path.exists(tmp), "a failed write left its temp file behind"
+        left = [n for n in os.listdir(crashlog.crash_dir()) if n.endswith(".tmp")]
+        assert not left, f"a failed write left its temp file behind: {left}"
     finally:
         crashlog._cleanup_native()
+
+
+def test_two_breadcrumb_writers_do_not_share_one_temp_file(isolated, monkeypatch):
+    """Two copies of the GUI both leave a breadcrumb, through one temp file.
+
+    Worse odds than any other writer in the program: this one is written from the
+    TICK, so "both at the same moment" is not a corner case, it is 1.4 chances a
+    second for as long as two windows are open. The interleaving is forced at the
+    instant that matters (see the same test in test_jsonfile.py for why it is
+    forced rather than raced).
+    """
+    crashlog._arm_wanted[0] = True
+    crashlog.arm_native()
+    real_replace = os.replace
+    second = []
+
+    def let_the_other_writer_in(src, dst):
+        if not second:                          # guard first: the second writer
+            second.append("did not finish")     # publishes through here as well
+            second[0] = crashlog.breadcrumb(page="second", running=False, windows=[])
+        return real_replace(src, dst)
+
+    try:
+        monkeypatch.setattr(os, "replace", let_the_other_writer_in)
+        first = crashlog.breadcrumb(page="first", running=True, windows=[])
+        # NOT monkeypatch.undo(): one monkeypatch object serves the whole test,
+        # `isolated` included, so undoing here would also put `user_data_dir` back
+        # and point the cleanup below at the user's REAL crashes folder. Teardown
+        # restores os.replace anyway, and the patch is a pass-through from here.
+
+        assert second == [True], f"the second writer failed ({second})"
+        assert first is True, ("the first writer failed - it tried to publish a temp "
+                               "file the second had already taken")
+        with open(os.path.join(crashlog.crash_dir(), crashlog.BREADCRUMB_NAME),
+                  encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["page"] in ("first", "second"), f"a mix of two writers: {data}"
+        left = [n for n in os.listdir(crashlog.crash_dir()) if n.endswith(".tmp")]
+        assert not left, f"a temp breadcrumb survived both writers: {left}"
+    finally:
+        crashlog._cleanup_native()
+
+
+def test_a_temp_breadcrumb_left_by_a_kill_is_swept_on_the_next_clean_exit(isolated):
+    """The leftover a unique name cannot heal on its own.
+
+    The old ``breadcrumb.json.tmp`` was reused by the next write, so an orphan
+    fixed itself. A unique one does not, and an orphan HERE does more than sit
+    there: ``crashes/`` is removed only when it is EMPTY, so a single stray temp
+    file would make every healthy run leave a folder behind for ever. Both name
+    shapes are swept - the one this version writes and the fixed one a version
+    before it could have left.
+    """
+    crashlog._arm_wanted[0] = True
+    crashlog.arm_native()
+    directory = crashlog.crash_dir()
+    for name in (crashlog.BREADCRUMB_NAME + ".tmp",             # pre-2026-09-03
+                 crashlog.BREADCRUMB_NAME + ".9kz1ab.tmp"):     # what temp_beside makes
+        with open(os.path.join(directory, name), "w", encoding="utf-8") as f:
+            f.write("{half writ")
+
+    crashlog._cleanup_native()
+
+    assert not os.path.isdir(directory), (
+        "a stray temp breadcrumb kept the folder alive: "
+        f"{sorted(os.listdir(directory))}")
 
 
 def test_the_running_gui_actually_leaves_one(isolated):

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -1319,3 +1319,80 @@ def test_the_stall_check_answers_no_for_every_state_that_is_not_one():
     eng._t_cap.join()
     check("dead capture thread: left to the liveness check",
           eng._capture_has_stalled() is False)
+
+
+# --- START and STOP must survive the worker ending badly ---------------------- #
+
+
+def test_a_start_that_fails_outside_Exception_still_gives_the_button_back():
+    """The queue is fed in a `finally`, so `_transition` can never stick.
+
+    `_transition` is only ever cleared by `_poll_transition` reading that queue.
+    A `run()` that ends without putting leaves the flag on "starting" forever:
+    `_start` and `_stop` return immediately while a transition is in flight, and
+    `_poll_transition` keeps re-arming `root.after(30, ...)`. START and STOP are
+    then dead for the life of the window, with a divert possibly still open -
+    which is the one control a network tester must never take away.
+
+    `KeyboardInterrupt` because it is not an `Exception`: the old handler caught
+    that class and nothing else, so anything outside it escaped past the `put`.
+    """
+    run_gui("""
+        def boom(*a, **k):
+            raise KeyboardInterrupt("out of nowhere")
+        app.engine.start = boom
+
+        app._start()
+        app._settle_transition()
+
+        assert app._transition is None, ("the button is stuck on %r"
+                                         % (app._transition,))
+        assert app.running is False
+
+        # ...and it still works afterwards, which is the point of giving it back.
+        app.engine.start = lambda filt, divert=None, duration=0, **kw: None
+        app._start()
+        app._settle_transition()
+        assert app.running is True
+    """, allow_faults=("out of nowhere",))
+
+
+def test_one_window_per_fault_not_one_per_occurrence():
+    """A binding that fires in a series must not stack modal windows.
+
+    `crashlog.record` deduplicates by fingerprint and counts the repeats.
+    `dialogs.show_error` deduplicated nothing, so an exception out of something
+    like `<Configure>` - which fires continuously while a window edge is dragged -
+    buried the user under a stack of modals to close one by one, on top of the
+    original fault and with the rest of the interface not responding.
+    """
+    run_gui("""
+        import beantester.gui.dialogs as dialogs
+
+        shown = []
+        dialogs.show_error = lambda parent, title, body: shown.append(body)
+
+        def raise_it():
+            raise ValueError("the same fault")
+
+        for _ in range(5):
+            try:
+                raise_it()
+            except ValueError as exc:
+                app._on_ui_exception(type(exc), exc, exc.__traceback__)
+
+        assert len(shown) == 1, ("one window per fault, got %d" % len(shown))
+
+        # Every occurrence still reaches the log, which is where the repeats live.
+        hits = [l for l in app._log_lines if "the same fault" in l]
+        assert len(hits) == 5, hits
+
+        # A DIFFERENT fault is still shown: this deduplicates, it does not go quiet.
+        def raise_other():
+            raise TypeError("a different fault")
+        try:
+            raise_other()
+        except TypeError as exc:
+            app._on_ui_exception(type(exc), exc, exc.__traceback__)
+        assert len(shown) == 2, shown
+    """, allow_faults=("the same fault", "a different fault"))

--- a/tests/test_failsafe.py
+++ b/tests/test_failsafe.py
@@ -1180,3 +1180,142 @@ def test_a_worker_the_engine_does_not_own_reports_through_the_same_door():
               not eng.is_running())
     finally:
         eng.stop()
+
+
+# --- alive, and no longer doing anything ------------------------------------- #
+#
+# The other half of fail-open. Until 2026-09-02 the watchdog asked `is_alive()`
+# and nothing else, so the one state this module's own docstring calls dangerous -
+# a process still ALIVE with an open divert and no working capture thread - was
+# the one it could not see. A thread spinning in a regular expression, waiting on
+# a deadlocked lock, or blocked on a driver that stopped answering is alive.
+
+
+class _StallingDivert(QuietDivert):
+    """Hands over one packet whose first field access never returns.
+
+    A real stall, not a poked flag: the capture thread gets past `recv()`, writes
+    its beat, and then blocks INSIDE our own code, which is exactly the shape the
+    watchdog has to tell apart from a quiet link. `release()` lets it finish so the
+    test does not leave a thread parked forever.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.released = threading.Event()
+        self._handed_over = False
+
+    def recv(self):
+        if not self._handed_over:
+            self._handed_over = True
+            return _StallingPacket(self.released)
+        return super().recv()           # then behave like a quiet link
+
+    def release(self):
+        self.released.set()
+
+
+class _StallingPacket(FakePacket):
+    def __init__(self, released):
+        super().__init__()
+        self._released = released
+
+    @property
+    def raw(self):
+        # `size = len(packet.raw)` is the first thing the loop does after writing
+        # its beat, so blocking here parks the thread on the far side of `recv()`.
+        self._released.wait(30)
+        return b"\x00" * 100
+
+    @raw.setter
+    def raw(self, value):
+        pass                            # FakePacket.__init__ assigns it
+
+
+def test_a_capture_thread_that_is_alive_but_no_longer_moving_fails_open():
+    """The session must stop and the divert must close, as for a DEAD thread.
+
+    The threshold is lowered on the instance rather than waited out: ten seconds is
+    the shipped value and it is chosen against a healthy session's worst gap
+    (31.912 ms measured), not against how long a test may take.
+    """
+    eng = BeanEngine()
+    eng.CAPTURE_STALL_S = 0.3
+    divert = _StallingDivert()
+    eng.start("test", divert=divert)
+    try:
+        def stopped_completely():
+            kinds = [(e[2], e[3]) for e in eng.events_snapshot()]
+            return (not eng.is_running() and divert.closed
+                    and ("STOP", "events.fault") in kinds)
+
+        check("stall: the session stops and finishes teardown",
+              _wait_until(stopped_completely),
+              f"(running={eng.is_running()}, closed={divert.closed})")
+        check("stall: the divert is closed (network restored)", divert.closed is True)
+        check("stall: the reason is recorded", eng.stop_reason == "fault",
+              f"({eng.stop_reason})")
+        check("stall: the fault says what happened",
+              "capture thread" in str(eng.fault).lower(), f"({eng.fault})")
+    finally:
+        divert.release()
+
+
+class _GoesQuietDivert(QuietDivert):
+    """One packet, then nothing - an ordinary link that falls silent."""
+
+    def __init__(self):
+        super().__init__()
+        self._handed_over = False
+
+    def recv(self):
+        if not self._handed_over:
+            self._handed_over = True
+            return FakePacket()
+        return super().recv()
+
+
+def test_a_quiet_link_is_never_mistaken_for_a_stalled_capture_thread():
+    """The half that matters more, because a false stall kills a real test.
+
+    A capture thread parked in `recv()` on a link with no traffic has not beaten
+    for as long as the link has been silent, which can be the whole session. That
+    is indistinguishable from a stall by any counter alone - `_cap_waiting` is the
+    only thing that separates them, and this is what would catch its removal.
+    """
+    eng = BeanEngine()
+    eng.CAPTURE_STALL_S = 0.2
+    divert = _GoesQuietDivert()
+    eng.start("test", divert=divert)
+    try:
+        # Long past the threshold and past several watchdog ticks (0.2 s each).
+        time.sleep(1.5)
+        check("quiet link: the session is still running",
+              eng.is_running() is True, f"(stop_reason={eng.stop_reason})")
+        check("quiet link: the divert is still open", divert.closed is False)
+        check("quiet link: nothing was recorded as a fault", eng.fault is None,
+              f"({eng.fault})")
+    finally:
+        eng.stop()
+
+
+def test_the_stall_check_answers_no_for_every_state_that_is_not_one():
+    """The degenerate-but-legal inputs, asked directly so they cannot be missed.
+
+    A session that has not seen its first packet has no beat at all, and a thread
+    that has already died is the liveness check's business, not this one - both
+    would otherwise fail-stop a session for the wrong reason.
+    """
+    eng = BeanEngine()
+    eng.CAPTURE_STALL_S = 0.01
+    check("no beat yet: not a stall", eng._capture_has_stalled() is False)
+
+    eng._cap_beat_at = time.monotonic() - 60
+    eng._cap_waiting = False
+    check("no capture thread: not a stall", eng._capture_has_stalled() is False)
+
+    eng._t_cap = threading.Thread(target=lambda: None)
+    eng._t_cap.start()
+    eng._t_cap.join()
+    check("dead capture thread: left to the liveness check",
+          eng._capture_has_stalled() is False)

--- a/tests/test_gui_state.py
+++ b/tests/test_gui_state.py
@@ -651,3 +651,86 @@ def test_the_gui_says_the_same_thing_before_an_unbounded_start():
         assert warned(list(app._log_lines)), \
             "clearing the target mid-session went unannounced: %r" % app._log_lines
     """)
+
+
+# --- the rebuild has to tell the pages first ---------------------------------- #
+#
+# ``_build_ui`` destroys every child of the root, which is what a language change
+# does. Nothing told the pages, so whatever they had scheduled through ``after()``
+# was still queued against widgets that no longer existed - and Tk deletes a
+# widget's registered commands when it destroys it, so those timers fire into
+# nothing. Seven of them existed across the pages, the form and the panels.
+
+
+def test_a_language_switch_cancels_what_the_pages_had_scheduled():
+    """Every page timer is cancelled BEFORE its widget is destroyed, not after.
+
+    Asserted through ``after_cancel`` actually being called, not just through the
+    attribute ending up None: setting the field to None without cancelling leaves
+    the timer armed, which is the bug wearing the fix's clothes.
+    """
+    run_gui("""
+        conns = app.pages["connections"]
+        stats = app.pages["statistics"]
+        control = app.pages["control"]
+
+        conns._poll_job = "poll-1"
+        conns._search_job = "search-1"
+        stats._chart_job = "chart-1"
+        control._job = "control-1"
+        app.form._relayout_job = "form-1"
+
+        cancelled = []
+        for widget, page in ((conns.frame, conns), (stats.frame, stats),
+                             (control.frame, control)):
+            widget.after_cancel = lambda job, c=cancelled: c.append(job)
+        app.form.host.after_cancel = lambda job, c=cancelled: c.append(job)
+
+        app.lang_var.set("English")
+        app._switch_language()
+
+        for job in ("poll-1", "search-1", "chart-1", "control-1", "form-1"):
+            assert job in cancelled, (job, cancelled)
+    """)
+
+
+def test_the_teardown_of_one_page_cannot_stop_the_rebuild():
+    """A page that raises must not cost the user the language they asked for.
+
+    The same rule ``pref_changed`` lives by, and for the same reason: refusing a
+    rebuild because a timer would not cancel is a worse answer than a log line.
+    """
+    run_gui("""
+        def explode():
+            raise RuntimeError("teardown exploded")
+        app.pages["statistics"].teardown = explode
+
+        app.lang_var.set("English")
+        app._switch_language()
+
+        assert app.pages, "the UI must have been rebuilt anyway"
+        assert app.log_box is not None
+    """, allow_faults=("teardown exploded",))
+
+
+def test_logging_into_a_destroyed_box_is_not_an_error():
+    """A destroyed Tk widget is NOT None - it is the same object with a dead path.
+
+    ``App.log`` drains synchronously when it is on the main thread, and the box
+    attribute keeps pointing at the corpse from the moment ``_build_ui`` destroys
+    it until a new one is attached. A guard written as ``if box is None`` passes
+    there and every call after it raises TclError, in a window nothing catches.
+    """
+    run_gui("""
+        app.log("before")
+        box = app.log_box
+        box.destroy()
+        assert box.winfo_exists() == 0, "the fake must model a destroyed widget"
+
+        app.log("during the rebuild")           # must not raise
+
+        # ...and the line is not lost: it is applied to the widget that comes next.
+        app._build_ui()
+        assert any("during the rebuild" in line for line in app._log_lines), \
+            app._log_lines[-3:]
+    """)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -5,6 +5,7 @@ Ported 1:1 from the original monolithic suite; every ``check(...)`` from the
 """
 import os
 import string
+import time
 
 from beantester import BeanEngine
 from fakes import LANG_DIR, LANGS, check
@@ -251,6 +252,60 @@ def test_lang_discovery_and_meta():
     finally:
         n.load_languages()            # restore the real language files
         n.set_language("pl")
+
+
+def test_a_cold_catalogue_is_loaded_once_however_many_threads_ask():
+    """The lazy load used to be an unguarded check-then-act, in five places.
+
+    Readers live on the engine's worker threads and on the UI thread, so two of
+    them could both find the catalogue empty and both scan ``lang/`` - the same
+    answer produced twice, at the cost of a second pass over every file.
+
+    Both entry points happen to load eagerly today (``run_cli`` and
+    ``App._build_ui`` call ``set_language`` among their first statements, before
+    any worker exists), which is a fact about the CALLERS and not a property of
+    this module. This pins the property.
+    """
+    import threading
+
+    from beantester import i18n
+
+    saved = (i18n._translations, i18n._language_names, i18n._LANG)
+    loads, seen, ready = [], [], threading.Barrier(6)
+    real_load = i18n.load_languages
+
+    def slow_load(directory=None):
+        loads.append(1)
+        time.sleep(0.05)            # widen the window a racing reader would use
+        return real_load(directory)
+
+    i18n.load_languages = slow_load
+    try:
+        i18n._translations, i18n._language_names = {}, {}       # a cold module
+        errors = []
+
+        def reader():
+            ready.wait(timeout=5)
+            try:
+                seen.append(i18n.T("app.name"))
+            except Exception as exc:                # noqa: BLE001 - reported below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(5)]
+        for t in threads:
+            t.start()
+        ready.wait(timeout=5)
+        for t in threads:
+            t.join(timeout=5)
+
+        check("no reader failed on a half-loaded catalogue", not errors, f"({errors})")
+        check("the catalogue was scanned once, not once per thread",
+              len(loads) == 1, f"({len(loads)} loads for {len(threads)} readers)")
+        check("and every reader got the same answer",
+              len(set(seen)) == 1 and seen[0], f"({set(seen)})")
+    finally:
+        i18n.load_languages = real_load
+        i18n._translations, i18n._language_names, i18n._LANG = saved
 
 
 def test_fallback_chain():

--- a/tests/test_jsonfile.py
+++ b/tests/test_jsonfile.py
@@ -46,6 +46,70 @@ def test_write_is_atomic_and_leaves_no_tmp(tmp_path):
           f"(found {leftovers})")
 
 
+def test_two_writers_do_not_share_one_temp_file(tmp_path, monkeypatch):
+    """Two copies of the program saving the same file at the same moment.
+
+    Nothing stops that from happening: there is no single-instance lock, and the
+    mutex in ``driver.py`` guards the DRIVER, not these files. The temp name used
+    to be ``<target>.tmp`` - a function of the TARGET - so both writers opened one
+    file, the second truncating what the first was still writing, and the first
+    then published the result as the user's profiles.
+
+    The interleaving is FORCED rather than raced, at the one instant that matters:
+    writer A has finished its temp file and is about to publish it. Two threads
+    would reproduce the collision only sometimes, and a test that reproduces a bug
+    sometimes proves nothing on the run where it passes.
+    """
+    path = str(tmp_path / "profiles.json")
+    first_data = {"writer": "A", "rows": list(range(50))}
+    second_data = {"writer": "B", "rows": list(range(50))}
+    real_replace = os.replace
+    second = []
+
+    def let_the_other_writer_in(src, dst):
+        # Guard BEFORE the nested save, not after: the second writer publishes
+        # through this same function and would otherwise recurse for ever.
+        if not second:
+            second.append("did not finish")
+            second[0] = write_json(path, second_data)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", let_the_other_writer_in)
+    first = write_json(path, first_data)
+    # No undo() here on purpose: one monkeypatch object serves the whole test, so
+    # undoing reverts every patch a fixture made too. Teardown restores it, and
+    # the patch is a pass-through once the second writer has run.
+
+    check("the second writer reported success", second == [None], f"(got {second!r})")
+    check("the first writer reported success too - it published a file of its own, "
+          "not one the second had already taken", first is None, f"(err={first!r})")
+    back, read_error = read_json(path)
+    check("the file both writers touched is readable", read_error is None,
+          f"(err={read_error!r})")
+    check("and it holds one writer's data, not a mix of the two",
+          back in (first_data, second_data), f"(got {back!r})")
+    leftovers = [p for p in os.listdir(tmp_path) if p.endswith(".tmp")]
+    check("neither writer left a temp file behind", not leftovers, f"(found {leftovers})")
+
+
+def test_a_value_json_cannot_write_is_an_error_not_a_crash(tmp_path):
+    """``json`` raises ``TypeError`` for a value it has no rule for - a set, a
+    widget, a ``datetime`` - and that walked straight out of ``write_json``, past
+    its own temp-file cleanup, and took down whatever was saving. It is the same
+    event as a non-finite float from the caller's side, and the reader's half made
+    that decision long ago: ``load_json`` splits by KIND, not by which exceptions
+    somebody happened to list.
+    """
+    path = str(tmp_path / "state.json")
+    error = write_json(path, {"windows": {"main", "stats"}})   # a set
+
+    check("a value json cannot write is reported, not raised",
+          isinstance(error, str) and error, f"(error={error!r})")
+    check("the target file was not created", not os.path.exists(path))
+    leftovers = [p for p in os.listdir(tmp_path) if p.endswith(".tmp")]
+    check("and no temp file is left behind", not leftovers, f"(found {leftovers})")
+
+
 def test_write_overwrites_existing_content(tmp_path):
     path = str(tmp_path / "state.json")
     write_json(path, {"v": 1})

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -420,3 +420,88 @@ def test_add_term_keeps_the_comma_escape_of_a_regex():
           f"({split_terms(out)})")
     check("the regex term is intact", split_terms(out)[0] == "re:^a,b$",
           f"({split_terms(out)[0]!r})")
+
+
+# --- a pattern that would never finish on the packet path ---------------------- #
+#
+# `re.compile` answers "does this parse", never "will this ever finish", and the
+# compiled matcher is then called on EVERY packet, on the capture thread, inside
+# `core._lock`. The consequence is not a slow filter: the capture thread stops
+# draining the divert, WinDivert queues the machine's traffic, and the UI thread
+# blocks on the same lock the moment a page asks `App.coverage()`.
+#
+# The reproduction, 2026-09-02: `re:^([1:]+)+x$` against an ordinary IPv6 address
+# did not return in 25 seconds.
+
+
+def test_a_pattern_that_cannot_finish_is_refused_at_parse_time():
+    """The two shapes that really explode in CPython, on the kinds that can see them.
+
+    🔴 NOT `^(a+)+$`. The textbook ReDoS example is 0.001 ms at every input length
+    here, because CPython optimises it away, so a guard written with it would pass
+    while proving nothing. Measured 2026-09-02, milliseconds at 8 / 12 / 16 / 20 /
+    24 characters: `^([1:]+)+x$` is 0.016 / 0.132 / 2.076 / 37.4 / 684, and
+    `^((a*)*)*b$` is 7.6 / 1254.
+    """
+    for text, kind, field in ((r"re:^([1:]+)+x$", KIND_IP, "fields.ip"),
+                              (r"re:^((a*)*)*b$", KIND_PROCESS, "fields.target")):
+        with pytest.raises(ValueError) as caught:
+            parse_matcher(text, kind, field)
+        # A ValueError like every other parse error, because every caller already
+        # handles that one: the CLI turns it into exit code CONFIG, the form marks
+        # the field red, `apply_settings` logs it and disables the target rather
+        # than killing a scenario thread.
+        check(f"{text}: says it is too SLOW, not that it is malformed",
+              "too slow" in str(caught.value).lower()
+              or "za wolne" in str(caught.value).lower(),
+              f"({str(caught.value)[:90]!r})")
+
+
+def test_the_patterns_a_person_would_actually_write_are_still_accepted():
+    """The half that matters more: a refusal breaks somebody's working filter.
+
+    Every one of these is heavier than average and none of them backtracks.
+    Measured 2026-09-02, worst SINGLE search over the whole probe ladder: 0.0046 ms
+    for the alternation, 0.0036 ms for the character class, 0.0049 ms for the
+    nested groups. The budget is 5 ms, so the gap between "fine" and "not fine" is
+    three orders of magnitude - which is why a wall clock is a fair judge here and
+    why this does not flake on a loaded runner.
+    """
+    # The repeat counts carry `\,`, which is the mini-language's escape and what a
+    # user has to type: an unescaped comma is a TERM SEPARATOR, so `{1,40}` splits
+    # the expression in two. Both halves happen to compile, so writing it the
+    # natural way makes this test pass while measuring something else entirely -
+    # found by writing it the natural way first.
+    fine = [
+        (r"re:^chrome|firefox$", KIND_PROCESS),
+        (r"re:" + "|".join(f"proc{n}" for n in range(50)), KIND_PROCESS),
+        (r"re:^[a-zA-Z0-9._\-]{1\,40}\.(exe|dll|sys)$", KIND_PROCESS),
+        (r"re:^(?=.*chrome)(?!.*helper).*$", KIND_PROCESS),
+        (r"re:^((a|b|c)+(d|e)*)+$", KIND_PROCESS),
+        (r"re:^10\.0\.\d+", KIND_IP),
+        (r"re:^([0-9a-f]{1\,4}:){7}[0-9a-f]{1\,4}$", KIND_IP),
+        (r"re:.*", KIND_PROCESS),
+        (r"re:^8(0|443)$", KIND_INT),
+    ]
+    for text, kind in fine:
+        try:
+            parse_matcher(text, kind, "fields.target")
+        except ValueError as exc:
+            check(f"{text[:40]}: accepted", False, f"({exc})")
+        else:
+            check(f"{text[:40]}: accepted", True)
+
+
+def test_refusing_a_slow_pattern_changes_nothing_about_a_good_one():
+    """The regression a speed guard can cause: matching quietly narrowing.
+
+    A check that runs the pattern before handing it over could leave it consumed,
+    recompiled differently, or anchored somewhere it was not. So this asserts the
+    BEHAVIOUR of an accepted regex, not that parsing returned an object.
+    """
+    m = _proc(r"re:^chrome")
+    check("regex still matches what it should", m.matches(1, "chrome.exe"))
+    check("regex still rejects what it should not", not m.matches(1, "notchrome.exe"))
+    ip = _ip(r"re:^10\.0\.")
+    check("ip regex still matches", ip.matches("10.0.0.1"))
+    check("ip regex still misses", not ip.matches("10.1.0.1"))

--- a/tests/test_model_worker.py
+++ b/tests/test_model_worker.py
@@ -201,3 +201,32 @@ def test_no_thread_is_left_behind():
         assert _collect(model, timeout=5) == [i]
     time.sleep(0.3)
     assert threading.active_count() <= before + 1, "model workers are leaking"
+
+
+def test_a_build_that_fails_outside_Exception_does_not_wedge_the_table():
+    """`_pending` must be cleared however the build ends, or the table is finished.
+
+    It is cleared in exactly two places: here, and by `poll()` reading a result. A
+    build that ends any other way therefore leaves it set for ever - `busy()` stays
+    True, the page's 40 ms catch-up poll re-arms itself indefinitely, and the
+    connection table never rebuilds again for the rest of the session. The user
+    sees a table that quietly stopped following the traffic.
+
+    `KeyboardInterrupt` because it is not an `Exception`: reproduced 2026-09-02
+    against the old handler, which caught that class and nothing wider.
+    """
+    def boom(payload):
+        raise KeyboardInterrupt("outside Exception")
+
+    model = AsyncModel(boom)
+    model.request("one")
+    deadline = time.time() + 5
+    while time.time() < deadline and model.busy():
+        time.sleep(0.02)
+
+    assert not model.busy(), "the model is wedged - it will never rebuild again"
+
+    # ...and it takes work again, which is what "not wedged" has to mean.
+    model._build = lambda payload: [payload]
+    model.request("two")
+    assert _collect(model, timeout=5) == ["two"]

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1638,6 +1638,38 @@ MUTATIONS = [
         "test": "test_a_temp_breadcrumb_left_by_a_kill_is_swept_on_the_next_clean_exit",
     },
     {
+        # atexit is LIFO, so without this call the diverts are closed by engine.py's
+        # own handler AFTER faulthandler is off - which is what shipped.
+        "label": "crashlog: the diverts are closed after the native handler is off",
+        "file": "beantester/crashlog.py",
+        "old": "            live._stop_live_engines()       "
+               "# idempotent: stop() forgets the engine",
+        "new": "            pass",
+        "test": "test_the_diverts_are_closed_while_the_native_handler_is_still_armed",
+    },
+    {
+        # The shipped cliff: full table -> new fingerprints refused -> every
+        # occurrence of a fault that arrived late is a fresh record and a write.
+        "label": "crashlog: the crash table refuses new faults instead of making room",
+        "file": "beantester/crashlog.py",
+        "old": "        _seen[fingerprint] = entry\n"
+               "        if len(_seen) > MAX_RECORDS:\n"
+               "            _seen.popitem(last=False)       "
+               "# the least recently seen fault",
+        "new": "        if len(_seen) < MAX_RECORDS:\n"
+               "            _seen[fingerprint] = entry",
+        "test": "test_a_repeating_fault_is_still_deduplicated_when_the_table_is_full",
+    },
+    {
+        # Bounded, but evicting by ARRIVAL: the fault firing right now is thrown
+        # out to make room for faults seen once each.
+        "label": "crashlog: the crash table evicts by arrival instead of by recency",
+        "file": "beantester/crashlog.py",
+        "old": "            _seen.move_to_end(fingerprint)",
+        "new": "            pass",
+        "test": "test_the_table_makes_room_by_dropping_the_coldest_fault_not_the_busiest",
+    },
+    {
         # One byte of the recorded driver hash. The version resource still reads
         # 2.2 - which is exactly what a swapped kernel driver looks like.
         "label": "legal: the recorded WinDivert driver hash stops matching",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -237,6 +237,49 @@ MUTATIONS = [
         "test": "test_doctor_says_where_the_users_own_files_are",
     },
     {
+        # Back onto the UI thread: a full filter and sort with no row cap, then a
+        # row-by-row CSV write, on a table that may hold 200 000 flows.
+        "label": "gui: the connection export is run inline instead of started",
+        "file": "beantester/gui/csv_export.py",
+        "old": "    worker.start()\n    return worker",
+        "new": "    worker.run()\n    return worker",
+        "test": "test_the_connection_export_does_not_run_on_the_ui_thread",
+    },
+    {
+        # One fixed path, two workers: whichever finishes last publishes, and the
+        # other one's file is gone. Easier to hit now that the window stays
+        # responsive during the write.
+        "label": "gui: two clicks can start two exports onto the same file",
+        "file": "beantester/gui/csv_export.py",
+        "old": ("    if not _EXPORT_LOCK.acquire(blocking=False):\n"
+                "        # Two clicks, one file. Refusing out loud beats two workers"
+                " racing to\n"
+                "        # `os.replace` the same path, where the winner is whichever"
+                " finishes last.\n"
+                '        app.log(T("log.conns_export_busy"))\n'
+                "        return None\n"),
+        "new": "    _EXPORT_LOCK.acquire(blocking=False)\n",
+        "test": "test_a_second_export_is_refused_while_the_first_is_still_writing",
+    },
+    {
+        # The split that lets one filtering pass answer both the sorted view and
+        # the footer's total. A half that stops filtering makes them disagree.
+        "label": "views: the filtering half of the split stops filtering",
+        "file": "beantester/views.py",
+        "old": "    return _filter_connections(conns, query, proc_map)\n\n\ndef sum_traffic",
+        "new": "    return list(conns)\n\n\ndef sum_traffic",
+        "test": "test_the_split_halves_agree_with_the_pair_they_replace",
+    },
+    {
+        # `_pending` is cleared here or by poll() reading a result, so a build that
+        # ends any other way wedges the table for the rest of the session.
+        "label": "gui: a model build that fails oddly wedges the table for good",
+        "file": "beantester/gui/model_worker.py",
+        "old": "        except BaseException as exc:",
+        "new": "        except Exception as exc:",
+        "test": "test_a_build_that_fails_outside_Exception_does_not_wedge_the_table",
+    },
+    {
         # Back to a rebuild that destroys every widget without telling the pages,
         # leaving their after() timers armed against commands Tk has deleted.
         "label": "gui: a language switch stops telling the pages to put their timers away",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1267,6 +1267,21 @@ MUTATIONS = [
         # Cleared only on success, as shipped: a socket table that keeps hiccupping
         # leaves the dict growing, and growing STALE - the rescue then puts a port
         # back in scope whose socket closed long ago.
+        # The shipped shape: an unguarded check-then-act, in five copies. Two
+        # readers both find the catalogue empty and both scan lang/.
+        "label": "i18n: the lazy load goes back to being unguarded",
+        "file": "beantester/i18n.py",
+        "old": "    if _translations:\n"
+               "        return\n"
+               "    with _load_lock:\n"
+               "        if not _translations:       "
+               "# somebody else may have loaded it while we\n"
+               "            load_languages()        "
+               "# waited - checked again inside the lock",
+        "new": "    if not _translations:\n        load_languages()",
+        "test": "test_a_cold_catalogue_is_loaded_once_however_many_threads_ask",
+    },
+    {
         "label": "targeting: late owners survive a walk that failed",
         "file": "beantester/targeting.py",
         "old": "            with self._ports_lock:\n"
@@ -2008,6 +2023,14 @@ PROVEN_BY_HAND = {
 # No mutation at all. Naming them is the point: an unproven guard and a guard nobody
 # looked at must not read the same. This list is allowed to grow only when a guard
 # is added without its proof - and every entry is a debt.
+# 🔴 These three lists are keyed by TEST NAME, so a property with no test of its
+# own has no slot here and must not be given one by borrowing a neighbour's name -
+# that is what "filed under exactly one state" catches. One such property exists as
+# of 2026-09-03: `i18n.load_languages` publishes `_language_names` before
+# `_translations` because the second is what every "loaded yet?" check reads, and
+# the window is two adjacent stores, so a guard would need a reader racing a loader
+# in a loop - slow, flaky, and green most of the time for the wrong reason. It is
+# recorded where it can be read next to the code, in a comment at the assignment.
 NOT_PROVEN = {
     "test_a_resize_after_the_label_is_gone_is_not_a_crash": "never mutated",
     "test_the_ui_rebuild_does_not_pile_up_configure_handlers_on_the_root": "never mutated",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1264,9 +1264,6 @@ MUTATIONS = [
         "test": "test_a_second_kind_of_resolver_failure_is_recorded_too",
     },
     {
-        # Cleared only on success, as shipped: a socket table that keeps hiccupping
-        # leaves the dict growing, and growing STALE - the rescue then puts a port
-        # back in scope whose socket closed long ago.
         # The shipped shape: an unguarded check-then-act, in five copies. Two
         # readers both find the catalogue empty and both scan lang/.
         "label": "i18n: the lazy load goes back to being unguarded",
@@ -1282,6 +1279,9 @@ MUTATIONS = [
         "test": "test_a_cold_catalogue_is_loaded_once_however_many_threads_ask",
     },
     {
+        # Cleared only on success, as shipped: a socket table that keeps hiccupping
+        # leaves the dict growing, and growing STALE - the rescue then puts a port
+        # back in scope whose socket closed long ago.
         "label": "targeting: late owners survive a walk that failed",
         "file": "beantester/targeting.py",
         "old": "            with self._ports_lock:\n"
@@ -1289,6 +1289,35 @@ MUTATIONS = [
                "            self.table.refresh(force=force)",
         "new": "            self.table.refresh(force=force)",
         "test": "test_a_failing_refresh_does_not_leave_late_owners_behind",
+    },
+    {
+        # The shipped shape: fourteen setters, fourteen separate holds of the lock
+        # a packet is judged under, so a packet in the middle sees a mixture.
+        #
+        # 🔴 There is deliberately NO companion entry turning `core._lock` back
+        # into a plain `Lock`. That mutation does not FAIL, it DEADLOCKS - the
+        # batch holds the lock and the first setter inside it waits forever - and
+        # this runner has no timeout, so the "proof" would be a hung suite rather
+        # than a red one. The reentrancy is REQUIRED by the entry below; it is not
+        # separately provable this way, and pretending otherwise would be the kind
+        # of claim this whole registry exists to refuse.
+        "label": "settings: an apply goes back to separate lock holds per setter",
+        "file": "beantester/settings.py",
+        "old": "    with _batch(engine):",
+        "new": "    with nullcontext():",
+        "test": "test_a_packet_decided_during_an_apply_never_sees_half_of_it",
+    },
+    {
+        # A compiled matcher stringified back into text is a matcher compiled
+        # AGAIN - and inside the batch, which is the one place compilation may not
+        # happen. Not invented: it is what the first version of this batch did,
+        # and the guard is what found it.
+        "label": "settings: a batched apply recompiles its port expressions",
+        "file": "beantester/core.py",
+        "old": "            parse_matcher(port if isinstance(port, Matcher) "
+               "else port_expression(port),",
+        "new": "            parse_matcher(port_expression(port),",
+        "test": "test_an_apply_holds_the_core_lock_over_assignments_only",
     },
     {
         "label": "targeting: a pid whose name will not resolve is written off",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -237,6 +237,29 @@ MUTATIONS = [
         "test": "test_doctor_says_where_the_users_own_files_are",
     },
     {
+        # Back to the state before 2026-09-02: `re.compile` succeeding was the
+        # whole check, so a pattern that parses but never finishes went straight
+        # onto the capture thread.
+        "label": "matchers: a pattern that cannot finish is no longer refused",
+        "file": "beantester/matchers.py",
+        "old": "    if _blows_the_budget(rx) and _blows_the_budget(rx):",
+        "new": "    if False:",
+        "test": "test_a_pattern_that_cannot_finish_is_refused_at_parse_time",
+    },
+    {
+        # The other way to make the guard useless without touching its call: stop
+        # the ladder before it reaches a length where backtracking shows. The
+        # budget cannot be loosened instead - a mutant with no ceiling would run
+        # the explosive pattern at 45 characters and hang the suite rather than
+        # fail it.
+        "label": "matchers: the probe ladder stops before backtracking shows",
+        "file": "beantester/matchers.py",
+        "old": "_REGEX_PROBE_LENGTHS = (6, 8, 10, 12, 14, 16, 20, 24, 32, 45)",
+        "new": "_REGEX_PROBE_LENGTHS = (6,)",
+        "test": ("test_a_pattern_that_cannot_finish_leaves_the_table_search"
+                 "_answering_normally"),
+    },
+    {
         # Back to the check as it stood before 2026-09-02, which is the exact
         # shape that let NaN through: `float('nan') <= 0` is False.
         "label": "cli: the report interval is only checked for being above zero",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -237,6 +237,55 @@ MUTATIONS = [
         "test": "test_doctor_says_where_the_users_own_files_are",
     },
     {
+        # Back to a rebuild that destroys every widget without telling the pages,
+        # leaving their after() timers armed against commands Tk has deleted.
+        "label": "gui: a language switch stops telling the pages to put their timers away",
+        "file": "beantester/gui/app.py",
+        "old": "        if getattr(self, \"pages\", None):\n            teardown_pages(self)\n",
+        "new": "",
+        "test": "test_a_language_switch_cancels_what_the_pages_had_scheduled",
+    },
+    {
+        # The guard that reads as thorough and is not: a DESTROYED Tk widget is not
+        # None, so `box is None` passes and every call after it raises TclError.
+        "label": "gui: the log box guard trusts the attribute instead of the widget",
+        "file": "beantester/gui/logview.py",
+        "old": "        try:\n            return bool(box.winfo_exists())",
+        "new": "        try:\n            return True",
+        "test": "test_logging_into_a_destroyed_box_is_not_an_error",
+    },
+    {
+        # `crashlog.record` deduplicates and counts. The dialog deduplicated
+        # nothing, so a binding firing in a series stacked modal windows.
+        "label": "gui: every occurrence of one fault opens its own modal window again",
+        "file": "beantester/gui/app.py",
+        "old": "        if key in self._ui_errors_shown:\n            return\n",
+        "new": "",
+        "test": "test_one_window_per_fault_not_one_per_occurrence",
+    },
+    {
+        # The exact shape before 2026-09-02: the put outside the try, and a catch
+        # narrow enough for anything else to escape past it - which leaves
+        # `_transition` set forever and START/STOP dead for the life of the window.
+        "label": "gui: a transition worker can end without ever feeding the queue",
+        "file": "beantester/gui/app.py",
+        "old": ("            err = None\n"
+                "            try:\n"
+                "                work()\n"
+                "            except BaseException as e:  # carried to the main thread,"
+                " never swallowed\n"
+                "                err = e\n"
+                "            finally:\n"
+                "                self._ui_queue.put((kind, err))"),
+        "new": ("            try:\n"
+                "                work()\n"
+                "                err = None\n"
+                "            except Exception as e:\n"
+                "                err = e\n"
+                "            self._ui_queue.put((kind, err))"),
+        "test": "test_a_start_that_fails_outside_Exception_still_gives_the_button_back",
+    },
+    {
         # Back to the watchdog as it stood before 2026-09-02, which asked
         # `is_alive()` and nothing else - so a thread spinning in a regular
         # expression or blocked on a driver that stopped answering was healthy.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -150,6 +150,31 @@ MUTATIONS = [
         "test": "test_no_loader_can_be_taken_down_by_a_hostile_file",
     },
     {
+        # The name that shipped: derived from the target, so two writers of one
+        # file are two writers of one temp file. This is not an invented break.
+        "label": "jsonfile: the temp file gets a predictable name again",
+        "file": "beantester/jsonfile.py",
+        "old": "        tmp = temp_beside(path)",
+        "new": '        tmp = f"{path}.tmp"',
+        "test": "test_two_writers_do_not_share_one_temp_file",
+    },
+    {
+        # TypeError back out of the tuple: a value json has no rule for escapes
+        # the writer again, past its own temp-file cleanup.
+        "label": "jsonfile: a value json cannot write escapes the writer",
+        "file": "beantester/jsonfile.py",
+        "old": "    except (OSError, TypeError, ValueError) as e:",
+        "new": "    except (OSError, ValueError) as e:",
+        "test": "test_a_value_json_cannot_write_is_an_error_not_a_crash",
+    },
+    {
+        "label": "paths: two copies migrate through one temp file again",
+        "file": "beantester/paths.py",
+        "old": "            tmp = temp_beside(dst)",
+        "new": '            tmp = dst + ".tmp"',
+        "test": "test_two_copies_migrating_at_once_do_not_share_one_temp_file",
+    },
+    {
         # The 2026-08-26 report in one line. "The screen" is SM_CXSCREEN on
         # Windows, which is the PRIMARY monitor whatever the window is on, so this
         # patch is not an invented break: it is the code that shipped.
@@ -1593,6 +1618,24 @@ MUTATIONS = [
         "old": ".hexdigest()[:12]",
         "new": ".hexdigest()",
         "test": "test_different_faults_get_different_fingerprints",
+    },
+    {
+        # Written from the GUI tick, so the shared name is 1.4 chances a second
+        # for as long as two windows are open.
+        "label": "crashlog: the breadcrumb temp file gets a predictable name again",
+        "file": "beantester/crashlog.py",
+        "old": "        tmp = temp_beside(path)",
+        "new": '        tmp = path + ".tmp"',
+        "test": "test_two_breadcrumb_writers_do_not_share_one_temp_file",
+    },
+    {
+        # Back to removing one known name. With a unique temp file that sweeps
+        # nothing, and one orphan keeps `crashes/` alive for ever after.
+        "label": "crashlog: the sweep for orphaned temp breadcrumbs stops sweeping",
+        "file": "beantester/crashlog.py",
+        "old": "    for name in [BREADCRUMB_NAME, *stale]:",
+        "new": "    for name in [BREADCRUMB_NAME]:",
+        "test": "test_a_temp_breadcrumb_left_by_a_kill_is_swept_on_the_next_clean_exit",
     },
     {
         # One byte of the recorded driver hash. The version resource still reads

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -237,6 +237,16 @@ MUTATIONS = [
         "test": "test_doctor_says_where_the_users_own_files_are",
     },
     {
+        # Back to the check as it stood before 2026-09-02, which is the exact
+        # shape that let NaN through: `float('nan') <= 0` is False.
+        "label": "cli: the report interval is only checked for being above zero",
+        "file": "beantester/cli.py",
+        "old": "if not (0 < interval <= MAX_INTERVAL_S):",
+        "new": "if interval <= 0:",
+        "test": ("test_the_report_interval_is_refused_while_it_is_still_a_number"
+                 "_on_a_command_line"),
+    },
+    {
         "label": "doctor: the JSON report loses the data_dir field",
         "file": "beantester/cli.py",
         "old": 'log.data(dict(event="doctor", ok=ok, data_dir=where,',

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -124,6 +124,37 @@ MUTATIONS = [
         "test": "test_a_timeline_that_breaks_takes_the_session_down_with_it",
     },
     {
+        # The shipped stop(): a flag and a return. The thread is still between two
+        # steps and applies one more set of settings after the caller moved on.
+        "label": "scenario: stop() goes back to setting a flag and returning",
+        "file": "beantester/scenario_runner.py",
+        "old": "        thread = self._thread\n"
+               "        if (thread is not None and thread.is_alive()\n"
+               "                and thread is not threading.current_thread()):\n"
+               "            thread.join(timeout=timeout)",
+        "new": "        return",
+        "test": "test_stop_returns_with_the_thread_already_gone",
+    },
+    {
+        # Joining the calling thread raises - and raises INSIDE the net that
+        # handles the timeline's own failure, because worker_failed comes back here
+        # on the runner thread.
+        "label": "scenario: stop() joins whichever thread called it",
+        "file": "beantester/scenario_runner.py",
+        "old": "                and thread is not threading.current_thread()):",
+        "new": "                and True):",
+        "test": "test_stopping_from_inside_the_runner_thread_does_not_raise",
+    },
+    {
+        # start() back to clearing the stop flag over a thread it never stopped:
+        # the orphan keeps applying its own timeline to the same engine.
+        "label": "scenario: start() abandons the thread it already owns",
+        "file": "beantester/scenario_runner.py",
+        "old": "        self.stop()\n        self._wake.clear()",
+        "new": "        self._wake.clear()",
+        "test": "test_starting_again_leaves_no_orphan_applying_the_old_timeline",
+    },
+    {
         # The exact shape that walked past all four JSON loaders: RecursionError is
         # neither OSError nor ValueError, so re-raising it is the bug restored.
         "label": "jsonfile: deep nesting escapes the reader again",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1249,9 +1249,31 @@ MUTATIONS = [
         "old": "            try:\n"
                "                targeting.adopt_new_pids()\n"
                "            except Exception as exc:\n"
-               "                crashlog.once(\"targeting.adopt\", exc)",
+               "                crashlog.note(exc, \"targeting.adopt\")"
+               "   # note, not once: see below",
         "new": "            targeting.adopt_new_pids()",
         "test": "test_a_failing_adoption_does_not_kill_the_resolver",
+    },
+    {
+        # `once` keys on the subsystem NAME, so the first failure silences every
+        # later one - including a different fault, which is the one worth reading.
+        "label": "targeting: only the resolver's FIRST kind of failure is recorded",
+        "file": "beantester/target_resolver.py",
+        "old": "                crashlog.note(exc, \"targeting.resolver\")",
+        "new": "                crashlog.once(\"targeting.resolver\", exc)",
+        "test": "test_a_second_kind_of_resolver_failure_is_recorded_too",
+    },
+    {
+        # Cleared only on success, as shipped: a socket table that keeps hiccupping
+        # leaves the dict growing, and growing STALE - the rescue then puts a port
+        # back in scope whose socket closed long ago.
+        "label": "targeting: late owners survive a walk that failed",
+        "file": "beantester/targeting.py",
+        "old": "            with self._ports_lock:\n"
+               "                self._late_owners = {}\n"
+               "            self.table.refresh(force=force)",
+        "new": "            self.table.refresh(force=force)",
+        "test": "test_a_failing_refresh_does_not_leave_late_owners_behind",
     },
     {
         "label": "targeting: a pid whose name will not resolve is written off",

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -237,6 +237,26 @@ MUTATIONS = [
         "test": "test_doctor_says_where_the_users_own_files_are",
     },
     {
+        # Back to the watchdog as it stood before 2026-09-02, which asked
+        # `is_alive()` and nothing else - so a thread spinning in a regular
+        # expression or blocked on a driver that stopped answering was healthy.
+        "label": "engine: the watchdog stops noticing a capture thread that stalled",
+        "file": "beantester/engine.py",
+        "old": "            if self._capture_has_stalled():",
+        "new": "            if False:",
+        "test": "test_a_capture_thread_that_is_alive_but_no_longer_moving_fails_open",
+    },
+    {
+        # The other direction, and the more expensive one to get wrong: without the
+        # phase, a thread parked in recv() on a link with no traffic looks exactly
+        # like a stalled one, and the watchdog would kill a healthy session.
+        "label": "engine: the stall check forgets which side of recv the thread is on",
+        "file": "beantester/engine.py",
+        "old": "        if self._cap_beat_at is None or self._cap_waiting:",
+        "new": "        if self._cap_beat_at is None:",
+        "test": "test_a_quiet_link_is_never_mistaken_for_a_stalled_capture_thread",
+    },
+    {
         # Back to the state before 2026-09-02: `re.compile` succeeding was the
         # whole check, so a pattern that parses but never finishes went straight
         # onto the capture thread.

--- a/tests/test_narrow_filter.py
+++ b/tests/test_narrow_filter.py
@@ -186,5 +186,11 @@ def test_a_destination_change_is_allowed_when_nothing_was_narrowed():
 
     engine = _PlainEngine()
     apply_settings(engine, dict(DEFAULT_SETTINGS, dst_ip="1.1.1.1"), lambda *_: None)
+    # `.raw` if it arrived compiled: since the apply became a single batch, the
+    # expressions are compiled BEFORE the lock is taken and handed to `set_dest`
+    # as matchers (see core.compile_endpoint). What this test is about is that the
+    # new destination reaches the engine at all, not which of the two shapes
+    # `set_dest` accepts it in.
+    applied = engine.applied[-1][1] if engine.applied else None
     check("an ordinary session still applies a new destination",
-          engine.applied and engine.applied[-1][1] == "1.1.1.1", str(engine.applied))
+          getattr(applied, "raw", applied) == "1.1.1.1", str(engine.applied))

--- a/tests/test_prefs.py
+++ b/tests/test_prefs.py
@@ -181,10 +181,12 @@ def test_a_resized_chart_spans_its_whole_window_at_once():
 
 
 def test_log_length_follows_the_preference():
+    # Through `app._logview`, which is where the box's own bookkeeping moved on
+    # 2026-09-02 (see gui/logview.py). `app._log_lines` still reads the same list.
     run_gui("""
         app.set_pref("log_lines", 50)
         for i in range(400):
-            app._append_log_line(f"line {i}")
+            app._logview._append(f"line {i}")
         # kept list is bounded to the preference (plus a small hysteresis margin)
         assert len(app._log_lines) <= 50 + 100, len(app._log_lines)
         assert app._log_lines[-1] == "line 399"

--- a/tests/test_scenario_runner.py
+++ b/tests/test_scenario_runner.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from beantester import scenario_runner
+from beantester import crashlog, scenario_runner
 from beantester.scenario_runner import ScenarioRunner
 from fakes import check, wait_until
 
@@ -148,6 +148,96 @@ def test_a_looping_scenario_keeps_running_past_its_duration(spy_apply):
         runner.stop()
         _join(runner)
     check("stop() actually stops the loop", not runner._thread.is_alive())
+
+
+def test_stop_returns_with_the_thread_already_gone(spy_apply):
+    """``stop()`` used to set a flag and return, which is not the same thing.
+
+    The thread was still between two steps, so up to one more ``apply_settings``
+    landed on the engine AFTER the caller believed the scenario was over.
+    ``BeanEngine.stop()`` calls this while tearing a session down, and
+    ``start_scenario`` calls it to replace a runner - in that second case the old
+    timeline's last step could overwrite the new one's first.
+
+    The wait is asserted to be SHORT as well, because a join that is correct and
+    slow is its own bug here: STOP is the control the user reaches for to undo
+    what they just did to their own network.
+    """
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    runner.start(FakeScenario(loop=True, duration=5.0), base_settings={})
+    wait_until(lambda: bool(spy_apply))       # it is running and applying steps
+
+    began = time.monotonic()
+    runner.stop()
+    waited = time.monotonic() - began
+
+    check("stop() returns only once the thread is actually gone",
+          not runner._thread.is_alive())
+    check("and it does not hold the caller up for a whole step interval",
+          waited < 0.1, f"(waited {waited:.3f}s)")
+    applied = len(spy_apply)
+    time.sleep(0.25)
+    check("nothing is applied to the engine after stop() has returned",
+          len(spy_apply) == applied, f"({len(spy_apply)} vs {applied})")
+
+
+def test_starting_again_leaves_no_orphan_applying_the_old_timeline(spy_apply):
+    """``start()`` on a runner that still owns a thread.
+
+    It set ``_stop`` back to False and overwrote ``_thread``: the previous thread
+    kept running with its stop flag freshly cleared, applying ITS timeline to the
+    same engine, and unreachable - ``stop()`` only ever knew about the current
+    thread. ``BeanEngine.start_scenario`` builds a fresh runner each time, so this
+    is the object's own guarantee rather than a path the program walks; the engine
+    side has its own guard (``test_engine.py::
+    test_a_second_scenario_stops_the_first_instead_of_orphaning_it``).
+    """
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    runner.start(FakeScenario(loop=True, duration=5.0), base_settings={})
+    wait_until(lambda: bool(spy_apply))
+    first = runner._thread
+
+    runner.start(FakeScenario(loop=True, duration=5.0), base_settings={})
+
+    check("the first thread is gone before the second one is handed out",
+          not first.is_alive())
+    check("and the runner really did hand out a second one",
+          runner._thread is not first and runner._thread.is_alive())
+    runner.stop()
+
+
+def test_stopping_from_inside_the_runner_thread_does_not_raise(spy_apply,
+                                                               monkeypatch):
+    """The runner's own failure path comes back through ``stop()``.
+
+    ``_loop`` catches, calls ``engine.worker_failed``, and on the real engine that
+    is ``_fail_stop`` -> ``_worker_stop`` -> ``_stop_locked`` -> ``stop_scenario()``
+    -> ``ScenarioRunner.stop()`` - on the runner thread itself. A join without the
+    current-thread check raises ``RuntimeError`` there, i.e. inside the net that
+    exists to handle a failure. The fake engine below is the real call chain
+    collapsed to its one relevant step.
+    """
+    def explode(*_a, **_kw):
+        raise TypeError("a value the engine cannot use")
+
+    monkeypatch.setattr(scenario_runner, "apply_settings", explode)
+
+    def joins(): return [r for r in crashlog.recent(50) if r["type"] == "RuntimeError"]
+
+    before = len(joins())               # counted, not assumed empty: the crash
+                                        # table is global and outlives one test
+    engine = FakeEngine()
+    runner = ScenarioRunner(engine)
+    engine.worker_failed = lambda error: runner.stop()      # what the engine does
+    runner.start(FakeScenario(loop=False, duration=5.0), base_settings={})
+    _join(runner)
+
+    check("the runner thread ended without a second exception",
+          not runner._thread.is_alive())
+    check("and the crash log holds the timeline's fault, not a join error",
+          len(joins()) == before, f"({[r['type'] for r in joins()]})")
 
 
 def test_a_completed_timeline_reports_that_it_finished(spy_apply):

--- a/tests/test_settings_config_scenario.py
+++ b/tests/test_settings_config_scenario.py
@@ -4,6 +4,7 @@ Ported 1:1 from the original monolithic suite; every ``check(...)`` from the
 270-assertion baseline is preserved as a pytest assertion.
 """
 import json
+import random
 
 from beantester import BeanEngine
 from fakes import check
@@ -81,6 +82,133 @@ def test_apply_settings_maps_engine():
           and c.block_ip == "203.0.113.0/24" and c.block_port == "8080"
           and c.block_ip_matcher.matches("203.0.113.9")
           and c.block_port_matcher.matches(8080))
+
+
+def test_a_packet_decided_during_an_apply_never_sees_half_of_it():
+    """The setters used to take and release the core's lock ONE AT A TIME.
+
+    So a packet judged in the middle of an apply was judged by a mixture: the new
+    loss with the old destination gate, a new rate limit with the old schedule.
+    It matters in two places in particular - a scenario step, where the mixed
+    window falls exactly where the tester is looking, and reproducibility under
+    ``--seed``, where the mixture is in no seed.
+
+    The pair of settings is chosen so that a MIXTURE IS VISIBLE, which is most of
+    the difficulty here: the two dicts move a gate and an impairment in opposite
+    directions, so their halves make four distinct answers of which only two are
+    legal.
+
+        A: no destination gate, loss 100            ->  (scoped=True,  drop=True)
+        B: gate on 10/8 (our packet is not), loss 0 ->  (False, False)
+        a blend of the two                          ->  (True, False)
+
+    🔴 And the interleaving is FORCED, not raced, because racing it does not work:
+    the first version of this test ran a reader thread flat out against 300
+    applies and the mutation that removes the batch SURVIVED it. The window is the
+    ~5 us an apply spends on its assignments, and a thread that holds the GIL for
+    that whole stretch never lets the reader into it. So the reader is released
+    from INSIDE the apply, right after the loss has changed and before the gate
+    has - the one instant at which a mixture exists at all - and the applier waits
+    there to give it every chance. With the batch the reader blocks on the core's
+    lock and samples a finished configuration; without it, it walks straight in.
+    """
+    import threading
+
+    from beantester import BeanEngine, apply_settings
+
+    both_halves_on = dict(loss=100, dst_ip="", dst_port="", target="")
+    both_halves_off = dict(loss=0, dst_ip="10.0.0.0/8", dst_port="", target="")
+    legal = {(True, True), (False, False)}
+
+    sh = BeanEngine()
+    apply_settings(sh, both_halves_on)
+    rng = random.Random(4321)
+    take, sampled, seen = threading.Event(), threading.Event(), []
+
+    def reader():
+        take.wait(timeout=5)
+        d = sh.core.decide(1400, True, 50000, 1000.0, rng,
+                           remote_ip="93.184.216.34", remote_port=443, is_tcp=True)
+        seen.append((d.scoped, d.drop))
+        sampled.set()
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+
+    # set_loss_burst is the third setter an apply calls: the loss is already new
+    # and the destination gate is still old, so this is exactly where a mixture
+    # lives. Shadowed on the instance, so nothing global is touched.
+    real = sh.set_loss_burst
+
+    def let_the_reader_in(*a, **kw):
+        real(*a, **kw)
+        take.set()
+        sampled.wait(timeout=0.5)       # returns False when the lock holds it out
+
+    sh.set_loss_burst = let_the_reader_in
+    try:
+        apply_settings(sh, both_halves_off)
+    finally:
+        del sh.set_loss_burst
+        take.set()
+        t.join(timeout=5)
+
+    check("the reader was let in from inside the apply", seen, "(it never sampled)")
+    check("no packet was judged by a configuration neither dict describes",
+          set(seen) <= legal, f"(saw {sorted(set(seen))})")
+
+
+def test_an_apply_holds_the_core_lock_over_assignments_only():
+    """What the batch may NOT contain, pinned as a property.
+
+    Whatever the batch holds, the capture thread waits for (convention 20).
+    Compiling a filter expression is the one part of an apply that can take real
+    time - a pathological ``re:`` pattern is why ``matchers`` carries a time
+    budget at all - so it happens before the lock is taken, not inside it.
+    Measured 2026-09-03: two benign expressions cost 19.5 us median against 5.3 us
+    for every assignment in an apply put together.
+
+    The probe is the matcher factory itself: it records whether the core's lock
+    was already held by THIS thread at the moment it was asked to compile, which
+    is what being inside a batch means.
+
+    ``_is_owned()`` and not ``acquire(blocking=False)``: an RLock grants itself
+    again to the thread that already holds it, so an acquire would succeed inside
+    a batch and prove nothing. The first draft of this test asked for ``_count``
+    instead - which the PYTHON RLock has and the C one shipped by CPython does
+    not, so ``getattr(..., None)`` made every reading False and the guard passed
+    without looking at anything.
+
+    What is counted is a REAL compilation, not every call to the factory: the
+    setters still call it from inside the batch, with matchers the caller already
+    compiled, and ``parse_matcher`` hands those straight back. That passthrough is
+    exactly what lets the setters keep one signature, so this pins it too - remove
+    it and these calls become real compilations under the lock, and this goes red.
+    """
+    from beantester import BeanEngine, apply_settings
+    from beantester import core as core_mod
+    from beantester.matchers import Matcher
+
+    sh = BeanEngine()
+    compiled = []
+    real_parse = core_mod.parse_matcher
+
+    def watching_parse(text, *a, **kw):
+        if not isinstance(text, Matcher):
+            compiled.append(sh.core._lock._is_owned())
+        return real_parse(text, *a, **kw)
+
+    core_mod.parse_matcher = watching_parse
+    try:
+        apply_settings(sh, dict(loss=5, dst_ip="10.0.0.0/8", dst_port="80,443",
+                                block_ip="203.0.113.0/24", block_port="8080",
+                                target=""))
+    finally:
+        core_mod.parse_matcher = real_parse
+
+    check("the apply really compiled something", compiled, "(nothing was compiled)")
+    check("no expression was compiled while the core's lock was held",
+          not any(compiled), f"({compiled})")
 
 
 def test_apply_settings_bad_schedule_fallback():

--- a/tests/test_target_resolver.py
+++ b/tests/test_target_resolver.py
@@ -16,6 +16,7 @@ import threading
 import time
 
 import bean_network_tester as bnt
+from beantester import crashlog
 from beantester.engine import BeanEngine
 from beantester.synthetic import SyntheticDivert
 from beantester.target_resolver import TargetResolver
@@ -259,6 +260,62 @@ def test_a_failing_refresh_does_not_kill_the_resolver():
     try:
         time.sleep(0.15)
         check("the resolver survived a broken table", resolver.is_running())
+    finally:
+        resolver.stop()
+
+
+def test_a_second_kind_of_resolver_failure_is_recorded_too():
+    """``crashlog.once`` keys on the SUBSYSTEM NAME, not on the fault.
+
+    So the first thing that went wrong in the resolver used to silence every later
+    one - including a completely different fault, which is the one worth reading.
+    A resolver whose table hiccupped once at startup and then began failing for a
+    real reason reported the hiccup and nothing else, for the life of the session.
+
+    The cost argument that puts ``once`` in the packet path does not reach here:
+    this line runs only when something has ALREADY failed, at most once per
+    ``min_interval``. Repeats stay cheap on disk because ``record`` de-duplicates
+    them by fingerprint - which is a different key from the subsystem, and that is
+    the whole point.
+    """
+    class _BrokenTwice:
+        """First pass fails one way, every pass after it fails another."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def refresh(self, *a, **k):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("socket table exploded")
+            raise OSError("the handle is gone")
+
+        def snapshot(self):
+            return {}
+
+        def name_of(self, pid):
+            return ""
+
+        def ancestors(self, pid, depth=8):
+            return []
+
+    def kinds():
+        return {r["type"] for r in crashlog.recent(200)
+                if r.get("subsystem") == "targeting.resolver"}
+
+    table = _BrokenTwice()
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
+    resolver = TargetResolver(interval=0.02, min_interval=0.01)
+    resolver.retarget(targeting)
+    resolver.start()
+    try:
+        check("the resolver kept going past the first failure",
+              _wait(lambda: table.calls >= 3), f"({table.calls} passes)")
+        # The SECOND kind is the assertion. The first may already be in the table
+        # from another test in this file, and with `once` that is exactly the
+        # silence being tested - the subsystem is burned by whoever failed first.
+        check("a different fault in the same subsystem is recorded, not swallowed",
+              _wait(lambda: "OSError" in kinds()), f"({sorted(kinds())})")
     finally:
         resolver.stop()
 

--- a/tests/test_targeting_socketwatch.py
+++ b/tests/test_targeting_socketwatch.py
@@ -518,7 +518,27 @@ def test_a_recycled_pid_reaches_further_through_the_push_path_but_not_further_in
     targeting.note_socket(7000, 100)
     check("inside the window the stranger's socket IS in scope", 7000 in targeting)
 
+    # 🔴 The rebuild, with the stranger's socket announced WHILE the walk is
+    # resolving names - the same interposition as
+    # test_a_rebuild_in_flight_does_not_lose_a_socket_the_event_added, and since
+    # 2026-09-03 the ONLY way a port reaches the rescue at all: `_late_owners` is
+    # emptied at the START of a walk now (it used to be emptied at the end, which
+    # let it hoard entries across failed walks). Announcing before the walk, the
+    # way this test used to, no longer reaches the owner check - it left the guard
+    # green whatever that check did, which the mutation registry reported as
+    # SURVIVED. This is the case the check exists for: the event names pid 100,
+    # and this very walk is in the middle of deciding 100 is no longer ours.
+    seen = []
+
+    def name_of(pid, cheap=False):
+        if not seen:
+            seen.append(pid)
+            targeting.note_socket(7000, 100)
+        return table.names.get(pid, "")
+
+    table.name_of = name_of
     targeting.refresh()          # the resolver's next tick
+    check("the event really landed mid-walk", seen, "(the interposition never ran)")
     check("the rebuild drops the pid", targeting.pids() == set(), f"({targeting.pids()})")
     check("...and the stranger's port with it", 7000 not in targeting,
           f"({sorted(targeting.ports())})")

--- a/tests/test_targeting_socketwatch.py
+++ b/tests/test_targeting_socketwatch.py
@@ -524,6 +524,49 @@ def test_a_recycled_pid_reaches_further_through_the_push_path_but_not_further_in
           f"({sorted(targeting.ports())})")
 
 
+def test_a_failing_refresh_does_not_leave_late_owners_behind():
+    """The late-port list was emptied only by a walk that SUCCEEDED.
+
+    Two consequences, and the second is the one that matters. It grew, fed by
+    every socket event of every process already targeted - and it grew STALE: the
+    rescue in ``refresh`` keeps a port whose RECORDED owner is still targeted, so
+    once a walk finally succeeded it could put back in scope a port whose socket
+    had closed long before, and which the OS may since have handed to somebody
+    else. That is the "until the next rebuild" bound this class documents, quietly
+    stretched to "until a refresh happens to work".
+
+    A socket table that keeps failing is not a hypothetical: the resolver loop
+    catches exactly this and carries on by design, which is what makes the
+    accumulation invisible.
+    """
+    table = _EventTable(ports={5000: 100}, names={100: "chrome.exe"})
+    targeting = ProcessTargeting(bnt.parse_target("chrome"), table=table)
+    targeting.refresh()
+    check("the target resolved", targeting.pids() == {100})
+
+    def explode(now=None, force=False):
+        raise OSError("the socket table hiccupped")
+
+    table.refresh = explode
+    for port in range(6000, 6060):          # the target keeps opening sockets
+        targeting.note_socket(port, 100)
+        try:
+            targeting.refresh()             # ...and every rebuild fails
+        except OSError:
+            pass                            # the resolver loop swallows this
+
+    check("a walk that failed does not hoard the ports noted before it",
+          not targeting._late_owners, f"({len(targeting._late_owners)} left)")
+
+    # And the staleness half: the sockets are long gone, the table is healthy
+    # again, so the next successful walk must not rescue any of them.
+    table.refresh = lambda now=None, force=False: True
+    table.ports = {5000: 100}
+    targeting.refresh()
+    check("a port whose socket closed while refresh was failing is not rescued",
+          sorted(targeting.ports()) == [5000], f"({sorted(targeting.ports())})")
+
+
 def test_the_pending_queue_cannot_grow_without_a_bound():
     """It is fed by every socket event on the machine. A fork bomb, or simply a
     busy server, must not turn that into an unbounded queue of OS lookups."""

--- a/tests/test_user_data_location.py
+++ b/tests/test_user_data_location.py
@@ -183,6 +183,46 @@ def test_a_failed_copy_is_reported_and_leaves_no_half_written_file(tmp_path, mon
     check("no half-written file and no .tmp is left", leftovers == [], f"({leftovers})")
 
 
+def test_two_copies_migrating_at_once_do_not_share_one_temp_file(tmp_path, monkeypatch):
+    """Two copies of the program launched together both adopt the same file.
+
+    This is the first thing either of them does, so "at the same moment" needs no
+    unlucky timing at all - a double click does it. Through one ``<dst>.tmp`` the
+    second truncated what the first was copying, and the loser then published a
+    half-copy as the user's adopted profile file.
+
+    Forced at the instant that matters rather than raced, for the reason spelled
+    out in ``test_jsonfile.py``: a collision reproduced sometimes is a guard that
+    proves nothing on the run where it passes.
+    """
+    source, target = _dirs(tmp_path)
+    (source / paths.PROFILE_NAME).write_text('{"slow": {}}', encoding="utf-8")
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / paths.PROFILE_NAME).write_text('{"fast": {}}', encoding="utf-8")
+
+    real_replace = os.replace
+    second = []
+
+    def let_the_other_copy_in(src, dst):
+        if not second:                              # guard first: the second copy
+            second.append(["did not finish"])       # publishes through here too
+            second[0] = paths.migrate_user_files(str(other), str(target))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", let_the_other_copy_in)
+    first = paths.migrate_user_files(str(source), str(target))
+
+    check("the second copy migrated without a problem", second == [[]], f"({second})")
+    check("the first copy did too - it published a temp file of its own, not one "
+          "the second had already taken", first == [], f"({first})")
+    adopted = (target / paths.PROFILE_NAME).read_text(encoding="utf-8")
+    check("the adopted file is one copy's data, not a mix of two",
+          adopted in ('{"slow": {}}', '{"fast": {}}'), f"({adopted!r})")
+    leftovers = sorted(p.name for p in target.iterdir() if p.name.endswith(".tmp"))
+    check("neither copy left a temp file behind", leftovers == [], f"({leftovers})")
+
+
 def test_an_unusable_data_directory_does_not_stop_the_program(tmp_path, monkeypatch):
     blocked = tmp_path / "not-a-directory"
     blocked.write_text("I am a file", encoding="utf-8")

--- a/tests/test_view_scope.py
+++ b/tests/test_view_scope.py
@@ -636,12 +636,15 @@ def test_the_window_says_whether_the_narrowing_actually_happened():
     """
     run_gui("""
         def start_with(narrow, narrowed):
-            app._log_lines = []
+            # cleared in place, not rebound: `_log_lines` is a read-only property
+            # over LogView's list (the log's state moved to gui/logview.py), and
+            # assigning to it raises. The list itself is the live one.
+            app._log_lines.clear()
             app.engine._narrowed = narrowed
             app._pending_start_settings = dict(app._settings_from_widgets(),
                                                narrow_filter=narrow)
             app._finish_start(None)
-            app._drain_log()
+            app._logview.drain()        # was App._drain_log before gui/logview.py
             return "\\n".join(app._log_lines)
 
         # not asked for: the log must not gain a line about it either way

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -400,3 +400,43 @@ def test_the_query_is_compiled_once_not_per_row():
     tests = compile_query("proc:chrome port:443 dropped:>0")
     check("one predicate per term", len(tests) == 3, f"({len(tests)})")
     check("an empty query compiles to nothing to do", compile_query("   ") == [])
+
+
+def test_a_pattern_that_cannot_finish_leaves_the_table_search_answering_normally():
+    """The SECOND door onto the same regex, and it is not the same failure.
+
+    The session filter puts a matcher on the capture thread inside ``core._lock``,
+    so a pattern that backtracks catastrophically there takes the machine's network
+    and the window with it. Here the matcher runs on the model worker, so the cost
+    is milder and quieter: the table stops refreshing, ``AsyncModel.busy()`` stays
+    True and the worker leaks. Both doors go through ``parse_matcher``, so both are
+    closed by the same guard - this pins that the search box actually inherits it,
+    rather than assuming a shared function is a shared behaviour.
+
+    "Answering normally" means the term simply matches nothing, which is what
+    ``compile_query`` already does with every value it cannot use: the box is typed
+    into character by character, so half of a pattern must never throw or blank the
+    table.
+    """
+    import time
+
+    from beantester.views import compile_query
+
+    # The process name is one the pattern MATCHES. A row it would miss anyway
+    # cannot tell "the term was refused" from "the term ran and did not match",
+    # and the first draft of this test used one - it passed with the guard removed.
+    row = {"proc": "aaab", "pid": 1, "proto": "TCP", "dir": "out",
+           "remote_ip": "1.1.1.1", "remote_port": 443, "local_port": 5000}
+    started = time.perf_counter()
+    tests = compile_query(r"proc:re:^((a*)*)*b$")
+    elapsed = time.perf_counter() - started
+
+    check("the search box does not raise on a pattern it refuses",
+          isinstance(tests, list) and len(tests) == 1, f"({tests!r})")
+    check("the refused term matches nothing, even a row it would have hit",
+          not all(t(row, None) for t in tests))
+    # Generous on purpose: the point is "bounded", not a stopwatch reading. The
+    # same call without the guard did not return in 25 seconds (measured
+    # 2026-09-02). With the guard the refusal costs ~83 ms on this machine.
+    check("and it comes back quickly enough to keep the worker free",
+          elapsed < 5.0, f"({elapsed * 1000:.0f} ms)")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -440,3 +440,72 @@ def test_a_pattern_that_cannot_finish_leaves_the_table_search_answering_normally
     # 2026-09-02). With the guard the refusal costs ~83 ms on this machine.
     check("and it comes back quickly enough to keep the worker free",
           elapsed < 5.0, f"({elapsed * 1000:.0f} ms)")
+
+
+# --- one filtering pass, not two ---------------------------------------------- #
+
+
+def test_the_split_halves_agree_with_the_pair_they_replace():
+    """`filter_connections` + `sort_connections` + `sum_traffic` == the old pair.
+
+    The model rebuild used to filter the whole table twice - once inside
+    `filter_sort_connections` and again inside `traffic_totals`, compiling the query
+    a second time on the way. The split lets one pass answer both, and the ONLY
+    thing that makes it safe is that it returns the same rows in the same order and
+    the same totals. So that is what is asserted, rather than the number of calls.
+    """
+    from beantester.views import (filter_connections, filter_sort_connections,
+                                  sort_connections, sum_traffic, traffic_totals)
+
+    conns = []
+    for i in range(40):
+        conns.append({"proc": "chrome.exe" if i % 2 else "firefox.exe",
+                      "pid": 100 + i, "proto": "TCP", "dir": "out",
+                      "remote_ip": f"10.0.0.{i}", "remote_port": 443 if i % 3 else 80,
+                      "local_port": 50000 + i, "packets": i, "bytes": 1000 * i,
+                      "sent": 900 * i, "sent_in": 500 * i, "sent_out": 400 * i,
+                      "first": 0.0, "last": float(i)})
+
+    for query in ("", "chrome", "port:443", "nothingmatchesthis"):
+        for col, rev, limit in (("bytes", True, 0), ("packets", False, 0),
+                                ("proc", True, 5), ("bytes", True, 5)):
+            old_rows = filter_sort_connections(conns, query, col, rev,
+                                               now=99.0, proc_map=None, limit=limit)
+            old_totals = traffic_totals(conns, query, None)
+
+            kept = filter_connections(conns, query, None)
+            new_totals = sum_traffic(kept)
+            new_rows = sort_connections(kept, col, rev, now=99.0, limit=limit)
+
+            where = f"({query!r}, {col}, reverse={rev}, limit={limit})"
+            assert new_rows == old_rows, f"rows differ {where}"
+            assert new_totals == old_totals, f"totals differ {where}"
+
+
+def test_summing_before_the_sort_is_why_the_split_is_worth_making():
+    """`sort_connections` may reorder in place, so the sum has to come first.
+
+    Not a style rule - a measurement. Walking 200 000 dicts in sorted order instead
+    of allocation order costs enough to turn the whole change NEGATIVE on an empty
+    query (0.85x, measured 2026-09-02 with internal_tools/bench_conn_model.py).
+    Summing first, 1.04-1.14x, and 1.83-2.00x with something typed in the box. This
+    pins the property that makes that ordering legal: the sum does not depend on the
+    order, and the rows are the SAME objects afterwards.
+    """
+    from beantester.views import filter_connections, sort_connections, sum_traffic
+
+    conns = [{"proc": "a", "sent": 10, "sent_in": 6, "sent_out": 4, "bytes": 3},
+             {"proc": "b", "sent": 20, "sent_in": 11, "sent_out": 9, "bytes": 1},
+             {"proc": "c", "sent": 30, "sent_in": 16, "sent_out": 14, "bytes": 2}]
+
+    kept = filter_connections(conns, "", None)
+    before = sum_traffic(kept)
+    rows = sort_connections(kept, "bytes", True, now=0.0, limit=0)
+    after = sum_traffic(kept)
+
+    check("the sum does not depend on the order", before == after, f"({before}, {after})")
+    check("and it is the true total", before["total"] == 60, f"({before})")
+    check("sorting really did reorder the list in place",
+          [c["proc"] for c in kept] == ["a", "c", "b"], f"({[c['proc'] for c in kept]})")
+    check("the sorted view is the same objects, not copies",
+          all(any(r is k for k in kept) for r in rows))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,10 +10,10 @@ that carry real risk:
   mis-order the connection table on exactly the large tables the optimisation
   exists for.
 * the **derived columns** (kb / dur / idle) computed inside the sort key.
-* ``SearchIndex`` - the per-keystroke search cache, whose correctness hinges on
-  rebuilding when a row's stamp changes and on never mutating the rows it caches.
+* the **split** between filtering, sorting and totalling: one pass has to answer
+  what two used to, without changing a row or an order.
 """
-from beantester.views import (DERIVED, SearchIndex, avg_packet_bytes, connection_proc,
+from beantester.views import (DERIVED, avg_packet_bytes, connection_proc,
                               filter_sort_connections, traffic_totals)
 from fakes import check
 
@@ -229,66 +229,6 @@ def test_connection_proc_falls_back_to_proc_map():
     check("an explicit proc on the row wins",
           connection_proc({"local_port": 40001, "proc": "firefox.exe"},
                           {40001: "chrome.exe"}) == "firefox.exe")
-
-
-# --- SearchIndex ------------------------------------------------------------- #
-def test_search_index_builds_the_blob_once_per_stamp():
-    calls = {"n": 0}
-
-    def blob_of(item):
-        calls["n"] += 1
-        return item["text"]
-
-    idx = SearchIndex(blob_of, key_of=lambda it: it["id"])
-    item = {"id": 1, "text": "Chrome HTTPS 443", "proc": None}
-
-    idx.blob(item, stamp=item["proc"])
-    idx.blob(item, stamp=item["proc"])          # same stamp -> cache hit
-    check("blob is built once while the stamp is unchanged", calls["n"] == 1,
-          f"(built {calls['n']} times)")
-
-    item["proc"] = "chrome.exe"                  # the process name arrived later
-    idx.blob(item, stamp=item["proc"])          # stamp changed -> rebuild
-    check("blob is rebuilt when the stamp changes", calls["n"] == 2,
-          f"(built {calls['n']} times)")
-
-
-def test_search_index_filter_is_case_insensitive_and_empty_query_returns_all():
-    items = [{"id": i, "text": t} for i, t in enumerate(
-        ["Chrome 443", "firefox 80", "curl 53"])]
-    idx = SearchIndex(lambda it: it["text"], key_of=lambda it: it["id"])
-    hits = idx.filter(items, "CHROME")
-    check("filter is case-insensitive", [h["id"] for h in hits] == [0], f"({hits})")
-    check("empty query returns every item", len(idx.filter(items, "")) == 3)
-
-
-def test_search_index_filter_uses_the_stamp_when_given():
-    items = [{"id": 1, "text": "port 443", "proc": None}]
-    idx = SearchIndex(lambda it: f"{it['text']} {it['proc'] or ''}",
-                      key_of=lambda it: it["id"])
-    # First pass with no proc: the process name is not searchable yet.
-    check("not found before the proc name is known",
-          idx.filter(items, "chrome", stamp_of=lambda it: it["proc"]) == [])
-    items[0]["proc"] = "chrome.exe"
-    check("found once the stamp (proc) updates and the blob is rebuilt",
-          len(idx.filter(items, "chrome", stamp_of=lambda it: it["proc"])) == 1)
-
-
-def test_search_index_clears_when_it_exceeds_its_limit():
-    idx = SearchIndex(lambda it: it["t"], key_of=lambda it: it["id"], limit=2)
-    for i in range(2):
-        idx.blob({"id": i, "t": f"row{i}"})
-    check("cache filled to the limit", len(idx._cache) == 2, f"({len(idx._cache)})")
-    idx.blob({"id": 99, "t": "overflow"})       # exceeding the limit clears first
-    check("cache is bounded: it clears instead of growing past the limit",
-          len(idx._cache) == 1, f"({len(idx._cache)})")
-
-
-def test_search_index_clear_empties_the_cache():
-    idx = SearchIndex(lambda it: it["t"], key_of=lambda it: it["id"])
-    idx.blob({"id": 1, "t": "x"})
-    idx.clear()
-    check("clear() empties the cache", idx._cache == {})
 
 
 # --- field-qualified search --------------------------------------------------- #


### PR DESCRIPTION
Eighteen stability findings, each verified in the code before it was fixed and each measured
before a design was chosen. Thirteen commits on one branch; the numbering below (S-01..S-19) is
the one used while working through them.

## What is fixed

| commit | findings |
|---|---|
| `fix(cli): bound the report interval` | S-02: `--interval nan` / `inf` walked past validation |
| `fix(matchers): refuse a filter pattern that cannot finish` | S-01: a `re:` expression could freeze the capture thread |
| `fix(engine): watchdog sees a capture thread that stalled` | S-03: the watchdog saw a DEAD worker, not a hung one |
| `fix(gui): tell the pages before destroying them` | S-05, S-06, S-07, S-13: UI lifecycle |
| `perf(gui): one filtering pass for the table, CSV export off the UI thread` | S-08, S-10 |
| `refactor(views): delete the search cache that could not be correct` | S-19 |
| `fix(files): give every atomic write a temp file of its own` | S-09 |
| `fix(crashlog): keep the crash logger working at two moments it was off` | S-11, S-15 |
| `fix(scenario): stop() returns with the runner thread actually gone` | S-12 |
| `fix(targeting): empty the late-port list before a walk, not after a good one` | S-14 |
| `fix(i18n): load the catalogue once, and say why portmap reads without its lock` | S-17, S-18 |
| `fix(core): apply a whole settings dict under one lock hold` | S-04 |

Every fix carries an entry in the mutation registry (`tests/test_mutation_registry.py`) and each
of those was run: the named guard was proven to go red when the behaviour is broken again.

## Where measuring changed the answer

The findings arrived as claims. Several did not survive contact with a measurement, and the
design followed the number rather than the claim:

* **The settings lock (S-04).** The proposal was to add private lock-free setters because
  `RLock` is "measurably more expensive" on a path taken per packet. Measured on every supported
  interpreter, paired in one process: 3.11 0.99x, 3.12 1.02x, 3.13 1.15-1.19x (the worst,
  +16 to +19 ns), 3.14 1.03-1.06x - against a `decide()` call at 1826 ns, so 0.3% to 1.0%. An
  end-to-end A/B came back 1.047x against a drift canary of 1.239x, i.e. below the noise floor.
  So the standard primitive won and roughly fourteen extra method definitions were not written.
* **The batched apply is cheaper, not dearer.** One hold of 5.3 us median replaces twelve
  separate acquire/release pairs.
* **The late-port list (S-14)** was reported as unbounded growth. It is keyed by port, so it
  cannot exceed the port space - a spike, not a leak. The half that matters is staleness: after a
  run of failed socket-table walks, the first successful one could put a port back in scope whose
  socket had closed long before, and which the OS may since have handed to another process.
* **The crash-table ceiling (S-15)** was worse than "de-duplication degrades": past the ceiling it
  stopped entirely for whatever broke last. Measured, the same repeating fault: 137 us and zero
  disk writes with a slot, 1926 us and a write PER OCCURRENCE without one.
* **The atexit ordering (S-11)** was filed as inference. The half that can be measured without a
  segfault now is: `faulthandler.is_enabled()` read False at the moment the diverts were closed,
  and reads True after the fix.
* **S-18 was a question, not a defect.** `PortTable.refresh_if_stale` reads without the lock
  deliberately; the defect was that nobody had written down why. It now says why, and nothing else
  changed.
* **S-16 was measured and rejected** - the change it asked for would have cost more than it saved.

## Two guards that were wrong before they were right

Worth flagging because both looked green while proving nothing:

* A lock-hold guard asked the C `RLock` for `_count`, which only the pure-Python implementation
  has, so every reading came back False. Rewritten to `_is_owned()` - at which point it
  immediately caught this branch recompiling two port expressions inside the very lock hold the
  change exists to keep clear.
* An atomicity guard ran a reader thread flat out against 300 applies and its mutation SURVIVED:
  the window is about 5 us and the applying thread holds the GIL across it. The interleaving is
  now forced at the one instant a mixture exists.

## Not in this PR

* One remaining place writes through a temp file named after its target (the connections CSV
  export). Left alone deliberately: its destination path is fixed too, so the question there is
  whether two instances should share one output file, which is a separate decision.
* Full atomicity of process targeting. Resolving a target walks the socket table, and the capture
  thread waits for whatever the core's lock holds, so targeting is applied just after the batch
  rather than inside it. Both docstrings say so.

## What was run

The first full run of this branch found four guards red - three left by earlier commits on it and
one by its own changelog prose - and the last commit closes them. None was a flake; each
reproduces on its own. Two are worth naming because they are the kind that only a whole-tree run
finds: a module carved out of the GUI was never added to the project layout in either README, and
two of that module's old names were still being driven by a test.

The full suite locally on Windows, elevated so the two administrator-only checks actually ran
rather than skipping: `1350 passed`, no failures and no skips. Plus `ruff` and `mypy` on every
touched file, and the mutation entry for every fix.

No rigs were run, and no real capture session: everything touching the live socket table and the
driver is covered by tests and doubles rather than by a live run. That is the gap worth knowing
about when reviewing this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
