### PR TITLE
chore: codebase-health audit - unjam the ratchet axes, add the class and cycle guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ beantester/              the implementation package
   core.py                pure per-packet decision core (BeanCore)
   damage.py              how much a session damaged: drop reasons, loss/corruption shares
   engine.py              capture/inject threads, statistics (BeanEngine)
+  connlog.py             the session's connection log: one row per flow, and its cap
   matchers.py            filter expressions (list/range/!/>/</wildcard/re:) - shared
                          by the process, IP and port fields; a single source of truth
   settings.py            settings model, config file, apply_settings

--- a/beantester/cli.py
+++ b/beantester/cli.py
@@ -656,7 +656,30 @@ def _plan_the_end_of_the_scenario(log, cfg, scen, engine):
              f"is no --duration, so the session keeps going until you stop it.")
 
 
-def _run_session(args, cfg, log, sleep, clock, engine):
+def _run_session(cfg, log, sleep, clock, engine):
+    """The CLI session, in three phases: open, drive, report.
+
+    Split out of one 133-line function on 2026-09-06. The phases are not a
+    tidying: each one has a different failure contract. ``_open_session`` may
+    only fail through ``_fail`` (nothing has been touched yet, so an exit is
+    free), ``_drive_session`` must turn ANY failure into a coded exit because
+    the driver is open and the engine has to be stopped, and
+    ``_report_session`` can still turn a successful run into a failing one.
+    """
+    engine, scen = _open_session(cfg, log, engine)
+    code, stop_reason, t0 = _drive_session(engine, cfg, log, sleep, clock, scen)
+    return _report_session(engine, cfg, log, clock, code, stop_reason, t0)
+
+
+def _open_session(cfg, log, engine):
+    """Everything that can fail BEFORE a single packet is touched.
+
+    Returns ``(engine, scenario)``. The order inside is the point of the phase:
+    the admin check, the unbounded-impairment warning and the scenario file are
+    all knowable without the driver, and each of them used to be discovered
+    later - the run opened the divert, said "Start.", impaired live traffic and
+    only then reported that the scenario file was broken.
+    """
     if cfg["simulate"] and cfg["settings"].get("target"):
         log.warn("--target is ignored in --simulate mode.")
         cfg["settings"]["target"] = ""
@@ -731,6 +754,22 @@ def _run_session(args, cfg, log, sleep, clock, engine):
                      "expressed as a driver filter (a wildcard or re: pattern, or "
                      "no destination set). Capturing everything, as usual.")
 
+    return engine, scen
+
+
+def _drive_session(engine, cfg, log, sleep, clock, scen):
+    """Run the session to its end, whatever ends it.
+
+    Returns ``(code, stop_reason, t0)``. ``t0`` is started HERE rather than by
+    the caller and handed back with the result: the clock has to start after the
+    scenario has been armed and before the loop, and moving it either way
+    changes the elapsed time every summary reports.
+
+    Every exit from the loop is a CODED exit (convention 18), including the
+    unforeseen one - that is why the broad handler sits here, where the engine
+    is still alive and its counters still readable, rather than at the top of
+    ``run_cli`` where the run could only hand back a truncated NDJSON file.
+    """
     scenario_failed = None
     cfg["stop_on_scenario"] = False
     if scen is not None:
@@ -781,7 +820,16 @@ def _run_session(args, cfg, log, sleep, clock, engine):
 
     if engine.fault and code == exitcodes.OK:
         code, stop_reason = exitcodes.RUNTIME, "fault"
+    return code, stop_reason, t0
 
+
+def _report_session(engine, cfg, log, clock, code, stop_reason, t0):
+    """Turn a finished session into its artefacts, and into the exit code.
+
+    Returns the final code, which is not the one it was given: an unwritable
+    repro report and a run that captured less than ``--min-packets`` are both
+    failures discovered after the traffic stopped.
+    """
     stats = engine.stats_snapshot()
     elapsed = round(clock() - t0, 1)
     eff = engine.effective_seed()
@@ -935,7 +983,7 @@ def run_cli(argv=None, sleep=time.sleep, clock=time.monotonic, engine=None,
                      "for Administrator rights and the WinDivert driver.")
             return exitcodes.OK
 
-        return _run_session(args, cfg, log, sleep, clock, engine)
+        return _run_session(cfg, log, sleep, clock, engine)
     except CliError as e:
         log.error(f"error: {e.message}")
         return e.code

--- a/beantester/connlog.py
+++ b/beantester/connlog.py
@@ -1,0 +1,243 @@
+"""The session's connection log: one row per flow, and the eviction that caps it.
+
+Carved out of ``engine.py`` on 2026-09-06, the same way ``damage.py`` was: this is
+a store with its own state (rows, its own lock, its own sampling RNG) and its own
+cap policy, and it was reachable only as seven methods on ``BeanEngine`` - which
+had grown to 72.
+
+**Why it may live behind one more attribute lookup.** The connection log is on the
+per-packet path, so the question was asked before the move rather than after:
+MEASURED 2026-07-29, disabling the WHOLE connection log is **1.012x** end to end
+(the number and its conditions are in PROJECT_NOTES, "Gorace sciezki"). A feature
+worth 1.2% of the pipeline cannot lose anything measurable to one attribute hop,
+and the same section records that every remaining lever in this pipeline is
+<= 1.02x. What is NOT negotiable is what the lock does and does not cover, so both
+of those rules travel here in full, in the docstrings that carry their
+measurements.
+
+**Owner resolution stays on the engine.** ``process_for`` and ``pid_for`` arrive as
+callables rather than being moved in with the rows, and that is deliberate: they
+read the port table and the live socket map, both of which the engine swaps at
+start and stop. A second reference to those, kept here and updated separately,
+would be a new way for the two to disagree - and their two failure domains are
+pinned by ``tests/test_owner_attribution.py``, which reads ``engine.py``.
+"""
+import heapq
+import random
+import threading
+
+
+class ConnectionLog:
+    """Flow rows for one session: ``flowkey -> dict``.
+
+    Threading, and it is not uniform - each rule is measured where it is written:
+
+    * ``log``, ``charge``, ``snapshot`` and ``trim`` take the lock.
+    * ``credit_delivered`` deliberately does NOT - see its docstring.
+    """
+
+    # A connection row is ~350 B, so the cap IS the memory budget: 200k flows is
+    # roughly 70-100 MB, which is what a long capture on a busy machine needs if
+    # the tables are to show the session honestly instead of an arbitrary slice.
+    MAX_CONNS = 200_000
+    EVICT_KEEP = 0.9                    # trim back to this fraction of the cap
+    EVICT_SAMPLES = 2000                # stamps sampled to estimate the cutoff
+
+    def __init__(self, process_for, pid_for):
+        self.rows = {}                  # connection log: flowkey -> stats
+        self._lock = threading.Lock()
+        # Sampling RNG for trim(). Deliberately NOT the engine's seeded RNG: that
+        # one drives the packet decisions, so drawing from it here would make a
+        # session's impairments depend on how often the table happened to be
+        # trimmed - i.e. it would silently break reproducibility.
+        self._rng_evict = random.Random(0)
+        self._process_for = process_for
+        self._pid_for = pid_for
+
+    def __len__(self):
+        return len(self.rows)
+
+    def clear(self):
+        with self._lock:
+            self.rows.clear()
+
+    def snapshot(self, limit=200):
+        """Rows of the connection log.
+
+        ``limit=<int>``  the ``limit`` most recently active flows, newest first.
+                         Uses ``heapq.nlargest``: O(n log limit), not a full sort
+                         of a table that may hold 200 000 rows.
+        ``limit=None``   every flow, UNSORTED - a pointer copy, cheap (see below).
+                         This is what the virtualised tables ask for: they sort by
+                         the column the user picked anyway, so sorting here as well
+                         was the same work done twice per refresh.
+
+        The copy is taken under the lock; any sorting happens outside it. A sort
+        under the lock would stall the CAPTURE thread, and a stalled capture
+        thread means WinDivert is queueing the user's packets into a void. THAT is
+        why the sort is outside - not the cost of the copy, which is small:
+
+        Measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, synthetic rows, median of
+        7): the pointer copy is **0.7 ms at the 200k cap** and 2.4 ms at 500k, while
+        a full sort of the same 200k rows through ``views.filter_sort_connections``
+        is ~29 ms. An earlier revision of this docstring claimed ~25 ms for the copy
+        and ~100 ms for the sort; neither reproduced.
+        """
+        with self._lock:
+            values = list(self.rows.values())
+        if limit is None:
+            return values
+        return heapq.nlargest(limit, values, key=lambda c: c["last"])
+
+    def trim(self):
+        """Evict the oldest flows once the log outgrows its cap.
+
+        Runs on the WATCHDOG thread, never on the capture thread, and does the
+        expensive part without the lock. The old version sorted the whole table
+        from inside ``log()`` - i.e. on the capture thread, under the lock.
+        At the previous 2000-row cap nobody could feel it; at 200 000 it is a
+        ~300 ms freeze of the capture thread, and a frozen capture thread means
+        WinDivert is quietly queueing (and then dropping) the user's packets.
+
+        Measured at the cap: sorting = ~300 ms, a sampled cutoff = ~6 ms (no lock)
+        plus a scan-and-delete = ~16 ms (lock held). The cutoff is an estimate,
+        so the table lands near - not exactly on - ``EVICT_KEEP``; for dropping
+        stale flows that is entirely good enough.
+        """
+        with self._lock:
+            if len(self.rows) <= self.MAX_CONNS:
+                return
+            # a pointer copy, not a deep copy: cheap even at 200k
+            values = list(self.rows.values())
+        # ---- outside the lock: estimate the activity cutoff from a sample ----
+        target_drop = len(values) - int(self.MAX_CONNS * self.EVICT_KEEP)
+        if target_drop <= 0:
+            return
+        sample = [values[self._rng_evict.randrange(len(values))]["last"]
+                  for _ in range(min(self.EVICT_SAMPLES, len(values)))]
+        sample.sort()
+        index = int(len(sample) * target_drop / len(values))
+        cutoff = sample[min(index, len(sample) - 1)]
+        # ---- lock again, only for the cheap part -----------------------------
+        with self._lock:
+            doomed = [k for k, c in self.rows.items() if c["last"] <= cutoff]
+            # The cutoff is a SAMPLED estimate and the comparison is inclusive, so
+            # rows sharing one timestamp all fall on the same side of it. With
+            # enough ties that is far more than the estimate intended - and with
+            # every row on one stamp it is the WHOLE table. Measured against a
+            # 1000-row cap: 1200 rows trimmed to 0 instead of 900.
+            #
+            # Not reachable from ordinary traffic on this machine (time.monotonic()
+            # resolves to ~100 ns here, so a 1200-row burst still produced 865
+            # distinct stamps and trimmed correctly), but it costs one max() to
+            # make the estimate incapable of emptying the log, and a coarser clock
+            # is a platform property this code should not have to rely on.
+            allowed = max(0, len(self.rows) - int(self.MAX_CONNS * self.EVICT_KEEP))
+            for key in doomed[:allowed]:
+                self.rows.pop(key, None)
+
+    def log(self, key, remote_ip, remote_port, local_port, is_out, size, now,
+            proto="IP", dropped=False, scoped=False):
+        if key is None:
+            return
+        with self._lock:
+            c = self.rows.get(key)
+            if c is None:
+                # NO eviction here: trimming is the watchdog's job (trim()).
+                # Doing it on the capture thread meant a new flow could pay for a
+                # full sort of the table while holding the lock.
+                # bytes/bytes_in/bytes_out are what this flow OFFERED (captured);
+                # sent/sent_in/sent_out are what actually went back on the wire.
+                # The two used to be one set of numbers under headings the session
+                # panel used for delivered - a row could read 5 122 600 B received
+                # while the application got 409 600 B.
+                c = dict(remote_ip=remote_ip, remote_port=remote_port,
+                         local_port=local_port, proto=proto, packets=0, bytes=0,
+                         bytes_in=0, bytes_out=0, sent=0, sent_in=0, sent_out=0,
+                         dropped=0, first=now, last=now,
+                         dir="", scoped=bool(scoped),
+                         proc=self._process_for(local_port),
+                         pid=self._pid_for(local_port))
+                self.rows[key] = c
+            elif not c["proc"]:
+                # the socket may not have been in the table yet when the flow
+                # appeared - try again while packets keep coming, otherwise the
+                # row would stay a "?" forever (resolve the pid on the same retry)
+                c["proc"] = self._process_for(local_port)
+                if not c.get("pid"):
+                    c["pid"] = self._pid_for(local_port)
+            c["packets"] += 1
+            c["bytes"] += size
+            if is_out:
+                c["bytes_out"] += size
+            else:
+                c["bytes_in"] += size
+            if dropped:
+                c["dropped"] += 1
+            # scoped is STICKY: once a flow has been in impairment scope it stays
+            # marked, for the life of the session's connection log. It is the audit
+            # answer to "was this connection impaired", not "is its port in the
+            # target set right now" - those differ the instant a socket closes, and
+            # a browser closes hundreds a minute. A live check flipped every
+            # finished flow to "not impaired" the moment it closed (its ephemeral
+            # port left the socket table), so a run that impaired all of chrome read
+            # as a table full of "no". The row highlight
+            # (gui/pages/conns.py::_tag_of) reads this same stored record, so the
+            # colour and the "impaired?" column can never disagree.
+            c["scoped"] = c["scoped"] or bool(scoped)
+            c["last"] = now
+            c["dir"] = "out" if is_out else "in"
+            c["proto"] = proto
+
+    def credit_delivered(self, key, size, is_out):
+        """Credit bytes that actually went back on the wire to their flow's row.
+
+        Returns whether that row is SCOPED, so the caller can add the same bytes to
+        the session's scoped totals - the flag lives on the row, and the engine owns
+        the stats dict, so this is the seam between them. False when there was no
+        row to credit.
+
+        Called from the INJECT thread, once per delivered packet, and deliberately
+        WITHOUT the lock - the same reasoning as ``SocketWatcher.pid_for`` (see
+        convention 20): taking a maintenance lock on a per-packet path puts that
+        path in the queue behind the watchdog's trimming. Measured with the lock:
+        160.4k -> 152.0k pkt/s on the synthetic path, a 5% regression bought for
+        nothing.
+
+        Safe because ``sent``/``sent_in``/``sent_out`` have exactly ONE writer -
+        this thread. The capture thread creates the row (with these at 0) BEFORE
+        the packet is queued, and never touches them again; readers only ever read
+        them, and an int rebind is atomic, so a reader sees the old value or the
+        new one, never a torn one. Any other counter shared with the capture thread
+        still goes through ``charge()``, which does take the lock.
+
+        A row can be missing when the watchdog trimmed the flow while its packet
+        sat in the delay queue. Then there is nothing to credit, and the row is
+        gone from the table anyway.
+        """
+        if key is None:
+            return False
+        c = self.rows.get(key)
+        if c is None:
+            return False
+        c["sent"] += size
+        if is_out:
+            c["sent_out"] += size
+        else:
+            c["sent_in"] += size
+        return bool(c.get("scoped"))
+
+    def charge(self, key, field, n=1):
+        """Add to one counter on one flow's row (no row = nothing to charge).
+
+        For losses discovered AFTER the capture thread has moved on: a queue that
+        overflowed, a session that ended with packets still parked, an injection
+        that failed. Those never reached the row before, so a flow could show
+        `dropped=0` in a session that threw 5 500 of its packets away.
+        """
+        if key is None:
+            return
+        with self._lock:
+            c = self.rows.get(key)
+            if c is not None:
+                c[field] += n

--- a/beantester/damage.py
+++ b/beantester/damage.py
@@ -11,12 +11,13 @@ Nothing here imports anything: it sits at the bottom of the layering, below
 ``core`` and ``engine``, so the GUI, the repro report and the tests can all ask
 "how much damage did this session do" without dragging the engine in.
 """
+from typing import Any, Dict, Mapping, Tuple
 
 # Which counter a dropped packet lands in, by the reason BeanCore.decide() gave.
 # Module level on purpose: written as a literal inside the capture loop it was
 # rebuilt for every dropped packet, and a session set to 100% loss drops as often
 # as it sees. It is also the SINGLE SOURCE for what counts as damage below.
-DROP_BY_REASON = {"syn": "drop_syn", "mtu": "drop_mtu", "nat": "drop_nat",
+DROP_BY_REASON: Dict[str, str] = {"syn": "drop_syn", "mtu": "drop_mtu", "nat": "drop_nat",
                   "rst": "drop_rst", "lan": "drop_lan",
                   "internet_only": "drop_internet_only", "block": "drop_block",
                   "flap": "drop_flap", "rate": "drop_rate"}
@@ -30,7 +31,7 @@ DROP_BY_REASON = {"syn": "drop_syn", "mtu": "drop_mtu", "nat": "drop_nat",
 # of silent lie this project keeps removing. Guarded by
 # test_rst_local.py::test_every_forged_reset_is_counted_under_its_own_cause, which
 # lives with the rest of the reset path rather than with the counters.
-RST_BY_REASON = {"rst": "rst_reset", "block": "block_rejected"}
+RST_BY_REASON: Dict[str, str] = {"rst": "rst_reset", "block": "block_rejected"}
 
 # Damage the simulated link inflicted: every reason decide() can name, plus the
 # unnamed default (the configured Loss). Derived from the map above so that a new
@@ -38,7 +39,7 @@ RST_BY_REASON = {"rst": "rst_reset", "block": "block_rejected"}
 # "Effective loss" came to read 0.0% through a session losing 90% to a speed
 # limit. Guarded by
 # test_engine.py::test_every_drop_counter_and_drop_reason_is_classified.
-IMPAIRMENT_DROP_KEYS = (*dict.fromkeys(DROP_BY_REASON.values()), "drop_loss")
+IMPAIRMENT_DROP_KEYS: Tuple[str, ...] = (*dict.fromkeys(DROP_BY_REASON.values()), "drop_loss")
 
 # Losses the TOOL caused, not the link: its delay queue filled up, the session
 # ended with packets still parked in it, or re-injecting one failed outright.
@@ -49,10 +50,10 @@ IMPAIRMENT_DROP_KEYS = (*dict.fromkeys(DROP_BY_REASON.values()), "drop_loss")
 # and overflow additionally raises a log warning and a banner. Counting them here
 # would also let the figure exceed 100%: the delay queue holds out-of-scope
 # packets too, so with a narrow target it can drop more than were ever in scope.
-TOOL_DROP_KEYS = ("drop_overflow", "drop_shutdown", "drop_send")
+TOOL_DROP_KEYS: Tuple[str, ...] = ("drop_overflow", "drop_shutdown", "drop_send")
 
 
-def impairment_loss_pct(stats):
+def impairment_loss_pct(stats: Mapping[str, Any]) -> float:
     """Share of the traffic the tool was aiming at that the impairments killed.
 
     Numerator: every drop ``decide()`` made. Denominator: packets that passed the
@@ -76,7 +77,7 @@ def impairment_loss_pct(stats):
     return 100.0 * sum(stats.get(k, 0) for k in IMPAIRMENT_DROP_KEYS) / scoped
 
 
-def corruption_pct(stats):
+def corruption_pct(stats: Mapping[str, Any]) -> float:
     """Share of the targeted traffic whose payload was actually altered.
 
     Same denominator as ``impairment_loss_pct``, for the same reason. ``corrupted``

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -307,17 +307,35 @@ class BeanEngine:
         return max(0.0, self._deadline - (time.monotonic() if now is None else now))
 
     # -- thin delegates to the decision core -------------------------------- #
-    def set_params(self, *a):
-        self.core.set_params(*a)
+    #
+    # They are the surface the engine is DRIVEN through: `settings.apply_settings`
+    # uses all fifteen, and so do ten test modules and one CI script - 67 call
+    # sites, which is why they are a facade rather than dead weight.
+    #
+    # 🔴 Each one repeats its core signature instead of forwarding `*a`, and that
+    # is the whole point of them being written out. `*a` erases the signature, so
+    # a wrong argument count on THIS seam - the one between the decision core and
+    # the threads that feed it - could only ever fail at runtime, and mypy had
+    # nothing to check here no matter how many modules around it were annotated.
+    # `tests/test_engine.py::test_every_core_setter_has_a_forwarder_that_matches_it`
+    # keeps the two sides identical, which also closes the other half of the cost:
+    # a new impairment field needs a forwarder, and nothing used to say so until
+    # the AttributeError arrived.
+    def set_params(self, loss_pct, corrupt_pct, dup_pct,
+                   latency_ms, jitter_ms, down_kbps, up_kbps):
+        self.core.set_params(loss_pct, corrupt_pct, dup_pct,
+                             latency_ms, jitter_ms, down_kbps, up_kbps)
 
-    def set_buffer(self, *a):
-        self.core.set_buffer(*a)
+    def set_buffer(self, buffer_ms):
+        self.core.set_buffer(buffer_ms)
 
-    def set_loss_burst(self, *a):
-        self.core.set_loss_burst(*a)
+    def set_loss_burst(self, mean_packets):
+        self.core.set_loss_burst(mean_packets)
 
-    def set_asymmetry(self, *a):
-        self.core.set_asymmetry(*a)
+    def set_asymmetry(self, enabled, loss_pct, corrupt_pct, dup_pct,
+                      latency_ms, jitter_ms, spike_prob_pct, spike_ms):
+        self.core.set_asymmetry(enabled, loss_pct, corrupt_pct, dup_pct,
+                                latency_ms, jitter_ms, spike_prob_pct, spike_ms)
 
     def set_target(self, active, ports=None):
         """Point the engine at a set of local ports (or a live port container).
@@ -411,11 +429,11 @@ class BeanEngine:
         # responsibility) and start() reconciles the two either way.
         return current
 
-    def set_flap(self, *a):
-        self.core.set_flap(*a)
+    def set_flap(self, enabled, period_s, down_pct):
+        self.core.set_flap(enabled, period_s, down_pct)
 
-    def set_dest(self, *a):
-        self.core.set_dest(*a)
+    def set_dest(self, active, ip=None, port=None):
+        self.core.set_dest(active, ip=ip, port=port)
 
     def targeting_active(self):
         """True when process or destination targeting is narrowing traffic."""
@@ -433,35 +451,35 @@ class BeanEngine:
         """
         return self.core.process_target_active()
 
-    def set_ip_family(self, *a, **kw):
-        self.core.set_ip_family(*a, **kw)
+    def set_ip_family(self, ipv4_only=False, ipv6_only=False):
+        self.core.set_ip_family(ipv4_only=ipv4_only, ipv6_only=ipv6_only)
 
-    def set_lan(self, *a):
-        self.core.set_lan(*a)
+    def set_lan(self, enabled):
+        self.core.set_lan(enabled)
 
-    def set_internet_only(self, *a):
-        self.core.set_internet_only(*a)
+    def set_internet_only(self, enabled):
+        self.core.set_internet_only(enabled)
 
-    def set_block(self, *a):
-        self.core.set_block(*a)
+    def set_block(self, active, ip=None, port=None, reject=False):
+        self.core.set_block(active, ip=ip, port=port, reject=reject)
 
-    def set_advanced(self, *a):
-        self.core.set_advanced(*a)
+    def set_advanced(self, syn_drop_pct, max_size):
+        self.core.set_advanced(syn_drop_pct, max_size)
 
-    def set_spike(self, *a):
-        self.core.set_spike(*a)
+    def set_spike(self, prob_pct, spike_ms):
+        self.core.set_spike(prob_pct, spike_ms)
 
-    def set_nat(self, *a):
-        self.core.set_nat(*a)
+    def set_nat(self, timeout_s):
+        self.core.set_nat(timeout_s)
 
-    def set_rst(self, *a):
-        self.core.set_rst(*a)
+    def set_rst(self, prob_pct, cooldown_s):
+        self.core.set_rst(prob_pct, cooldown_s)
 
-    def set_schedule(self, *a):
-        self.core.set_schedule(*a)
+    def set_schedule(self, steps_kbps):
+        self.core.set_schedule(steps_kbps)
 
-    def reset_now(self, *a):
-        self.core.reset_now(*a)
+    def reset_now(self, duration_s=2.0, now=None):
+        self.core.reset_now(duration_s, now=now)
         self.log_event("RESET", "events.manual_reset")
 
     # -- scenario ------------------------------------------------------------ #

--- a/beantester/engine.py
+++ b/beantester/engine.py
@@ -98,6 +98,7 @@ import weakref
 from . import filters
 from . import portmap
 from . import winenv
+from .connlog import ConnectionLog
 from .core import BeanCore
 from .damage import DROP_BY_REASON, RST_BY_REASON
 from .i18n import T
@@ -138,13 +139,12 @@ class BeanEngine:
         self._cv = threading.Condition()
         self.max_queue = 20000
         self._slock = threading.Lock()
-        self._conns = {}            # connection log: flowkey -> stats
-        self._clock = threading.Lock()
-        # Sampling RNG for _trim_conns. Deliberately NOT self._rng: that one is
-        # seeded and drives the packet decisions, so drawing from it here would
-        # make a session's impairments depend on how often the table happened to
-        # be trimmed - i.e. it would silently break reproducibility.
-        self._rng_evict = random.Random(0)
+        # The session's flow rows, their lock and their cap policy (connlog.py).
+        # The two resolvers are passed as bound methods rather than moved in with
+        # the rows: they read _ports and _socketwatch, which this class swaps at
+        # start and stop, so a second reference kept over there would be a new way
+        # for the two to disagree.
+        self._conns_log = ConnectionLog(self._process_for, self._pid_for)
         self._overflow_warned = 0.0     # rate-limit for the queue-overflow warning
         self._send_warned = 0.0         # rate-limit for the failed-injection warning
         self._rst_warned = 0.0          # rate-limit for the failed-reset warning
@@ -595,212 +595,35 @@ class BeanEngine:
         self._rst_warned = 0.0
         self._driver_wait_warned = 0.0
         self._wait_sample_at = 0.0
-        with self._clock:
-            self._conns.clear()
+        self._conns_log.clear()
 
     def connections_snapshot(self, limit=200):
-        """Rows of the connection log.
+        """Rows of the connection log - see ``connlog.ConnectionLog.snapshot``.
 
-        ``limit=<int>``  the ``limit`` most recently active flows, newest first.
-                         Uses ``heapq.nlargest``: O(n log limit), not a full sort
-                         of a table that may hold 200 000 rows.
-        ``limit=None``   every flow, UNSORTED - a pointer copy, cheap (see below).
-                         This is what the virtualised tables ask for: they sort by
-                         the column the user picked anyway, so sorting here as well
-                         was the same work done twice per refresh.
-
-        The copy is taken under the lock; any sorting happens outside it. A sort
-        under ``_clock`` would stall the CAPTURE thread, and a stalled capture
-        thread means WinDivert is queueing the user's packets into a void. THAT is
-        why the sort is outside - not the cost of the copy, which is small:
-
-        Measured 2026-07-21 (Win11 AMD64, CPython 3.14.6, synthetic rows, median of
-        7): the pointer copy is **0.7 ms at the 200k cap** and 2.4 ms at 500k, while
-        a full sort of the same 200k rows through ``views.filter_sort_connections``
-        is ~29 ms. An earlier revision of this docstring claimed ~25 ms for the copy
-        and ~100 ms for the sort; neither reproduced.
+        Kept on the engine because it is the PUBLIC surface: `cli`, `gui`, the CSV
+        export and the repro report all ask the engine for its connections.
         """
-        with self._clock:
-            values = list(self._conns.values())
-        if limit is None:
-            return values
-        return heapq.nlargest(limit, values, key=lambda c: c["last"])
-
-    # A connection row is ~350 B, so the cap IS the memory budget: 200k flows is
-    # roughly 70-100 MB, which is what a long capture on a busy machine needs if
-    # the tables are to show the session honestly instead of an arbitrary slice.
-    MAX_CONNS = 200_000
-    EVICT_KEEP = 0.9                    # trim back to this fraction of the cap
-    EVICT_SAMPLES = 2000                # stamps sampled to estimate the cutoff
-
-    def _trim_conns(self):
-        """Evict the oldest flows once the log outgrows its cap.
-
-        Runs on the WATCHDOG thread, never on the capture thread, and does the
-        expensive part without the lock. The old version sorted the whole table
-        from inside ``_log_conn`` - i.e. on the capture thread, under ``_clock``.
-        At the previous 2000-row cap nobody could feel it; at 200 000 it is a
-        ~300 ms freeze of the capture thread, and a frozen capture thread means
-        WinDivert is quietly queueing (and then dropping) the user's packets.
-
-        Measured at the cap: sorting = ~300 ms, a sampled cutoff = ~6 ms (no lock)
-        plus a scan-and-delete = ~16 ms (lock held). The cutoff is an estimate,
-        so the table lands near - not exactly on - ``EVICT_KEEP``; for dropping
-        stale flows that is entirely good enough.
-        """
-        with self._clock:
-            if len(self._conns) <= self.MAX_CONNS:
-                return
-            # a pointer copy, not a deep copy: cheap even at 200k
-            values = list(self._conns.values())
-        # ---- outside the lock: estimate the activity cutoff from a sample ----
-        target_drop = len(values) - int(self.MAX_CONNS * self.EVICT_KEEP)
-        if target_drop <= 0:
-            return
-        sample = [values[self._rng_evict.randrange(len(values))]["last"]
-                  for _ in range(min(self.EVICT_SAMPLES, len(values)))]
-        sample.sort()
-        index = int(len(sample) * target_drop / len(values))
-        cutoff = sample[min(index, len(sample) - 1)]
-        # ---- lock again, only for the cheap part -----------------------------
-        with self._clock:
-            doomed = [k for k, c in self._conns.items() if c["last"] <= cutoff]
-            # The cutoff is a SAMPLED estimate and the comparison is inclusive, so
-            # rows sharing one timestamp all fall on the same side of it. With
-            # enough ties that is far more than the estimate intended - and with
-            # every row on one stamp it is the WHOLE table. Measured against a
-            # 1000-row cap: 1200 rows trimmed to 0 instead of 900.
-            #
-            # Not reachable from ordinary traffic on this machine (time.monotonic()
-            # resolves to ~100 ns here, so a 1200-row burst still produced 865
-            # distinct stamps and trimmed correctly), but it costs one max() to
-            # make the estimate incapable of emptying the log, and a coarser clock
-            # is a platform property this code should not have to rely on.
-            allowed = max(0, len(self._conns) - int(self.MAX_CONNS * self.EVICT_KEEP))
-            for key in doomed[:allowed]:
-                self._conns.pop(key, None)
-
-    # kept under its old name: the capture path no longer evicts, but callers
-    # (and tests) that ask for a trim explicitly still get one
-    _evict_conns = _trim_conns
-
-    def _log_conn(self, key, remote_ip, remote_port, local_port, is_out, size, now,
-                  proto="IP", dropped=False, scoped=False):
-        if key is None:
-            return
-        with self._clock:
-            c = self._conns.get(key)
-            if c is None:
-                # NO eviction here: trimming is the watchdog's job (_trim_conns).
-                # Doing it on the capture thread meant a new flow could pay for a
-                # full sort of the table while holding the lock.
-                # bytes/bytes_in/bytes_out are what this flow OFFERED (captured);
-                # sent/sent_in/sent_out are what actually went back on the wire.
-                # The two used to be one set of numbers under headings the session
-                # panel used for delivered - a row could read 5 122 600 B received
-                # while the application got 409 600 B.
-                c = dict(remote_ip=remote_ip, remote_port=remote_port,
-                         local_port=local_port, proto=proto, packets=0, bytes=0,
-                         bytes_in=0, bytes_out=0, sent=0, sent_in=0, sent_out=0,
-                         dropped=0, first=now, last=now,
-                         dir="", scoped=bool(scoped),
-                         proc=self._process_for(local_port),
-                         pid=self._pid_for(local_port))
-                self._conns[key] = c
-            elif not c["proc"]:
-                # the socket may not have been in the table yet when the flow
-                # appeared - try again while packets keep coming, otherwise the
-                # row would stay a "?" forever (resolve the pid on the same retry)
-                c["proc"] = self._process_for(local_port)
-                if not c.get("pid"):
-                    c["pid"] = self._pid_for(local_port)
-            c["packets"] += 1
-            c["bytes"] += size
-            if is_out:
-                c["bytes_out"] += size
-            else:
-                c["bytes_in"] += size
-            if dropped:
-                c["dropped"] += 1
-            # scoped is STICKY: once a flow has been in impairment scope it stays
-            # marked, for the life of the session's connection log. It is the audit
-            # answer to "was this connection impaired", not "is its port in the
-            # target set right now" - those differ the instant a socket closes, and
-            # a browser closes hundreds a minute. A live check flipped every
-            # finished flow to "not impaired" the moment it closed (its ephemeral
-            # port left the socket table), so a run that impaired all of chrome read
-            # as a table full of "no". The row highlight
-            # (gui/pages/conns.py::_tag_of) reads this same stored record, so the
-            # colour and the "impaired?" column can never disagree.
-            c["scoped"] = c["scoped"] or bool(scoped)
-            c["last"] = now
-            c["dir"] = "out" if is_out else "in"
-            c["proto"] = proto
+        return self._conns_log.snapshot(limit)
 
     def _log_delivered(self, key, size, is_out):
-        """Credit bytes that actually went back on the wire to their flow's row.
+        """Credit delivered bytes to their flow's row, and to the scoped totals.
 
-        Called from the INJECT thread, once per delivered packet, and deliberately
-        WITHOUT ``_clock`` - the same reasoning as ``SocketWatcher.pid_for`` (see
-        convention 20): taking a maintenance lock on a per-packet path puts that
-        path in the queue behind the watchdog's trimming. Measured with the lock:
-        160.4k -> 152.0k pkt/s on the synthetic path, a 5% regression bought for
-        nothing.
-
-        Safe because ``sent``/``sent_in``/``sent_out`` have exactly ONE writer -
-        this thread. The capture thread creates the row (with these at 0) BEFORE
-        the packet is queued, and never touches them again; readers only ever read
-        them, and an int rebind is atomic, so a reader sees the old value or the
-        new one, never a torn one. Any other counter shared with the capture thread
-        still goes through ``_charge_flow``, which does take the lock.
-
-        A row can be missing when the watchdog trimmed the flow while its packet
-        sat in the delay queue. Then there is nothing to credit, and the row is
-        gone from the table anyway.
+        The row half lives in ``connlog`` and takes no lock (its docstring carries
+        the measurement); the session totals live here, because the stats dict is
+        this class's. Written WITHOUT ``_slock`` for the same reason and the same
+        trade: this thread is the only writer (``reset_stats`` zeroes them before
+        any worker exists), readers only read, and an int rebind is atomic - a
+        reader sees the old value or the new one, never a torn one. Taking _slock
+        here would put the per-packet inject path in the queue behind stats
+        readers, which is the 5% regression measured for the sibling counters.
         """
-        if key is None:
+        if not self._conns_log.credit_delivered(key, size, is_out):
             return
-        c = self._conns.get(key)
-        if c is None:
-            return
-        c["sent"] += size
+        st = self.st
         if is_out:
-            c["sent_out"] += size
+            st["bytes_out_scoped"] = st["bytes_out_scoped"] + size
         else:
-            c["sent_in"] += size
-        # Session totals for the SCOPED half, from the row's own sticky flag. The
-        # flag is right here, which is why this needs no wider change: the capture
-        # thread sets it before the packet is queued, so by the time the injector
-        # reaches this line the answer is already on the row.
-        #
-        # Written WITHOUT the stats lock, and that is the same trade the docstring
-        # above justifies for sent/sent_in/sent_out: this thread is the only writer
-        # (reset_stats zeroes them before any worker exists), readers only read, and
-        # an int rebind is atomic - a reader sees the old value or the new one, never
-        # a torn one. Taking _slock here would put the per-packet inject path in the
-        # queue behind stats readers, which is the 5% regression measured for the
-        # sibling counters.
-        if c.get("scoped"):
-            st = self.st
-            if is_out:
-                st["bytes_out_scoped"] = st["bytes_out_scoped"] + size
-            else:
-                st["bytes_in_scoped"] = st["bytes_in_scoped"] + size
-
-    def _charge_flow(self, key, field, n=1):
-        """Add to one counter on one flow's row (no row = nothing to charge).
-
-        For losses discovered AFTER the capture thread has moved on: a queue that
-        overflowed, a session that ended with packets still parked, an injection
-        that failed. Those never reached the row before, so a flow could show
-        `dropped=0` in a session that threw 5 500 of its packets away.
-        """
-        if key is None:
-            return
-        with self._clock:
-            c = self._conns.get(key)
-            if c is not None:
-                c[field] += n
+            st["bytes_in_scoped"] = st["bytes_in_scoped"] + size
 
     def _process_for(self, local_port):
         """Process name owning ``local_port`` right now ("" when unknown).
@@ -1360,7 +1183,7 @@ class BeanEngine:
         # packets still queued. Outside the _cv block and off the capture thread:
         # this runs once, at STOP, on whichever thread called it.
         for key in stranded:
-            self._charge_flow(key, "dropped")
+            self._conns_log.charge(key, "dropped")
         if discarded:
             # Packets still queued for delayed injection when the session ended:
             # counted at capture (seen / bytes_*_total) but never delivered. Record
@@ -1487,7 +1310,7 @@ class BeanEngine:
             except Exception as _exc:
                 crashlog.note(_exc, "engine.ports")
             try:
-                self._trim_conns()
+                self._conns_log.trim()
                 # Same principle: freeing a retired 200k flow generation costs
                 # ~7-22 ms (measured). The capture thread must not spend that in a
                 # tool whose job is to inject a PRECISE amount of latency, so the
@@ -1676,8 +1499,9 @@ class BeanEngine:
                     self._bump(RST_BY_REASON.get(dec.reason, "rst_reset"))
                     self._send_rst(packet)
                 self._bump(DROP_BY_REASON.get(dec.reason, "drop_loss"))
-                self._log_conn(key, remote_ip, remote_port, local_port, is_out, size,
-                               now, proto, dropped=True, scoped=dec.scoped)
+                self._conns_log.log(key, remote_ip, remote_port, local_port,
+                                    is_out, size, now, proto, dropped=True,
+                                    scoped=dec.scoped)
                 continue
             # Whether this packet's BYTES were changed decides whether the
             # injector has to recompute its checksums - see _enqueue. Corruption
@@ -1698,8 +1522,8 @@ class BeanEngine:
             # has nowhere to credit it if the row does not exist yet. (It usually
             # loses that race - it has to wake on _cv first - which is exactly the
             # kind of "usually" that becomes a flake later.)
-            self._log_conn(key, remote_ip, remote_port, local_port, is_out, size,
-                           now, proto, scoped=dec.scoped)
+            self._conns_log.log(key, remote_ip, remote_port, local_port, is_out,
+                                size, now, proto, scoped=dec.scoped)
             rels = dec.releases
             queued = self._enqueue(rels[0], packet, key=key, modified=modified)
             if len(rels) > 1:
@@ -1723,7 +1547,7 @@ class BeanEngine:
                 # Measured drop_overflow=5500 against `dropped=0` in the row it
                 # happened to. Charged here instead, off the common path - a queue
                 # that is not full costs nothing for this.
-                self._charge_flow(key, "dropped")
+                self._conns_log.charge(key, "dropped")
 
     def _send_rst(self, packet):
         """Inject a TCP RST to the local end to reset the connection."""
@@ -2066,7 +1890,7 @@ class BeanEngine:
                     # was one packet wide already, and batching would have made it
                     # a whole batch wide.
                     self._bump("drop_shutdown")
-                    self._charge_flow(key, "dropped")
+                    self._conns_log.charge(key, "dropped")
                 else:
                     # Recompute the checksums only when this tool actually edited
                     # the bytes. An untouched packet goes back exactly as it
@@ -2107,6 +1931,6 @@ class BeanEngine:
                 # these numbers honest. Every other way a packet can die has a
                 # counter; this one only had a log line.
                 self._bump("drop_send")
-                self._charge_flow(key, "dropped")
+                self._conns_log.charge(key, "dropped")
                 if self._running:
                     self._warn_send_failed(e)

--- a/beantester/filters.py
+++ b/beantester/filters.py
@@ -15,11 +15,12 @@ Two rules this file exists to enforce:
   deciding about ports, with different semantics). Ports belong to the port
   field, which understands lists, ranges and exclusions anyway.
 """
+from typing import Any, Dict, List, Optional, Tuple
 
 _ALL_IP = "(ip or ipv6)"
 _ALL_PROTO = "(tcp or udp or icmp or icmpv6)"
 
-FILTER_DEFS = [
+FILTER_DEFS: List[Tuple[str, str, str]] = [
     ("both", "filters.both", f"{_ALL_IP} and {_ALL_PROTO}"),
     ("out",  "filters.out",  f"outbound and {_ALL_IP} and {_ALL_PROTO}"),
     ("in",   "filters.in",   f"inbound and {_ALL_IP} and {_ALL_PROTO}"),
@@ -29,42 +30,44 @@ FILTER_DEFS = [
     ("loopback", "filters.loopback", f"loopback and {_ALL_IP} and {_ALL_PROTO}"),
 ]
 
-FILTERS = {name: wd for _, name, wd in FILTER_DEFS}
-CLI_FILTERS = {key: wd for key, _, wd in FILTER_DEFS}
+FILTERS: Dict[str, str] = {name: wd for _, name, wd in FILTER_DEFS}
+CLI_FILTERS: Dict[str, str] = {key: wd for key, _, wd in FILTER_DEFS}
 
 # Explicit lookups instead of the old index gymnastics
 # (``list(CLI_FILTERS)[list(FILTERS).index(name)]``), which silently depended on
 # both dicts keeping the same insertion order.
-_BY_CLI = {key: (key, name, wd) for key, name, wd in FILTER_DEFS}
-_BY_I18N = {name: (key, name, wd) for key, name, wd in FILTER_DEFS}
-DEFAULT_FILTER = FILTER_DEFS[0][0]
+_BY_CLI: Dict[str, Tuple[str, str, str]] = {
+    key: (key, name, wd) for key, name, wd in FILTER_DEFS}
+_BY_I18N: Dict[str, Tuple[str, str, str]] = {
+    name: (key, name, wd) for key, name, wd in FILTER_DEFS}
+DEFAULT_FILTER: str = FILTER_DEFS[0][0]
 
 
-def cli_key_for(i18n_key, default=DEFAULT_FILTER):
+def cli_key_for(i18n_key: str, default: str = DEFAULT_FILTER) -> str:
     """i18n filter key -> CLI key (``filters.both`` -> ``both``)."""
     entry = _BY_I18N.get(i18n_key)
     return entry[0] if entry else default
 
 
-def i18n_key_for(cli_key, default=FILTER_DEFS[0][1]):
+def i18n_key_for(cli_key: str, default: str = FILTER_DEFS[0][1]) -> str:
     """CLI filter key -> i18n key (``both`` -> ``filters.both``)."""
     entry = _BY_CLI.get(cli_key)
     return entry[1] if entry else default
 
 
-def windivert_for(cli_key):
+def windivert_for(cli_key: str) -> str:
     """CLI filter key -> WinDivert filter expression."""
     entry = _BY_CLI.get(cli_key)
     return entry[2] if entry else CLI_FILTERS[DEFAULT_FILTER]
 
 
-def i18n_keys():
+def i18n_keys() -> List[str]:
     """Filter i18n keys in canonical order (drives the GUI combobox)."""
     return [name for _, name, _ in FILTER_DEFS]
 
 
 # -- narrowing the handle's filter to what could possibly be impaired ------------ #
-def filter_compiles(text):
+def filter_compiles(text: str) -> bool:
     """Would WinDivert accept this filter? ``False`` when it cannot be asked.
 
     ``WinDivertHelperCompileFilter`` is a DLL helper - no handle, no admin - so
@@ -91,7 +94,8 @@ def filter_compiles(text):
         return False
 
 
-def narrowed_filter(base, dst_ip_matcher=None, dst_port_matcher=None):
+def narrowed_filter(base: str, dst_ip_matcher: Optional[Any] = None,
+                    dst_port_matcher: Optional[Any] = None) -> Tuple[str, bool]:
     """``base`` AND the destination expressions, when that can be PROVEN safe.
 
     Returns ``(filter_text, narrowed)``. ``narrowed`` is False whenever anything

--- a/beantester/gui/labels.py
+++ b/beantester/gui/labels.py
@@ -11,6 +11,8 @@ exactly what happened to the "these are all captured connections" note.
 from tkinter import ttk
 
 from .scaling import scaled
+from .tooltip import retip
+from ..i18n import T
 from .. import crashlog
 
 
@@ -51,3 +53,32 @@ def wrapping_label(parent, text="", style="Muted.TLabel", pad=16, **kw):
                       anchor="w", wraplength=scaled(600), **kw)
     bind_wraplength(label, parent, pad)
     return label
+
+
+def sync_note(owner, notes, tips, state, subsystem, attr="_scope_note"):
+    """Re-word a note built by ``wrapping_label`` - and its bubble - on a new state.
+
+    Both scope notes on the Statistics and Connections pages were this, written
+    twice: the same nine lines, differing only in which i18n maps they read and
+    which subsystem they record under. Structurally identical code in two files is
+    code that gets FIXED in one of them, and this pair has the scar - the tooltip
+    used to be bound once and never touched again, so re-wording the note left the
+    bubble underneath still explaining the other state, and that was repaired on
+    each page separately.
+
+    The state comparison is what makes it cheap enough to call from a refresh that
+    runs several times a second: a state that has not moved does no widget work at
+    all. ``crashlog.quiet`` rather than a bare guard because the note may already
+    be destroyed - a language switch rebuilds the page under a refresh that is
+    already in flight, which is the ordinary case here and not an edge one.
+    """
+    note = getattr(owner, attr, None)
+    if note is None:
+        return
+    seen = attr + "_state"
+    if state == getattr(owner, seen, None):
+        return
+    setattr(owner, seen, state)
+    with crashlog.quiet(subsystem):
+        note.config(text=T(notes[state]))
+        retip(note, tips[state])

--- a/beantester/gui/pages/conns.py
+++ b/beantester/gui/pages/conns.py
@@ -33,11 +33,11 @@ from ...views import (avg_packet_bytes, connection_proc, filter_connections,
                       sort_connections, sum_traffic)
 from .. import dialogs
 from ..model_worker import AsyncModel
-from ..labels import wrapping_label
+from ..labels import sync_note, wrapping_label
 from ..scaling import scaled
 from .. import scope
 from ..theme import CONN_COLORS, style_menu
-from ..tooltip import add_tooltip, retip
+from ..tooltip import add_tooltip
 from ..widgets import SortableTree
 from ... import crashlog
 
@@ -547,16 +547,8 @@ class ConnsPage:
         capture verdict lands when a session starts. A note describing the other
         state is the misleading sentence it exists to prevent.
         """
-        note = getattr(self, "_scope_note", None)
-        if note is None:
-            return
-        state = self.app.coverage().state
-        if state == getattr(self, "_scope_note_state", None):
-            return
-        self._scope_note_state = state
-        with crashlog.quiet("gui.pages.conns"):
-            note.config(text=T(SCOPE_NOTES[state]))
-            retip(note, SCOPE_TIPS[state])
+        sync_note(self, SCOPE_NOTES, SCOPE_TIPS, self.app.coverage().state,
+                  "gui.pages.conns")
 
     def refresh(self, force=False):
         """Repaint always (cheap); rebuild off-thread (never blocks the UI).

--- a/beantester/gui/pages/stats.py
+++ b/beantester/gui/pages/stats.py
@@ -17,13 +17,13 @@ from ...damage import impairment_loss_pct
 from ...i18n import T, event_kind_label
 from ...views import sort_events
 from ..chart import draw_throughput_chart
-from ..labels import wrapping_label
+from ..labels import sync_note, wrapping_label
 from ..rates import average_kbps, format_rate, rate_with_unit, RATE_FIELD_KEYS, UNIT_LABEL
 from ..scaling import scaled
 from ..scrollable import ScrollableFrame
 from .. import scope
 from ..theme import BG2, DOWN_C, EVENT_COLORS, UP_C, style_menu
-from ..tooltip import add_tooltip, retip
+from ..tooltip import add_tooltip
 from ..widgets import SortableTree
 from ... import crashlog
 
@@ -486,18 +486,11 @@ class StatsPage:
         The tooltip moves with it. It used to be bound once and never touched
         again, so toggling the preference re-worded the note and left the bubble
         underneath still explaining the other state - the same contradiction one
-        hover deeper.
+        hover deeper. That repair was made on this page and on the Connections
+        page separately, which is why the mechanism now lives in one place.
         """
-        note = getattr(self, "_scope_note", None)
-        if note is None:
-            return
-        state = self.app.coverage().state
-        if state == getattr(self, "_scope_note_state", None):
-            return
-        self._scope_note_state = state
-        with crashlog.quiet("gui.pages.stats"):
-            note.config(text=T(SCOPE_NOTES[state]))
-            retip(note, SCOPE_TIPS[state])
+        sync_note(self, SCOPE_NOTES, SCOPE_TIPS, self.app.coverage().state,
+                  "gui.pages.stats")
 
     def _sync_rate_captions(self, unit):
         """Rewrite the "(KB/s)" in the throughput captions when the unit changes.

--- a/beantester/gui/widgets/sortable_tree.py
+++ b/beantester/gui/widgets/sortable_tree.py
@@ -52,6 +52,7 @@ Kept from the original:
 import sys
 from tkinter import ttk
 
+from ...i18n import T
 from ..scaling import column_width, scaled
 from ..tooltip import make_bubble
 from ..wheel import wheel_units
@@ -420,7 +421,6 @@ class SortableTree:
         note = getattr(self, "_empty_note", None)
         if note is None:
             return
-        from ...i18n import T
         try:
             if empty and self._empty_text:
                 note.config(text=T(self._empty_text))
@@ -621,7 +621,6 @@ class SortableTree:
             self._tip_job = None
 
     def _show_tip(self, column, x_root, y_root):
-        from ...i18n import T
         self._tip_job = None
         if column != self._tip_column:
             return
@@ -746,7 +745,6 @@ class SortableTree:
     # -- copying --------------------------------------------------------------- #
     def copy_text(self, header=False):
         """The selected rows as tab-separated text (what Ctrl+C puts on the clipboard)."""
-        from ...i18n import T
         rows = self.selected_rows()
         if not rows:
             return ""
@@ -769,11 +767,9 @@ class SortableTree:
 
     # -- headers --------------------------------------------------------------- #
     def _width_for(self, col, key):
-        from ...i18n import T
         return column_width(T(key) + "  " + DESC, self._min_chars.get(col, 6))
 
     def refresh_headers(self):
-        from ...i18n import T
         for col, key in self.columns.items():
             arrow = ""
             if col == self.sort["col"]:

--- a/beantester/jsonfile.py
+++ b/beantester/jsonfile.py
@@ -21,6 +21,7 @@ silently:
 import json
 import os
 import time
+from typing import Any, Optional, Tuple, Union
 from . import crashlog
 from .paths import temp_beside
 
@@ -32,10 +33,10 @@ from .paths import temp_beside
 # 300 KB. Four megabytes is roughly seventy-five times the largest real file and
 # thirteen times that worst case, which is the point: the limit must never be the
 # thing a user meets, only the thing a hostile file meets.
-MAX_BYTES = 4 * 1024 * 1024
+MAX_BYTES: int = 4 * 1024 * 1024
 
 
-def _reject_constant(name):
+def _reject_constant(name: str) -> Any:
     """``json`` calls this for ``NaN`` / ``Infinity`` / ``-Infinity``.
 
     Those three are not JSON - the format has no way to write them, and Python's
@@ -47,7 +48,7 @@ def _reject_constant(name):
     raise ValueError(f"{name} is not a value a JSON file may carry")
 
 
-def load_json(path):
+def load_json(path: str) -> Any:
     """Parse a JSON file. ``ValueError`` for the CONTENT, ``OSError`` for the FILE.
 
     The one place every reader goes through, because before this there were four
@@ -87,7 +88,7 @@ def load_json(path):
             raise ValueError("not enough memory to read this file") from exc
 
 
-def quarantine(path):
+def quarantine(path: str) -> Optional[str]:
     """Move a broken file aside. Returns the backup path, or None."""
     try:
         # isfile, not exists: a DIRECTORY carrying one of these names is what a
@@ -104,7 +105,9 @@ def quarantine(path):
         return None
 
 
-def read_json(path, expect=dict):
+def read_json(path: str,
+              expect: Optional[Union[type, Tuple[type, ...]]] = dict
+              ) -> Tuple[Any, Optional[str]]:
     """Read a JSON file.
 
     Returns ``(data, error)``:
@@ -131,7 +134,7 @@ def read_json(path, expect=dict):
     return data, None
 
 
-def write_json(path, data, indent=2):
+def write_json(path: str, data: Any, indent: int = 2) -> Optional[str]:
     """Atomically write JSON. Returns an error message, or None on success.
 
     ``allow_nan=False`` so the WRITER refuses exactly what the READER refuses. The

--- a/beantester/portmap.py
+++ b/beantester/portmap.py
@@ -230,8 +230,8 @@ def _psutil_port_pid_map(owners=None):
     """Same shape - and the same collapse - as the native path. See port_pid_map."""
     try:
         import psutil
-    except Exception:
-        return None
+    except ImportError:
+        return None          # a supported state, not a fault: nothing to record
     try:
         out = {}
         for conn in psutil.net_connections(kind="inet"):
@@ -242,7 +242,13 @@ def _psutil_port_pid_map(owners=None):
             if port:
                 _put(out, owners, int(port), int(pid))
         return out
-    except Exception:
+    except Exception as _exc:
+        # The LAST resort for the whole port map. Silence here is
+        # indistinguishable from a machine with no sockets open, and what reads
+        # it is the targeting gate - so a failure looked exactly like "the
+        # process you targeted owns nothing". note(), not once(): this is the
+        # refresh path, not the packet path (convention 30).
+        crashlog.note(_exc, "portmap.psutil.ports")
         return None
 
 
@@ -250,8 +256,8 @@ def _psutil_process_table():
     """``{pid: (name, ppid, created)}`` for every process (the slow, portable path)."""
     try:
         import psutil
-    except Exception:
-        return {}
+    except ImportError:
+        return {}            # a supported state, not a fault: nothing to record
     try:
         table = {}
         for proc in psutil.process_iter(["pid", "name", "ppid", "create_time"]):
@@ -262,7 +268,11 @@ def _psutil_process_table():
             table[int(pid)] = (str(info.get("name") or ""), info.get("ppid"),
                                info.get("create_time"))
         return table
-    except Exception:
+    except Exception as _exc:
+        # The whole process table, so silence turns every row's process into "?"
+        # - the symptom this module exists to prevent, reported as if no name
+        # could be resolved rather than as a failure to resolve them.
+        crashlog.note(_exc, "portmap.psutil.processes")
         return {}
 
 
@@ -322,7 +332,11 @@ def _toolhelp_process_table():
             return out or None
         finally:
             k32.CloseHandle(snap)
-    except Exception:
+    except Exception as _exc:
+        # Same shape as the psutil table below it, one layer down: the native
+        # snapshot failing wholesale is a fact worth having when the names are
+        # missing.
+        crashlog.note(_exc, "portmap.toolhelp")
         return None
 
 
@@ -445,7 +459,11 @@ def _native_info_api():
                 wintypes.ULONG, ctypes.POINTER(wintypes.ULONG)]
             _NATIVE_INFO_API[0] = (ctypes, wintypes, k32, ntdll,
                                    PROCESS_BASIC_INFORMATION)
-        except Exception:
+        except Exception as _exc:
+            # This disables the fast per-PID route for the whole session, and it
+            # runs once, so the record costs nothing and explains why every later
+            # lookup took the slow path.
+            crashlog.note(_exc, "portmap.native_info_api")
             _NATIVE_INFO_API[0] = False
     return _NATIVE_INFO_API[0] or None
 
@@ -657,7 +675,12 @@ class PortTable:
         if native is not None:
             try:
                 ports = native.port_pid_map(owners)
-            except Exception:                        # pragma: no cover
+            except Exception as _exc:                # pragma: no cover
+                # `native_broke` below retires the native path for the rest of
+                # the session. That is the right behaviour and it used to happen
+                # without a word: the session silently changed how it resolves
+                # every port and nothing said why.
+                crashlog.note(_exc, "portmap.native.port_pid_map")
                 ports = None
             if ports is None:
                 native_broke = True                  # it stopped answering

--- a/beantester/repro.py
+++ b/beantester/repro.py
@@ -1,12 +1,15 @@
 """Bug reproduction: CLI command builder and the full repro report (JSON)."""
 import json
+import os
 import time
 
 from .appinfo import TOOL_ID, command_name
 from .damage import corruption_pct, impairment_loss_pct
 from .i18n import translate
+from .paths import temp_beside
 from .settings import DEFAULT_SETTINGS, setting_expression
 from .utils import bytes_to_mb, number_string, to_number
+from . import crashlog
 
 
 def settings_to_cli(settings, seed=None, simulate=False):
@@ -163,7 +166,35 @@ def build_repro_report(engine, settings):
 
 
 def save_repro_report(path, engine, settings):
+    """Write the report atomically. RAISES on failure - both callers rely on that.
+
+    Deliberately not ``jsonfile.write_json``, which is the same write and would be
+    the obvious reuse: it RETURNS an error string instead of raising, and both
+    callers here catch. The CLI would then log "Repro report saved", set
+    ``report_path`` and exit 0 over a file that was never written, which is a
+    worse outcome than the duplication.
+
+    Atomic for the reason in ``paths.temp_beside``: a temp name derived from the
+    target is a name a second writer of that target picks too. Here the target is
+    chosen by the user rather than fixed, so the collision is rarer than the one
+    that motivated ``temp_beside`` - but a crash halfway through no longer leaves
+    a truncated report sitting where a whole one is expected, which is the half
+    that matters for an artefact people attach to bug reports.
+    """
     rep = build_repro_report(engine, settings)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(rep, f, indent=2, ensure_ascii=False)
+    tmp = temp_beside(path)
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(rep, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        # Leave no half-written file behind, then let the caller see the failure.
+        # BaseException, not Exception: an interrupt here is exactly when the
+        # litter would be left, and the cleanup must not depend on how we left.
+        with crashlog.quiet("repro.cleanup"):
+            if os.path.exists(tmp):
+                os.remove(tmp)
+        raise
     return rep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,7 +174,14 @@ warn_unused_ignores = true
 # because a flag turned on over 66 unannotated modules would have to be silenced
 # everywhere, and a check that is silenced everywhere teaches that silence is
 # normal.
-module = ["beantester.utils", "beantester.gui.rates", "beantester.gui.scope"]
+#
+# Three more on 2026-09-06, and the reason is the ratchet itself: it had not moved
+# since the day it was created, which is a decision to stay at three modules that
+# nobody actually took. These are the next cheapest leaves - no tkinter, narrow
+# APIs, and `damage`/`filters` sit at the bottom of the layering where a wrong
+# type travels furthest. The rate to keep is one module per release, not a target.
+module = ["beantester.utils", "beantester.gui.rates", "beantester.gui.scope",
+          "beantester.damage", "beantester.jsonfile", "beantester.filters"]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,10 @@ max-complexity = 27
 # nothing about them is cryptographic. `seed` exists to make them repeatable.
 "beantester/engine.py" = ["S311"]
 "beantester/synthetic.py" = ["S311"]
+# The eviction sampler, moved here with the connection log. Its RNG is seeded at
+# 0 on purpose and picks which STALE ROWS to drop - see ConnectionLog.__init__ for
+# why it may not be the engine's seeded RNG.
+"beantester/connlog.py" = ["S311"]
 # Both continue past a widget or an adapter that answered nothing, in a loop whose
 # point is to survive exactly that.
 "beantester/gui/widgets/sortable_tree.py" = ["S112"]

--- a/tests/test_code_hygiene.py
+++ b/tests/test_code_hygiene.py
@@ -374,3 +374,122 @@ def test_the_known_unused_list_only_ever_shrinks():
     revived = sorted(name for name in KNOWN_UNUSED if name not in still_dead)
     check("no name on the exception list has quietly gained a caller", not revived,
           f"({revived} - it is used again, so take it out of KNOWN_UNUSED)")
+
+
+# -- the same shape, everywhere else: an INVENTORY rather than a rule ----------- #
+#
+# The guard above holds `core.py` to an absolute rule and says, in its own
+# docstring, why the rest of the package is not held to it: most broad handlers
+# out here are legitimate control-flow fallbacks - a parse returning None on bad
+# input, a DPI probe falling back to a default, a widget query answered by a
+# toolkit that has already destroyed the widget.
+#
+# That reasoning is right and this does not touch it. What it leaves open is the
+# COUNT. Finding F3 was a silent `except Exception: return False` in the decision
+# core; the same shape exists 93 times elsewhere, and nothing could tell a new one
+# from the 93 that were considered and kept. So the population is frozen instead
+# of the practice: today's numbers, per file, and they may only go DOWN.
+#
+# Measured 2026-09-06 with the same two predicates the core guard uses, so the two
+# can never drift into meaning different things by "silent" and "broad".
+#
+# 🔴 A file absent from this map must have ZERO. That is what makes the map a
+# ratchet rather than a list of the usual suspects: a NEW file full of silent
+# handlers cannot slip in by simply not being mentioned.
+SILENT_BROAD_HANDLERS = {
+    "gui/app.py": 13,
+    # 12 on 2026-09-06, then seven were dealt with in the same change - the file
+    # this inventory was built to look at first, because it is on the targeting
+    # path. The five left are per-PID lookups (`_make_native`, the two halves of
+    # `_native_process_info`, `_psutil_created`, `_psutil_process_info`), where a
+    # process that exited between the listing and the query, or one that denies a
+    # handle, is an ORDINARY event: recording those would fill the crash log with
+    # the normal running of the machine. The seven that went were the whole-table
+    # collapses and the capability probes, where silence is indistinguishable
+    # from an empty machine.
+    "portmap.py": 5,
+    # The recorder itself, and the one module allowed to swallow by this
+    # repository's own rule (see the per-file ignore in pyproject.toml): a crash
+    # reporter that raises while reporting a crash is worse than a quiet one.
+    "crashlog.py": 10,
+    "gui/widgets/sortable_tree.py": 9,
+    "cli.py": 5,
+    "engine.py": 5,
+    "gui/tooltip.py": 4,
+    "legal.py": 4,
+    "winenv.py": 4,
+    "gui/scrollable.py": 3,
+    "gui/windows.py": 3,
+    "gui/form.py": 2,
+    "gui/icon.py": 2,
+    "gui/pages/stats.py": 2,
+    "gui/scaling.py": 2,
+    "gui/theme.py": 2,
+    "i18n.py": 2,
+    "utils.py": 2,
+    "driver.py": 1,
+    "filters.py": 1,
+    "gui/chart.py": 1,
+    "gui/csv_export.py": 1,
+    "gui/pages/conns.py": 1,
+    "matchers.py": 1,
+    "settings.py": 1,
+}
+
+
+def _silent_broad_handlers():
+    """Per package file: how many broad handlers neither record nor re-raise."""
+    counts = {}
+    root = os.path.join(ROOT, "beantester")
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        for name in sorted(filenames):
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, name)
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            tree = ast.parse(open(path, encoding="utf-8").read())
+            found = sum(1 for node in ast.walk(tree)
+                        if isinstance(node, ast.ExceptHandler)
+                        and _is_broad_handler(node)
+                        and not _handler_reaches_crashlog_or_reraises(node))
+            if found:
+                counts[rel] = found
+    return counts
+
+
+def test_no_file_grows_a_new_silently_swallowed_exception():
+    """The population of the F3 shape may fall and may not rise.
+
+    Nothing here says any of the 93 is wrong. It says that the next one is a
+    DECISION: either it is a fallback worth keeping, and the number beside its
+    file goes up in the same change with a reason - which is the owner's call, the
+    same as raising any ceiling in this repository - or it routes to `crashlog`
+    like the convention asks.
+    """
+    measured = _silent_broad_handlers()
+    check("the handler scan actually read the package (an empty scan passes)",
+          sum(measured.values()) > 50, f"({sum(measured.values())} found)")
+
+    grown = sorted(f"{name}: {n} (was {SILENT_BROAD_HANDLERS.get(name, 0)})"
+                   for name, n in measured.items()
+                   if n > SILENT_BROAD_HANDLERS.get(name, 0))
+    check("no file swallows more broadly than it did", not grown,
+          f"({grown} - route the new one to crashlog.quiet/once/note, or raise "
+          "its number here on purpose)")
+
+
+def test_the_silent_handler_inventory_is_todays_measurement():
+    """The pinning half, for the reason every ceiling in this repository has one.
+
+    A number parked above the truth grants room nobody decided to grant, and the
+    next arrival slips in under it in silence - which is precisely the failure
+    this inventory exists to prevent, wearing its own badge. So fixing a handler
+    comes with a two-character chore: bring its number down with it.
+    """
+    measured = _silent_broad_handlers()
+    stale = sorted(f"{name}: {frozen} frozen, {measured.get(name, 0)} measured"
+                   for name, frozen in SILENT_BROAD_HANDLERS.items()
+                   if measured.get(name, 0) != frozen)
+    check("every frozen count is the measurement, not a number above it",
+          not stale, f"({stale} - lower it, that is what makes the fix stick)")

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -719,3 +719,133 @@ def test_the_strictly_typed_modules_only_ever_grow():
     gained = sorted(strict - STRICTLY_TYPED)
     check("a newly strict module is recorded here as well", not gained,
           f"({gained} - add it to STRICTLY_TYPED, that is what makes it stick)")
+
+
+# 🔴 THE FOURTH AXIS, added 2026-09-06: the CLASS. The three axes above measure
+# files, functions and branches, and a class is none of them - which is not a
+# gap in principle but a measured hole in practice. `gui/logview.py` was carved
+# out of `app.py` in September and took ninety lines of FILE off the number that
+# is watched; `App` came out of it with the same 96 methods it went in with. The
+# same is true of `gui/crash.py` and `gui/csv_export.py` before it. Three carves,
+# a file ratchet that moved every time, and the object a reader actually has to
+# hold in their head did not shrink once.
+#
+# What this buys that FILE_CEILING cannot: a class is the unit of state. Ninety-six
+# methods over eighty attributes is eighty things any of the ninety-six may have
+# changed, and splitting the FILE it lives in does not divide that by anything.
+#
+# Today's measurement, and both are `gui/app.py::App`. Same rule as every ratchet
+# in this file: down is routine, up is the owner's decision, and the numbers must
+# BE the measurement rather than sit above it (two tests below enforce that, the
+# same pair that guards the ceilings).
+CLASS_METHOD_CEILING = 96       # gui/app.py::App
+CLASS_ATTR_CEILING = 80         # gui/app.py::App
+# The crowd counts, on the same 70% band as the sizes. Methods: App (96) and
+# BeanEngine (69) against a band of 67.2. Attributes: App (80) and BeanCore (57)
+# against a band of 56.0 - and BeanCore is the interesting one, because it is a
+# 485-line file that no size ratchet has ever had a reason to look at. Fifty-seven
+# attributes is what a decision core with twelve pipeline steps accumulates.
+CLASSES_NEAR_METHOD_CEILING = 2     # App, BeanEngine
+CLASSES_NEAR_ATTR_CEILING = 2       # App, BeanCore
+
+
+def _classes():
+    """Every class in the package as (methods, attributes, name), biggest first.
+
+    METHODS are the class body's own defs - a nested helper inside one of them is
+    that method's business, not another entry in this class's surface. ATTRIBUTES
+    are the distinct `self.x = ...` targets anywhere inside the class, which is
+    the honest count of its state: `__init__` is where most of them are bound, but
+    an attribute grown in a later method is exactly the kind this axis exists to
+    notice.
+    """
+    methods, attributes = [], []
+    for path in _package_files():
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        tree = ast.parse(open(path, encoding="utf-8").read())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            own = [m for m in node.body
+                   if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))]
+            state = {sub.attr for sub in ast.walk(node)
+                     if isinstance(sub, ast.Attribute)
+                     and isinstance(sub.value, ast.Name) and sub.value.id == "self"
+                     and isinstance(sub.ctx, ast.Store)}
+            methods.append((len(own), f"{rel}::{node.name}"))
+            attributes.append((len(state), f"{rel}::{node.name}"))
+    methods.sort(reverse=True)
+    attributes.sort(reverse=True)
+    return methods, attributes
+
+
+def test_no_class_has_grown_past_the_ratchet():
+    """The axis a file split cannot answer - see CLASS_METHOD_CEILING."""
+    methods, attributes = _classes()
+    check("the class scan actually read the package (an empty scan passes)",
+          len(methods) >= 30, f"({len(methods)} classes)")
+
+    worst_methods = methods[0]
+    check(f"no class has more than {CLASS_METHOD_CEILING} methods",
+          worst_methods[0] <= CLASS_METHOD_CEILING,
+          f"({worst_methods[1]} has {worst_methods[0]} - move behaviour out, "
+          f"do not raise the number)")
+    worst_attributes = attributes[0]
+    check(f"no class holds more than {CLASS_ATTR_CEILING} attributes",
+          worst_attributes[0] <= CLASS_ATTR_CEILING,
+          f"({worst_attributes[1]} holds {worst_attributes[0]} - move state out, "
+          f"do not raise the number)")
+
+
+def test_no_second_class_is_creeping_up_on_the_class_ceilings():
+    """The crowd knob for this axis, for the reason written above CROWD_BAND.
+
+    A ceiling watches the worst class. It cannot see two classes climbing
+    together, which is the shape this package actually drifts into: `App` and
+    `BeanEngine` have been the top two on both counts for every release measured.
+    """
+    methods, attributes = _classes()
+    method_band = CLASS_METHOD_CEILING * CROWD_BAND
+    crowded = [f"{name} ({n})" for n, name in methods if n >= method_band]
+    check(f"at most {CLASSES_NEAR_METHOD_CEILING} class(es) within "
+          f"{CROWD_BAND:.0%} of the method ceiling ({method_band:.0f})",
+          len(crowded) <= CLASSES_NEAR_METHOD_CEILING, f"({crowded})")
+
+    attr_band = CLASS_ATTR_CEILING * CROWD_BAND
+    crowded = [f"{name} ({n})" for n, name in attributes if n >= attr_band]
+    check(f"at most {CLASSES_NEAR_ATTR_CEILING} class(es) within "
+          f"{CROWD_BAND:.0%} of the attribute ceiling ({attr_band:.0f})",
+          len(crowded) <= CLASSES_NEAR_ATTR_CEILING, f"({crowded})")
+
+
+def test_the_class_numbers_are_the_measurement_not_a_number_above_them():
+    """Both ceilings and both counts, pinned - the rule that made this axis worth
+    adding in the first place.
+
+    A ceiling standing above the truth grants headroom nobody decided to grant,
+    and the next arrival slips in under it in silence. That is not hypothetical
+    here: `FILE_CEILING` sat twelve lines above `gui/app.py` for a week after
+    `gui/crash.py` was carved out, and was found only because somebody printed the
+    numbers. This is the same test, one axis over, written at the same time as the
+    axis so the gap never opens.
+    """
+    methods, attributes = _classes()
+    check("the method ceiling IS the largest class, not a number above it",
+          methods[0][0] == CLASS_METHOD_CEILING,
+          f"({methods[0][1]} has {methods[0][0]}, ceiling is "
+          f"{CLASS_METHOD_CEILING} - move the ceiling to {methods[0][0]})")
+    check("the attribute ceiling IS the widest class, not a number above it",
+          attributes[0][0] == CLASS_ATTR_CEILING,
+          f"({attributes[0][1]} holds {attributes[0][0]}, ceiling is "
+          f"{CLASS_ATTR_CEILING} - move the ceiling to {attributes[0][0]})")
+
+    in_method_band = sum(1 for n, _ in methods if n >= CLASS_METHOD_CEILING * CROWD_BAND)
+    in_attr_band = sum(1 for n, _ in attributes if n >= CLASS_ATTR_CEILING * CROWD_BAND)
+    check("the method crowd count is today's measurement, not a looser number",
+          in_method_band == CLASSES_NEAR_METHOD_CEILING,
+          f"(measured {in_method_band}, frozen at {CLASSES_NEAR_METHOD_CEILING} "
+          f"- lower it)")
+    check("the attribute crowd count is today's measurement, not a looser number",
+          in_attr_band == CLASSES_NEAR_ATTR_CEILING,
+          f"(measured {in_attr_band}, frozen at {CLASSES_NEAR_ATTR_CEILING} "
+          f"- lower it)")

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -690,6 +690,14 @@ STRICTLY_TYPED = {
     "beantester.utils",
     "beantester.gui.rates",
     "beantester.gui.scope",
+    # 2026-09-06. The list had not grown once since the day it was written, and a
+    # ratchet that never moves is a decision to stay where it is that nobody
+    # actually made. These three are the next cheapest leaves: no tkinter, narrow
+    # public APIs, and two of them sit at the bottom of the layering, where a
+    # wrong type travels furthest.
+    "beantester.damage",
+    "beantester.jsonfile",
+    "beantester.filters",
 }
 
 

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -60,7 +60,17 @@ from fakes import ROOT, check
 # was carved out of `app.py` and left it at 1287, so twelve lines of allowance sat
 # there for a week and were found only because somebody printed the numbers. That is
 # the same defect the crowd counts below exist to catch, one level up.
-FUNCTION_CEILING = 133          # beantester/cli.py::_run_session
+# Lowered 2026-09-06 from 133 (`cli.py::_run_session`), the routine door again:
+# that function was split into the three phases it always had - open, drive,
+# report - which each have a different FAILURE contract, and the largest function
+# in the package is now `gui/app.py::_build_ui`.
+# 🔴 There is NO headroom downwards here, and the arithmetic is worth stating
+# because it is not obvious: the band is 70% of the ceiling, and the two runners-up
+# (`app.py::__init__` and `core.decide`) both sit at exactly 86. 86 / 0.7 = 122.9,
+# so the moment `_build_ui` loses a single line the band drops under 86 and BOTH
+# of them join the crowd, taking the count from 2 to 4. Carving `_build_ui`
+# therefore has to happen in the same change as carving one of those two.
+FUNCTION_CEILING = 123          # beantester/gui/app.py::_build_ui
 # Lowered 2026-09-02 from 1192, the routine door again: the four GUI lifecycle fixes
 # needed room in `app.py`, which was pinned to the ceiling exactly, so the log box's
 # own bookkeeping moved to `gui/logview.py` and the fixes went in under the number
@@ -94,7 +104,7 @@ FILE_CEILING = 1166             # beantester/gui/app.py
 # lines of headroom before it joins the count.
 CROWD_BAND = 0.70
 FILES_NEAR_CEILING = 1          # beantester/gui/app.py
-FUNCTIONS_NEAR_CEILING = 3      # _run_session, _build_ui, build_arg_parser
+FUNCTIONS_NEAR_CEILING = 2      # _build_ui, build_arg_parser
 
 # 🔴 THE THIRD AXIS, added 2026-08-21 - and this file used to say, in the paragraph
 # above, that nesting depth was not measured. It is now, because nothing else can
@@ -513,8 +523,13 @@ def test_the_ceilings_are_not_set_so_loosely_that_they_never_fire():
 # to 25 from the 27 the same change had pushed it to. Lowering a ceiling tightens
 # the band that hangs off it, and this number has to be re-measured when it moves,
 # exactly like the ceiling itself.
-COMPLEX_NEAR_CEILING = 5    # decide, _run_session, settings_summary,
-                            # _capture_loop, test_layering._module_level
+# 5 -> 4 on 2026-09-06: `_run_session` left the band by being split into three
+# phases. `decide` stays at 27 and stays the ceiling - its twelve steps are a
+# pipeline whose ORDER is a contract pinned by two other tests, so splitting it to
+# move a metric would be damaging something that works in order to make a number
+# look better.
+COMPLEX_NEAR_CEILING = 4    # decide, settings_summary, _capture_loop,
+                            # test_layering._module_level
 
 
 # Ruff is not in requirements-dev.txt: it lives in requirements-lint.txt, which a

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,6 +11,7 @@ import time
 import pytest
 
 from beantester import BeanEngine
+from beantester.connlog import ConnectionLog
 from beantester.core import BeanCore
 from beantester.damage import (DROP_BY_REASON, IMPAIRMENT_DROP_KEYS, TOOL_DROP_KEYS,
                                impairment_loss_pct)
@@ -329,22 +330,22 @@ def test_scoped_is_a_sticky_session_record():
 
     key = (5000, "1.1.1.1", 443)
     # first packet arrives in scope (targeting matched, an impairment applied)
-    eng._log_conn(key, "1.1.1.1", 443, 5000, True, 100, 1.0, "TCP",
-                  dropped=True, scoped=True)
+    eng._conns_log.log(key, "1.1.1.1", 443, 5000, True, 100, 1.0, "TCP",
+                       dropped=True, scoped=True)
     check("in scope on the first packet", row(5000)["scoped"] is True,
           f"(scoped={row(5000)['scoped']})")
 
     # later packets on the SAME flow arrive OUT of scope (target narrowed away):
     # the record must not flip back to "not impaired"
     for t in (2.0, 3.0):
-        eng._log_conn(key, "1.1.1.1", 443, 5000, True, 100, t, "TCP",
-                      dropped=False, scoped=False)
+        eng._conns_log.log(key, "1.1.1.1", 443, 5000, True, 100, t, "TCP",
+                           dropped=False, scoped=False)
     check("still recorded as impaired after leaving scope", row(5000)["scoped"] is True,
           f"(scoped={row(5000)['scoped']})")
 
     # a flow that is NEVER in scope stays out - stickiness only ever adds "yes"
-    eng._log_conn((5001, "2.2.2.2", 80), "2.2.2.2", 80, 5001, True, 100, 4.0, "TCP",
-                  dropped=False, scoped=False)
+    eng._conns_log.log((5001, "2.2.2.2", 80), "2.2.2.2", 80, 5001, True, 100,
+                       4.0, "TCP", dropped=False, scoped=False)
     check("a never-scoped flow is not marked impaired", row(5001)["scoped"] is False,
           f"(scoped={row(5001)['scoped']})")
 
@@ -725,30 +726,31 @@ def test_evicting_the_connection_log_can_never_empty_it():
     """
     def rows(engine, stamps):
         for i, last in enumerate(stamps):
-            engine._conns[i] = dict(remote_ip="1.1.1.1", remote_port=1, local_port=i,
-                                    proto="TCP", packets=1, bytes=1, bytes_in=0,
-                                    bytes_out=0, sent=0, sent_in=0, sent_out=0,
-                                    dropped=0, first=last, last=last, dir="out",
-                                    scoped=False, proc="", pid=None)
+            engine._conns_log.rows[i] = dict(
+                remote_ip="1.1.1.1", remote_port=1, local_port=i,
+                proto="TCP", packets=1, bytes=1, bytes_in=0,
+                bytes_out=0, sent=0, sent_in=0, sent_out=0,
+                dropped=0, first=last, last=last, dir="out",
+                scoped=False, proc="", pid=None)
 
-    keep = int(1000 * BeanEngine.EVICT_KEEP)
+    keep = int(1000 * ConnectionLog.EVICT_KEEP)
 
     tied = BeanEngine()
-    tied.MAX_CONNS = 1000
+    tied._conns_log.MAX_CONNS = 1000
     rows(tied, [12345.0] * 1200)                      # every row on ONE stamp
-    tied._trim_conns()
+    tied._conns_log.trim()
     check("a tie storm trims to the floor instead of wiping the log",
-          len(tied._conns) == keep, f"({len(tied._conns)} left, expected {keep})")
+          len(tied._conns_log.rows) == keep, f"({len(tied._conns_log.rows)} left, expected {keep})")
 
     spread = BeanEngine()
-    spread.MAX_CONNS = 1000
+    spread._conns_log.MAX_CONNS = 1000
     rows(spread, [12345.0 + i * 1e-6 for i in range(1200)])
-    spread._trim_conns()
+    spread._conns_log.trim()
     check("ordinary rows still trim to about the keep fraction",
-          keep <= len(spread._conns) <= keep + 50,
-          f"({len(spread._conns)} left, expected ~{keep})")
+          keep <= len(spread._conns_log.rows) <= keep + 50,
+          f"({len(spread._conns_log.rows)} left, expected ~{keep})")
     check("...and the SURVIVORS are the newest ones",
-          min(c["last"] for c in spread._conns.values()) > 12345.0,
+          min(c["last"] for c in spread._conns_log.rows.values()) > 12345.0,
           "(an old row survived while a newer one was evicted)")
 
 
@@ -1156,7 +1158,7 @@ def test_an_undisturbed_row_has_delivered_equal_to_captured():
 
 
 def test_only_the_injector_writes_the_delivered_counters():
-    """`_log_delivered` runs without the connection-log lock, and that is only safe
+    """`credit_delivered` runs without the connection-log lock, and that is only safe
     while `sent`/`sent_in`/`sent_out` have exactly ONE writer - the inject thread.
 
     Nothing enforces that but this scan. A future edit that credits delivered bytes
@@ -1164,15 +1166,27 @@ def test_only_the_injector_writes_the_delivered_counters():
     updates against itself, silently and only under load. Source-level, like the
     hot-path purity check in test_code_hygiene.py, because there is no runtime
     symptom to assert on until it is already wrong.
+
+    🔴 Reads BOTH files, and the second half is why: this scan named
+    ``engine.py`` alone until the rows moved to ``connlog.py`` on 2026-09-06, and
+    a scanner that knows one spelling reports ZERO writers as happily as it
+    reports one. The count over both files is the assertion; the per-file check
+    below is what makes an empty scan impossible to pass.
     """
-    src = open(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                            "beantester", "engine.py"), encoding="utf-8").read()
-    writes = re.findall(r'^\s*c\[\"(sent(?:_in|_out)?)\"\]\s*\+?=', src, re.M)
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sources = {name: open(os.path.join(root, "beantester", name),
+                          encoding="utf-8").read()
+               for name in ("engine.py", "connlog.py")}
+    writes = [m for src in sources.values()
+              for m in re.findall(r'^\s*c\[\"(sent(?:_in|_out)?)\"\]\s*\+?=',
+                                  src, re.M)]
     check("delivered counters are incremented in exactly one place",
           len(writes) == 3, f"({writes})")
-    body = src.split("def _log_delivered")[1].split("\n    def ")[0]
-    check("and that place is _log_delivered",
+    body = sources["connlog.py"].split("def credit_delivered")[1].split("\n    def ")[0]
+    check("and that place is credit_delivered",
           body.count('c["sent') == 3, f"({body.count(chr(99) + chr(91))})")
+    check("engine.py no longer writes them at all (the rows moved out)",
+          'c["sent' not in sources["engine.py"])
 
 
 class ParamDivert(FakeDivert):
@@ -1378,7 +1392,7 @@ def test_connections_snapshot_limit():
     sh = BeanEngine()
     for i in range(10):
         key = (5000 + i, "1.1.1.1", 80)
-        sh._log_conn(key, "1.1.1.1", 80, 5000 + i, True, 100, now=float(i), proto="TCP")
+        sh._conns_log.log(key, "1.1.1.1", 80, 5000 + i, True, 100, now=float(i), proto="TCP")
     top = sh.connections_snapshot(limit=5)
     check("connections: snapshot limit respected", len(top) == 5, f"(len={len(top)})")
     check("connections: most recent first",
@@ -1514,26 +1528,26 @@ def test_capture_path_never_evicts_and_the_watchdog_does():
     from beantester.engine import BeanEngine
 
     eng = BeanEngine()
-    eng.MAX_CONNS = 500
+    eng._conns_log.MAX_CONNS = 500
 
     # fill well past the cap straight through the capture-path helper
     now = time.monotonic()
     for i in range(900):
-        eng._log_conn((i, "1.2.3.4", 80), "1.2.3.4", 80, 1000 + i,
-                      True, 100, now + i * 0.001)
+        eng._conns_log.log((i, "1.2.3.4", 80), "1.2.3.4", 80, 1000 + i,
+                           True, 100, now + i * 0.001)
 
     check("the capture path does not evict (that is the watchdog's job)",
-          len(eng._conns) == 900, f"({len(eng._conns)})")
+          len(eng._conns_log.rows) == 900, f"({len(eng._conns_log.rows)})")
 
-    eng._trim_conns()
-    kept = len(eng._conns)
+    eng._conns_log.trim()
+    kept = len(eng._conns_log.rows)
     check("the watchdog trims back to roughly EVICT_KEEP of the cap",
           400 <= kept <= 520, f"(kept {kept})")
     check("the flows that survive are the RECENT ones",
-          all(c["last"] >= now + 0.3 for c in eng._conns.values()))
+          all(c["last"] >= now + 0.3 for c in eng._conns_log.rows.values()))
 
-    eng._trim_conns()
-    check("trimming under the cap is a no-op", len(eng._conns) == kept)
+    eng._conns_log.trim()
+    check("trimming under the cap is a no-op", len(eng._conns_log.rows) == kept)
 
 
 def test_snapshot_does_not_sort_the_whole_table_for_the_tables():
@@ -1549,8 +1563,8 @@ def test_snapshot_does_not_sort_the_whole_table_for_the_tables():
     eng = BeanEngine()
     now = time.monotonic()
     for i in range(50):
-        eng._log_conn((i, "1.2.3.4", 80), "1.2.3.4", 80, 1000 + i,
-                      True, 100, now + i)
+        eng._conns_log.log((i, "1.2.3.4", 80), "1.2.3.4", 80, 1000 + i,
+                           True, 100, now + i)
 
     everything = eng.connections_snapshot(limit=None)
     check("limit=None returns every row", len(everything) == 50)
@@ -1568,7 +1582,7 @@ def test_eviction_sampling_never_touches_the_seeded_rng():
     from beantester.engine import BeanEngine
 
     eng = BeanEngine()
-    check("eviction has its own RNG", eng._rng_evict is not eng._rng)
+    check("eviction has its own RNG", eng._conns_log._rng_evict is not eng._rng)
 
 
 def test_a_full_queue_says_so_instead_of_quietly_eating_packets():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1628,3 +1628,57 @@ def test_a_full_queue_says_so_instead_of_quietly_eating_packets():
     check("a reset re-arms the warning", any("queue" in line.lower()
                                              or "kolejka" in line.lower()
                                              for line in lines), f"({lines})")
+
+
+def test_every_core_setter_has_a_forwarder_that_matches_it():
+    """The engine's `set_*` methods are the surface it is DRIVEN through.
+
+    `settings.apply_settings` uses all fifteen, and so do ten test modules and one
+    CI script - 67 call sites, which is why they exist rather than being deleted
+    in favour of reaching into `.core`. But they used to forward `*a`, and that
+    cost two things nothing else could recover.
+
+    The first is mypy: `*a` erases the signature, so a wrong argument count on the
+    seam between the decision core and the threads that feed it could only fail at
+    runtime, and no amount of annotating the modules around it would ever help.
+
+    The second is the recipe. A new impairment field adds `core.set_x`, and the
+    forwarder is easy to forget because the notes' own "how to add an impairment"
+    list does not mention it - the failure arrives later, as an AttributeError
+    from `apply_settings`, in whatever ran first. This test is that missing step:
+    a core setter with no forwarder, or one whose parameters have drifted, is red
+    here instead.
+
+    Compared by NAME and by parameter list, not by call: two signatures that agree
+    on shape while disagreeing on order would pass a call-through test that only
+    ever passes positionally.
+    """
+    import inspect
+
+    core_setters = {name for name, _ in inspect.getmembers(BeanCore, inspect.isfunction)
+                    if name.startswith("set_")}
+    check("the scan found the core's setters at all (an empty scan passes)",
+          len(core_setters) >= 10, f"({sorted(core_setters)})")
+
+    missing = sorted(n for n in core_setters if not hasattr(BeanEngine, n))
+    check("every core setter has a forwarder on the engine", not missing,
+          f"({missing} - apply_settings drives the ENGINE, so a core-only setter "
+          "is an AttributeError waiting for whoever sets that field first)")
+
+    # `set_target` is the declared exception and says so here rather than being
+    # skipped in silence: the engine's version does substantially more than
+    # forward (it points the resolver at the target and is the ONE place that
+    # happens), so its signature is its own.
+    drifted = []
+    for name in sorted(core_setters - {"set_target"}):
+        core_params = list(inspect.signature(getattr(BeanCore, name)).parameters)
+        engine_params = list(inspect.signature(getattr(BeanEngine, name)).parameters)
+        if core_params != engine_params:
+            drifted.append(f"{name}: core{core_params} vs engine{engine_params}")
+    check("and its parameters are the same ones, in the same order", not drifted,
+          f"({drifted})")
+
+    check("set_target is still the exception this test knows about",
+          list(inspect.signature(BeanEngine.set_target).parameters)
+          == ["self", "active", "ports"],
+          "(if it became a plain forwarder, drop it from the exception above)")

--- a/tests/test_inject_batch.py
+++ b/tests/test_inject_batch.py
@@ -27,7 +27,7 @@ def test_a_packet_popped_after_the_handle_is_gone_is_recorded_not_lost():
         # handle left to send it through
         engine._divert = None
         engine._bump("drop_shutdown")          # what the loop now does
-        engine._charge_flow(None, "dropped")
+        engine._conns_log.charge(None, "dropped")
         after = engine.stats_snapshot()
         check("the packet is accounted for at shutdown",
               after["drop_shutdown"] == before["drop_shutdown"] + 1,

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -117,3 +117,220 @@ def test_tkinter_never_imported_at_module_load_outside_gui():
             offenders.append(os.path.relpath(path, ROOT))
     check("tkinter is only imported lazily outside gui/",
           not offenders, f"({offenders})")
+
+
+# --------------------------------------------------------------------------- #
+# Cycles. The four checks above pin the DIRECTION between four named layers; none
+# of them can see a loop, and a loop is the other way a dependency graph stops
+# being a graph anybody can reason about. Added 2026-09-06 after an audit measured
+# both numbers for the first time: zero at module load, two behind lazy imports.
+#
+# 🔴 The zero is the point. It has held on its own through five releases and 68
+# modules, and nothing was watching it - the first import cycle would have been
+# found by whoever hit the ImportError, which on this package means at GUI start
+# in a frozen build. A guard costs nothing while nothing loops.
+# --------------------------------------------------------------------------- #
+
+# The lazy cycles that exist today, each with the reason it is allowed. A NEW one
+# reddens this test, which is the whole point: a lazy import is invisible to every
+# other check in this file, so a loop hidden behind one can be built by accident
+# and stays working right up until somebody hoists the import to the top of its
+# file for tidiness.
+KNOWN_LAZY_CYCLES = {
+    frozenset({"appinfo", "crashlog", "paths"}):
+        "paths needs TOOL_ID to build the user data directory and appinfo needs "
+        "resource_path to find its own files, so one of the two has to defer - "
+        "the reason is written at paths.py's lazy import. crashlog sits in the "
+        "same knot because it writes THROUGH paths and stamps records with the "
+        "version from appinfo.",
+    frozenset({"", "cli", "gui"}):
+        "the launch path, and deliberate: cli.main starts the GUI through a lazy "
+        "import so that `import beantester` never pulls in tkinter (the test "
+        "above is the other half of that rule), and gui reaches back into the "
+        "package facade for the public names.",
+}
+
+
+def _internal_imports(path):
+    """(eager, lazy-only) internal module names for one file, at FULL granularity.
+
+    Unlike ``_module_level`` above, this keeps ``gui/app`` apart from ``gui``:
+    collapsing a subpackage to its top name would merge every module under
+    ``gui/`` into one node and hide any loop inside it.
+
+    🔴 ``from . import core`` is an edge to the SUBMODULE, not to the package's
+    ``__init__``. Resolving it the other way reports one 23-module cycle covering
+    half the package - measured while writing this, and it is a convincing lie:
+    the shape looks exactly like the tangle a reader expects to find.
+    """
+    modules = _package_modules()
+    current = _module_name(path)
+
+    def resolve(dotted):
+        parts = dotted.split(".")
+        if parts and parts[0] == "beantester":
+            parts = parts[1:]
+        candidate = "/".join(parts)
+        while candidate:
+            if candidate in modules:
+                return candidate
+            candidate = candidate.rsplit("/", 1)[0] if "/" in candidate else ""
+        return None
+
+    eager, lazy = set(), set()
+
+    def add_names(bucket, base, aliases):
+        hit = False
+        for alias in aliases:
+            candidate = (base + "/" + alias.name).strip("/")
+            if candidate in modules and candidate != current:
+                bucket.add(candidate)
+                hit = True
+        if not hit and base in modules and base != current:
+            bucket.add(base)
+
+    def walk(nodes, is_lazy):
+        for node in nodes:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                walk(node.body, True)
+                continue
+            bucket = lazy if is_lazy else eager
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    found = resolve(alias.name)
+                    if found is not None and found != current:
+                        bucket.add(found)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    parts = current.split("/")[:-1] if "/" in current else []
+                    up = node.level - 1
+                    if up:
+                        parts = parts[:-up] if up <= len(parts) else []
+                    tail = [(node.module or "").replace(".", "/")] if node.module else []
+                    add_names(bucket, "/".join([p for p in parts + tail if p]),
+                              node.names)
+                elif (node.module or "").startswith("beantester"):
+                    base = resolve(node.module)
+                    if base is not None:
+                        add_names(bucket, base, node.names)
+            for attr in ("body", "orelse", "finalbody"):
+                child = getattr(node, attr, None)
+                if isinstance(child, list):
+                    walk(child, is_lazy)
+            if isinstance(node, ast.Try):
+                for handler in node.handlers:
+                    walk(handler.body, is_lazy)
+
+    walk(ast.parse(open(path, encoding="utf-8").read()).body, False)
+    return eager, lazy - eager
+
+
+def _module_name(path):
+    name = os.path.relpath(path, os.path.join(ROOT, "beantester"))
+    name = name.replace(os.sep, "/")[: -len(".py")]
+    if name.endswith("/__init__"):
+        name = name[: -len("/__init__")]
+    return "" if name == "__init__" else name
+
+
+def _package_modules():
+    out = {}
+    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, "beantester")):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        for name in filenames:
+            if name.endswith(".py"):
+                path = os.path.join(dirpath, name)
+                out[_module_name(path)] = path
+    return out
+
+
+def _cycles(graph):
+    """Strongly connected components with more than one member.
+
+    Iterative rather than recursive: this walks 68 modules today and a recursive
+    Tarjan would be one deep subpackage away from the interpreter's limit.
+    """
+    index, low, stack, on_stack, found, counter = {}, {}, [], set(), [], [0]
+
+    def connect(root):
+        work = [(root, iter(graph.get(root, ())))]
+        index[root] = low[root] = counter[0]
+        counter[0] += 1
+        stack.append(root)
+        on_stack.add(root)
+        while work:
+            node, children = work[-1]
+            descended = False
+            for child in children:
+                if child not in index:
+                    index[child] = low[child] = counter[0]
+                    counter[0] += 1
+                    stack.append(child)
+                    on_stack.add(child)
+                    work.append((child, iter(graph.get(child, ()))))
+                    descended = True
+                    break
+                if child in on_stack:
+                    low[node] = min(low[node], index[child])
+            if descended:
+                continue
+            work.pop()
+            if work:
+                low[work[-1][0]] = min(low[work[-1][0]], low[node])
+            if low[node] == index[node]:
+                component = []
+                while True:
+                    member = stack.pop()
+                    on_stack.discard(member)
+                    component.append(member)
+                    if member == node:
+                        break
+                found.append(component)
+
+    for node in graph:
+        if node not in index:
+            connect(node)
+    return [frozenset(c) for c in found if len(c) > 1]
+
+
+def _graphs():
+    eager, combined = {}, {}
+    for name, path in _package_modules().items():
+        at_load, deferred = _internal_imports(path)
+        eager[name] = at_load
+        combined[name] = at_load | deferred
+    return eager, combined
+
+
+def test_the_package_has_no_import_cycle_at_module_load():
+    """Zero, and it has been zero for five releases with nothing watching it."""
+    eager, _ = _graphs()
+    check("the import scan actually read the package (an empty graph passes)",
+          sum(len(v) for v in eager.values()) > 50,
+          f"({sum(len(v) for v in eager.values())} edges)")
+    loops = _cycles(eager)
+    check("no module-load import cycle",
+          not loops,
+          f"({[sorted(c) for c in loops]} - an eager loop is an ImportError "
+          "waiting for whichever module happens to be imported first)")
+
+
+def test_every_lazy_import_cycle_is_one_this_file_knows_about():
+    """The half no other check here can see - see KNOWN_LAZY_CYCLES.
+
+    A lazy import creates no load-time edge, so the four direction checks above
+    pass straight through it. That is right for what they measure and wrong as a
+    complete picture: the loop is still there, and the day somebody moves the
+    import to the top of the file for tidiness it becomes an ImportError.
+    """
+    _, combined = _graphs()
+    loops = set(_cycles(combined))
+    known = set(KNOWN_LAZY_CYCLES)
+    check("the lazy graph is not empty (an empty scan passes everything)",
+          loops, "(no cycle found at all - the scan probably broke)")
+    new = sorted(sorted(c) for c in loops - known)
+    check("no lazy import cycle without a declared reason", not new,
+          f"({new} - add it to KNOWN_LAZY_CYCLES with the reason, or break it)")
+    gone = sorted(sorted(c) for c in known - loops)
+    check("a cycle that was broken is removed from the list as well", not gone,
+          f"({gone} - the knot is gone, so its entry is now a stale excuse)")

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -151,77 +151,98 @@ KNOWN_LAZY_CYCLES = {
 }
 
 
+def _resolve_dotted(dotted, modules):
+    """Longest prefix of an absolute `beantester.a.b` name that is a real module."""
+    parts = dotted.split(".")
+    if parts and parts[0] == "beantester":
+        parts = parts[1:]
+    candidate = "/".join(parts)
+    while candidate:
+        if candidate in modules:
+            return candidate
+        candidate = candidate.rsplit("/", 1)[0] if "/" in candidate else ""
+    return None
+
+
+def _relative_base(node, current):
+    """Package path a `from .x import y` is relative to, as a module path."""
+    parts = current.split("/")[:-1] if "/" in current else []
+    up = node.level - 1
+    if up:
+        parts = parts[:-up] if up <= len(parts) else []
+    if node.module:
+        parts = parts + [node.module.replace(".", "/")]
+    return "/".join(p for p in parts if p)
+
+
+def _named_modules(base, aliases, current, modules):
+    """The submodules `from <base> import a, b` names, else `base` itself.
+
+    🔴 This is the whole trap. `from . import core` is an edge to the SUBMODULE,
+    not to the package's ``__init__``: resolving it the other way reports one
+    23-module cycle covering half the package - measured while writing this, and
+    convincing, because it looks exactly like the tangle a reader expects to find.
+    """
+    hits = {(base + "/" + alias.name).strip("/") for alias in aliases}
+    hits = {h for h in hits if h in modules and h != current}
+    if hits:
+        return hits
+    return {base} if base in modules and base != current else set()
+
+
+def _import_targets(node, current, modules):
+    """Internal modules one import statement points at (empty for anything else)."""
+    if isinstance(node, ast.Import):
+        found = {_resolve_dotted(a.name, modules) for a in node.names}
+        return {f for f in found if f is not None and f != current}
+    if not isinstance(node, ast.ImportFrom):
+        return set()
+    if node.level:
+        return _named_modules(_relative_base(node, current), node.names,
+                              current, modules)
+    if not (node.module or "").startswith("beantester"):
+        return set()
+    base = _resolve_dotted(node.module, modules)
+    return set() if base is None else _named_modules(base, node.names,
+                                                     current, modules)
+
+
+def _statements(nodes):
+    """Every statement reachable from `nodes` without entering a function body.
+
+    Yields `(statement, is_lazy)`. A function body is descended into with
+    is_lazy=True and never resets: an import three blocks deep inside a method is
+    still deferred until that method runs.
+    """
+    stack = [(node, False) for node in reversed(nodes)]
+    while stack:
+        node, is_lazy = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            stack += [(child, True) for child in reversed(node.body)]
+            continue
+        yield node, is_lazy
+        children = []
+        for attr in ("body", "orelse", "finalbody"):
+            children += getattr(node, attr, None) or []
+        for handler in getattr(node, "handlers", None) or []:
+            children += handler.body
+        stack += [(child, is_lazy) for child in reversed(children)]
+
+
 def _internal_imports(path):
     """(eager, lazy-only) internal module names for one file, at FULL granularity.
 
     Unlike ``_module_level`` above, this keeps ``gui/app`` apart from ``gui``:
     collapsing a subpackage to its top name would merge every module under
     ``gui/`` into one node and hide any loop inside it.
-
-    🔴 ``from . import core`` is an edge to the SUBMODULE, not to the package's
-    ``__init__``. Resolving it the other way reports one 23-module cycle covering
-    half the package - measured while writing this, and it is a convincing lie:
-    the shape looks exactly like the tangle a reader expects to find.
     """
     modules = _package_modules()
     current = _module_name(path)
-
-    def resolve(dotted):
-        parts = dotted.split(".")
-        if parts and parts[0] == "beantester":
-            parts = parts[1:]
-        candidate = "/".join(parts)
-        while candidate:
-            if candidate in modules:
-                return candidate
-            candidate = candidate.rsplit("/", 1)[0] if "/" in candidate else ""
-        return None
-
     eager, lazy = set(), set()
-
-    def add_names(bucket, base, aliases):
-        hit = False
-        for alias in aliases:
-            candidate = (base + "/" + alias.name).strip("/")
-            if candidate in modules and candidate != current:
-                bucket.add(candidate)
-                hit = True
-        if not hit and base in modules and base != current:
-            bucket.add(base)
-
-    def walk(nodes, is_lazy):
-        for node in nodes:
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                walk(node.body, True)
-                continue
-            bucket = lazy if is_lazy else eager
-            if isinstance(node, ast.Import):
-                for alias in node.names:
-                    found = resolve(alias.name)
-                    if found is not None and found != current:
-                        bucket.add(found)
-            elif isinstance(node, ast.ImportFrom):
-                if node.level:
-                    parts = current.split("/")[:-1] if "/" in current else []
-                    up = node.level - 1
-                    if up:
-                        parts = parts[:-up] if up <= len(parts) else []
-                    tail = [(node.module or "").replace(".", "/")] if node.module else []
-                    add_names(bucket, "/".join([p for p in parts + tail if p]),
-                              node.names)
-                elif (node.module or "").startswith("beantester"):
-                    base = resolve(node.module)
-                    if base is not None:
-                        add_names(bucket, base, node.names)
-            for attr in ("body", "orelse", "finalbody"):
-                child = getattr(node, attr, None)
-                if isinstance(child, list):
-                    walk(child, is_lazy)
-            if isinstance(node, ast.Try):
-                for handler in node.handlers:
-                    walk(handler.body, is_lazy)
-
-    walk(ast.parse(open(path, encoding="utf-8").read()).body, False)
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    for node, is_lazy in _statements(tree.body):
+        targets = _import_targets(node, current, modules)
+        (lazy if is_lazy else eager).update(targets)
     return eager, lazy - eager
 
 

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1853,8 +1853,8 @@ MUTATIONS = [
         # vanishes cannot fail, which is why the list is recorded twice.
         "label": "types: a module loses its strict typing quietly",
         "file": "pyproject.toml",
-        "old": 'module = ["beantester.utils", "beantester.gui.rates", "beantester.gui.scope"]',
-        "new": 'module = ["beantester.gui.rates", "beantester.gui.scope"]',
+        "old": 'module = ["beantester.utils", "beantester.gui.rates", "beantester.gui.scope",',
+        "new": 'module = ["beantester.gui.rates", "beantester.gui.scope",',
         "test": "test_the_strictly_typed_modules_only_ever_grow",
     },
     {

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -722,13 +722,35 @@ MUTATIONS = [
         "test": "test_the_class_numbers_are_the_measurement_not_a_number_above_them",
     },
     {
-        # Half the package is only ever named from the suite, so a scan that stops
-        # reading tests/ calls a live helper dead. This is the noisy direction and
-        # the one that gets a guard switched off.
-        "label": "dead code: the usage scan stops reading the test suite",
-        "file": "tests/test_code_hygiene.py",
-        "old": 'USAGE_TREES = ("beantester", "tests", "tools", "lang", "scenarios")',
-        "new": 'USAGE_TREES = ("beantester", "tools", "lang", "scenarios")',
+        # The rule itself: a definition nothing names must be caught.
+        #
+        # 🔴 RE-AIMED 2026-09-06, after this entry SURVIVED on CI. It used to drop
+        # `tests` from `USAGE_TREES`, on the reasoning that half the package is
+        # only ever named from the suite, so a scan that stops reading tests/
+        # would call a live helper dead. That reasoning stopped being true on
+        # 2026-09-02, when a mention from the test tree stopped counting as LIFE
+        # (backlog B-16): the twelve definitions that would go dead are now all in
+        # KNOWN_UNUSED already, so removing the tree changes the `unexpected` list
+        # from empty to empty.
+        #
+        # MEASURED while re-aiming, and it is worth writing down because it is
+        # larger than this one entry: dropping ANY of the five trees - `tests`,
+        # `tools`, `lang` or `scenarios` - leaves the guard green. `USAGE_TREES`
+        # is a knob no mutation can reach any more, and its real job (an allow
+        # list, so that a tree existing only on the maintainer's machine cannot
+        # make a name look alive locally and dead on CI) is a property about
+        # ABSENT directories, which nothing present can demonstrate. Aiming at the
+        # rule is honest; aiming at a knob that no longer moves the answer is the
+        # SKIP-shaped non-result this registry exists to avoid.
+        #
+        # Verified by hand before being written down: an unreferenced helper added
+        # to `summary.py` reddens this test by name.
+        "label": "dead code: a definition nothing names is left in the package",
+        "file": "beantester/summary.py",
+        "old": "def settings_summary(",
+        "new": "def _orphan_helper(value):\n"
+               "    return value\n\n\n"
+               "def settings_summary(",
         "test": "test_no_definition_in_the_package_is_unreferenced",
     },
     {

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -569,12 +569,15 @@ MUTATIONS = [
         # function and cannot see the runners-up climbing together underneath it.
         "label": "ratchet: the complexity crowd count is frozen looser than the measurement",
         "file": "tests/test_code_shape.py",
-        # Re-anchored 2026-08-31: the constant moved 3 -> 5 when the complexity
-        # ceiling came down and the band came down with it. The mutation still
-        # proves the same thing - a count frozen looser than today's measurement
-        # is caught by the equality half of that test, not by the "at most" half.
-        "old": "COMPLEX_NEAR_CEILING = 5    # decide, _run_session, settings_summary,",
-        "new": "COMPLEX_NEAR_CEILING = 7    # decide, _run_session, settings_summary,",
+        # Re-anchored 2026-08-31 (3 -> 5) and again 2026-09-06 (5 -> 4, when
+        # `_run_session` was split into three phases and left the band). The
+        # mutation still proves the same thing - a count frozen looser than
+        # today's measurement is caught by the equality half of that test, not by
+        # the "at most" half. Re-anchoring is the routine cost of a pattern that
+        # pins exact source text; a stale one reports SKIP, which reads like a
+        # result and is not one.
+        "old": "COMPLEX_NEAR_CEILING = 4    # decide, settings_summary, _capture_loop,",
+        "new": "COMPLEX_NEAR_CEILING = 7    # decide, settings_summary, _capture_loop,",
         "test": "test_nothing_else_is_creeping_up_on_the_complexity_ceiling",
     },
     {

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -655,6 +655,32 @@ MUTATIONS = [
         "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
     },
     {
+        # The other half, and the one no other check in the repository can reach:
+        # a loop built entirely out of lazy imports. It runs, it passes every
+        # direction check, and it becomes an ImportError the day somebody hoists
+        # the import to the top of the file for tidiness. `cli` imports `views`,
+        # so one deferred import pointing back closes the ring.
+        "label": "layering: a new lazy import cycle appears with no reason declared",
+        "file": "beantester/views.py",
+        "old": "def filter_sort_connections(",
+        "new": "def _probe():\n"
+               "    from . import cli\n"
+               "    return cli\n\n\n"
+               "def filter_sort_connections(",
+        "test": "test_every_lazy_import_cycle_is_one_this_file_knows_about",
+    },
+    {
+        # The loop the four DIRECTION checks in that file cannot see. `utils` is
+        # the bottom layer and `core` imports it, so one line pointing back is a
+        # genuine cycle and reaches nothing else: no other test in the repository
+        # asserts anything about what utils.py imports.
+        "label": "layering: an import cycle appears at module load",
+        "file": "beantester/utils.py",
+        "old": "import math\n",
+        "new": "import math\n\nfrom . import core\n",
+        "test": "test_the_package_has_no_import_cycle_at_module_load",
+    },
+    {
         # The FOURTH axis, added 2026-09-06. Aimed at the class GROWING rather
         # than at a loosened constant, because that is the direction this axis
         # exists for: three carves out of `app.py` moved the file ratchet every

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -655,6 +655,20 @@ MUTATIONS = [
         "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
     },
     {
+        # The step the notes' "how to add an impairment" recipe does not mention:
+        # a new core setter needs a forwarder, and forgetting one used to surface
+        # much later as an AttributeError out of apply_settings, in whatever ran
+        # first. Aimed at the ADDITION rather than at a deleted forwarder, because
+        # that is the direction a session actually takes.
+        "label": "engine: a new core setter arrives without its forwarder",
+        "file": "beantester/core.py",
+        "old": "    def set_nat(self, timeout_s):",
+        "new": "    def set_brand_new_thing(self, x):\n"
+               "        return x\n\n"
+               "    def set_nat(self, timeout_s):",
+        "test": "test_every_core_setter_has_a_forwarder_that_matches_it",
+    },
+    {
         # The other half, and the one no other check in the repository can reach:
         # a loop built entirely out of lazy imports. It runs, it passes every
         # direction check, and it becomes an ImportError the day somebody hoists

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -655,6 +655,30 @@ MUTATIONS = [
         "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
     },
     {
+        # The FOURTH axis, added 2026-09-06. Aimed at the class GROWING rather
+        # than at a loosened constant, because that is the direction this axis
+        # exists for: three carves out of `app.py` moved the file ratchet every
+        # time and left `App` at the same 96 methods, so the object a reader has
+        # to hold in their head was never once measured.
+        "label": "ratchet: a class quietly grows another method",
+        "file": "beantester/gui/app.py",
+        "old": "    def _reveal(self):\n",
+        "new": "    def _ratchet_probe(self):\n"
+               "        return None\n\n"
+               "    def _reveal(self):\n",
+        "test": "test_no_class_has_grown_past_the_ratchet",
+    },
+    {
+        # The same axis from the other side: a ceiling parked above the truth.
+        # Kept separate from the entry above because they fail for different
+        # reasons, and an entry that reddens both proves neither.
+        "label": "ratchet: the class attribute ceiling is raised above the truth",
+        "file": "tests/test_code_shape.py",
+        "old": "CLASS_ATTR_CEILING = 80         # gui/app.py::App",
+        "new": "CLASS_ATTR_CEILING = 88         # gui/app.py::App",
+        "test": "test_the_class_numbers_are_the_measurement_not_a_number_above_them",
+    },
+    {
         # Half the package is only ever named from the suite, so a scan that stops
         # reading tests/ calls a live helper dead. This is the noisy direction and
         # the one that gets a guard switched off.

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -2088,9 +2088,9 @@ MUTATIONS = [
         "label": "reordering: a refused send still moves the mark",
         "file": "beantester/engine.py",
         "old": '                self._bump("drop_send")\n'
-               '                self._charge_flow(key, "dropped")\n',
+               '                self._conns_log.charge(key, "dropped")\n',
         "new": '                self._bump("drop_send")\n'
-               '                self._charge_flow(key, "dropped")\n'
+               '                self._conns_log.charge(key, "dropped")\n'
                "                self._note_order(arrived,\n"
                '                                 bool(getattr(packet, "is_outbound", True)))\n',
         "test": "test_a_packet_the_driver_refused_does_not_make_the_next_one_look_overtaken",


### PR DESCRIPTION
Nine commits from a codebase-health audit. No behaviour changes for the user: no CLI flag, exit code, on-disk format or GUI text moves. Everything here is structure, plus the guards that keep it from sliding back.

## Why now: three ratchet axes were jammed

`engine.py` stood at 815 logic lines against a crowd band of 816.2. Two more lines anywhere in the engine reddened the suite, and carving anything out of `gui/app.py` reddened it from the other side, because the ceiling is pinned to the largest module and lowering it drops the band onto the runner-up. A session hitting that would have looked for the cause in its own change.

Carving the connection log out fixed both directions: 75 lines of room upward, 107 down.

## What changed

- **`connlog.py`** - the session's flow rows, their lock, their eviction RNG and their cap policy, previously seven methods on a class that had grown to 72. `engine.py` 815 -> 741 logic lines, `BeanEngine` 72 -> 69 methods. The per-packet objection was answered before the move, not after: disabling the whole connection log measures 1.012x end to end, so one attribute hop into a feature worth ~1% of the pipeline cannot cost anything measurable. Both threading rules travel with the code - `credit_delivered` still takes no lock, and still may not.
- **A fourth ratchet axis: the class.** Files, functions and branches were measured; a class was not. That was a measured hole, not a theoretical one - three carves out of `app.py` each moved the file ratchet and left `App` at the same 96 methods every time. A class is the unit of state, and splitting the file it lives in does not divide 80 attributes by anything.
- **Two cycle guards.** Measured across 68 modules: zero import cycles at module load (held on its own through five releases with nothing watching it) and two behind lazy imports, both deliberate, both now carrying their reason. The lazy half is the one no other check can reach - a ring of deferred imports passes every direction check and becomes an `ImportError` the day someone hoists one to the top of its file.
- **The engine's fifteen `set_*` forwarders carry real signatures** instead of `*a`, and a guard keeps them in step with the core by name and by parameter list. A new core setter arriving without its forwarder used to surface later as an `AttributeError` out of `apply_settings`.
- **An inventory ratchet for silently swallowed exceptions.** The absolute rule stays where it was (the decision core); what is new is that the population elsewhere - 93 handlers - is frozen per file and may only fall. `portmap.py` went 12 -> 5 in the same change: the whole port map and the whole process table collapsing to `None`/`{}` used to be indistinguishable from a machine with no sockets open, on the path the targeting gate reads.
- **`cli.py::_run_session` split into three phases** with three different failure contracts. `FUNCTION_CEILING` 133 -> 123, `COMPLEX_NEAR_CEILING` 5 -> 4.
- **Three more modules under strict mypy** (3 -> 6 of 69), the package's **only structurally duplicated function** removed, the repro report written atomically, and `sortable_tree.py` importing `T` at module level like its twelve neighbours.

## A tool defect found on the way

The guard-selection tool was dropping the first character of the first changed path. Its `git()` helper strips the whole output, and a `git status --porcelain` line for an unstaged edit begins with a space, so the strip removed one character from the first line only and the `line[3:]` slice then cut into the path. `beantester/engine.py` arrived as `eantester/engine.py`, and the tool answered "no guard names this file" for the module with the most guards in the repository - 32 test files it should have selected, reported as none. Always the first file, always without an error.

## Verification

Full suite green: **1402 passed**, ruff and mypy clean, crash log empty after the run.

New guards are proven by mutation rather than left green - six registry entries, all `caught`: a class growing a method, a ceiling parked above the truth, an eager import cycle, a new undeclared lazy cycle, a core setter without its forwarder, and the re-anchored complexity crowd count. The exception inventory was forced red three ways by hand, including a new file absent from the map.

## Not done, deliberately

One planned step was dropped after measuring it. Carving `app.py` to lower `FILE_CEILING` was expected to buy headroom; the arithmetic says it spends it. The band is 70% of the ceiling and only one file may sit in it, so cutting the leader pulls the band down onto the runner-up: moving the whole profile family out of `App` (105 logic lines) puts `engine.py` **inside** the band and breaks the ratchet, and moving all but one method leaves it 5 lines of headroom instead of today's 71 - trading the jam this branch just cleared for the same jam one file over. Keeping today's headroom while cutting `app.py` by 94 lines needs `engine.py` to lose 66, so it is a second carve the size of `connlog.py`, not a small step. `FILES_NEAR_CEILING` was left at 1.

`App` (96 methods, 80 attributes) is still the largest single architectural problem here. It is now frozen by the new axis instead of growing quietly, and narrowing its contract page by page is its own change.

Rigs were not run (they belong to a release, not a chunk) and `smoke_gui.py` was not run - the single GUI change is covered by the layout and scope tests, but no real render was observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
