### PR TITLE
test(shape): put the suite under the ratchet, on the two axes that fit it

### DIFF
--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -70,6 +70,19 @@ from fakes import ROOT, check
 # so the moment `_build_ui` loses a single line the band drops under 86 and BOTH
 # of them join the crowd, taking the count from 2 to 4. Carving `_build_ui`
 # therefore has to happen in the same change as carving one of those two.
+#
+# 🔴 MEASURED 2026-09-06, before anyone spends a day on the wrong one of them: the
+# headroom is `123 - max(decide, __init__) / 0.7`, so it is set by the LARGER of
+# the pair and cutting only one buys nothing. Taking `core.decide` from 86 to 50
+# moves the headroom from 0.1 lines to 0.1 lines, because `App.__init__` still
+# stands at 86 - which means a hot-path change to the decision core would be paid
+# for a return of zero.
+#
+# And `App.__init__` cannot be cut on its own terms: 86 logic lines of which only
+# two are a block, the rest being one `self.x = ...` after another. That is not a
+# function that can be split, it is the 80-attribute god object showing through.
+# So this ceiling is unblocked by narrowing `App`'s contract and by nothing else -
+# it is the same work as H2.3, wearing a different hat.
 FUNCTION_CEILING = 123          # beantester/gui/app.py::_build_ui
 # Lowered 2026-09-02 from 1192, the routine door again: the four GUI lifecycle fixes
 # needed room in `app.py`, which was pinned to the ceiling exactly, so the log box's
@@ -204,12 +217,24 @@ def _nesting_depth(node):
     return walk(node, 0)
 
 
-def _package_files():
+def _tree_files(tree):
+    """Every ``.py`` under one top-level tree, ``__pycache__`` excluded.
+
+    One walk for both trees rather than two copies of it: the second copy arrived
+    with the suite axes on 2026-09-06 and immediately made the registry entry that
+    empties this list ambiguous - its anchor line existed twice, so the mutation
+    reported "occurs 2 times, not 1" instead of running. A shared helper keeps that
+    anchor unique, and the mutation now proves BOTH walks read something.
+    """
     out = []
-    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, "beantester")):
+    for dirpath, dirnames, filenames in os.walk(os.path.join(ROOT, tree)):
         dirnames[:] = [d for d in dirnames if d != "__pycache__"]
         out += [os.path.join(dirpath, n) for n in filenames if n.endswith(".py")]
     return out
+
+
+def _package_files():
+    return _tree_files("beantester")
 
 
 def _sizes():
@@ -872,3 +897,112 @@ def test_the_class_numbers_are_the_measurement_not_a_number_above_them():
           in_attr_band == CLASSES_NEAR_ATTR_CEILING,
           f"(measured {in_attr_band}, frozen at {CLASSES_NEAR_ATTR_CEILING} "
           f"- lower it)")
+
+
+# --------------------------------------------------------------------------- #
+# THE SUITE ITSELF. Everything above measures `beantester/` and nothing has ever
+# measured `tests/`, which is 23 359 logic lines against the package's 5 290 -
+# **the thing doing the guarding is 4.4x the size of the thing it guards**, and
+# only the complexity axis (which runs ruff over the whole tree) has ever looked
+# at it. Added 2026-09-06.
+#
+# 🔴 THERE IS DELIBERATELY NO FILE CEILING HERE, and that is the whole design
+# decision rather than an omission. A ratchet pins the ceiling to today's maximum,
+# so a file ceiling over `tests/` would be pinned to `test_mutation_registry.py` at
+# 1887 - and that file is 237 registry entries at about eight lines each, i.e.
+# almost entirely DATA. Every new mutation would redden the suite. That is a
+# threshold that punishes adding a proven guard, which is the exact opposite of
+# what this repository is trying to make cheap. A test file growing means more
+# tests; that is the good direction and nothing should tax it.
+#
+# What DOES transfer is the per-function shape. One test at 94 logic lines, or
+# nested seven deep, is not "more tests" - it is one test nobody can follow, and
+# when it fails it will not say what broke. Those two are worth a ceiling for the
+# same reason they are in the package: nobody reads this line by line.
+TEST_FUNCTION_CEILING = 94      # test_concurrency_chaos.py::test_the_model_worker_survives...
+TESTS_NEAR_FUNCTION_CEILING = 3     # the above, test_the_whole_stack_survives..., and
+                                    # test_the_live_map_pushes_into_targeting...
+# Absolute, like DEPTH_BAND above and for the same reason written there: a
+# percentage of a number this small is noise. Two functions reach 7 - both are
+# property-based sweeps with a matcher loop inside a packet loop - and three more
+# sit at 5.
+TEST_DEPTH_CEILING = 7
+TEST_DEPTH_BAND = 5
+TESTS_NEAR_DEPTH_CEILING = 5
+
+
+def _suite_files():
+    return _tree_files("tests")
+
+
+def _suite_functions():
+    """(logic lines, name) and (depth, name) for every function under tests/."""
+    sizes, depths = [], []
+    for path in _suite_files():
+        rel = os.path.relpath(path, ROOT).replace(os.sep, "/")
+        tree, live = _logic_lines(open(path, encoding="utf-8").read())
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            span = sum(1 for n in live if node.lineno <= n <= (node.end_lineno or 0))
+            sizes.append((span, f"{rel}::{node.name}"))
+            depths.append((_nesting_depth(node), f"{rel}::{node.name}"))
+    sizes.sort(reverse=True)
+    depths.sort(reverse=True)
+    return sizes, depths
+
+
+def test_no_test_function_has_grown_past_the_ratchet():
+    """One test at a hundred lines is one test nobody can follow - see above."""
+    sizes, depths = _suite_functions()
+    check("the suite scan actually read tests/ (an empty scan passes everything)",
+          len(sizes) > 500, f"({len(sizes)} functions)")
+
+    worst = sizes[0]
+    check(f"no test function is longer than {TEST_FUNCTION_CEILING} logic lines",
+          worst[0] <= TEST_FUNCTION_CEILING,
+          f"({worst[1]} is {worst[0]} - split the scenario, do not raise the number)")
+    deepest = depths[0]
+    check(f"no test function nests deeper than {TEST_DEPTH_CEILING}",
+          deepest[0] <= TEST_DEPTH_CEILING,
+          f"({deepest[1]} is {deepest[0]} deep)")
+
+
+def test_nothing_else_in_the_suite_is_creeping_up_on_those_ceilings():
+    """The crowd knob, for the reason written above CROWD_BAND."""
+    sizes, depths = _suite_functions()
+    band = TEST_FUNCTION_CEILING * CROWD_BAND
+    crowded = [f"{name} ({n})" for n, name in sizes if n >= band]
+    check(f"at most {TESTS_NEAR_FUNCTION_CEILING} test function(s) within "
+          f"{CROWD_BAND:.0%} of {TEST_FUNCTION_CEILING} ({band:.0f} or more)",
+          len(crowded) <= TESTS_NEAR_FUNCTION_CEILING, f"({crowded})")
+
+    deep = [f"{name} ({n})" for n, name in depths if n >= TEST_DEPTH_BAND]
+    check(f"at most {TESTS_NEAR_DEPTH_CEILING} test function(s) at depth "
+          f"{TEST_DEPTH_BAND} or more",
+          len(deep) <= TESTS_NEAR_DEPTH_CEILING, f"({deep})")
+
+
+def test_the_suite_ceilings_are_the_measurement_not_a_number_above_them():
+    """Pinned, like every other ceiling here - see FILE_CEILING for what drifts.
+
+    Also states the omission out loud: there is no file ceiling over `tests/`, and
+    a future session must not read that as an oversight to correct. The reason is
+    written above TEST_FUNCTION_CEILING.
+    """
+    sizes, depths = _suite_functions()
+    check("the test-function ceiling IS the longest test, not a number above it",
+          sizes[0][0] == TEST_FUNCTION_CEILING,
+          f"({sizes[0][1]} is {sizes[0][0]}, ceiling is {TEST_FUNCTION_CEILING})")
+    check("the test-depth ceiling IS the deepest test",
+          depths[0][0] == TEST_DEPTH_CEILING,
+          f"({depths[0][1]} is {depths[0][0]}, ceiling is {TEST_DEPTH_CEILING})")
+
+    in_size_band = sum(1 for n, _ in sizes if n >= TEST_FUNCTION_CEILING * CROWD_BAND)
+    in_depth_band = sum(1 for n, _ in depths if n >= TEST_DEPTH_BAND)
+    check("the test-size crowd count is today's measurement",
+          in_size_band == TESTS_NEAR_FUNCTION_CEILING,
+          f"(measured {in_size_band}, frozen at {TESTS_NEAR_FUNCTION_CEILING})")
+    check("the test-depth crowd count is today's measurement",
+          in_depth_band == TESTS_NEAR_DEPTH_CEILING,
+          f"(measured {in_depth_band}, frozen at {TESTS_NEAR_DEPTH_CEILING})")

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -722,6 +722,20 @@ MUTATIONS = [
         "test": "test_the_class_numbers_are_the_measurement_not_a_number_above_them",
     },
     {
+        # The suite's own axes, added 2026-09-06. Aimed at a test GROWING, which
+        # is the direction they exist for: 23 359 logic lines of tests guarded the
+        # package while nothing measured their shape, and one test at a hundred
+        # lines is not "more tests" - it is one test nobody can follow, which will
+        # not say what broke when it fails. The ceiling is pinned to this exact
+        # function, so one statement is enough to cross it.
+        "label": "ratchet: a test function grows past the suite ceiling",
+        "file": "tests/test_concurrency_chaos.py",
+        "old": "def test_the_model_worker_survives_a_live_connection_table():",
+        "new": "def test_the_model_worker_survives_a_live_connection_table():\n"
+               "    _ratchet_probe = 1",
+        "test": "test_no_test_function_has_grown_past_the_ratchet",
+    },
+    {
         # The rule itself: a definition nothing names must be caught.
         #
         # 🔴 RE-AIMED 2026-09-06, after this entry SURVIVED on CI. It used to drop
@@ -1244,7 +1258,12 @@ MUTATIONS = [
         "test": "test_the_repository_scanners_stay_out_of_what_is_not_in_the_repository",
     },
     {
-        "label": "shape: the package walk finds no files to measure",
+        # Since 2026-09-06 this one line is the walk for BOTH trees (the package
+        # and the suite), so emptying it proves both canaries at once. It briefly
+        # existed twice, when the suite axes arrived with their own copy, and the
+        # runner said "occurs 2 times, not 1" instead of running - which is how a
+        # duplicated helper turns a proven guard into a non-result.
+        "label": "shape: the tree walk finds no files to measure",
         "file": "tests/test_code_shape.py",
         "old": "        out += [os.path.join(dirpath, n) for n in filenames if n.endswith(\".py\")]",
         "new": "        out += []",


### PR DESCRIPTION
Follow-up to #181. Test-only change: nothing in `beantester/` moves.

## The gap

Everything the size ratchet measures is in `beantester/`. Nothing had ever measured `tests/`, which is **23 359 logic lines against the package's 5 290** - the thing doing the guarding is 4.4x the size of the thing it guards. Only the complexity axis, which runs ruff over the whole tree, had ever looked at it.

## Two axes transfer, one deliberately does not

Added: **test-function length** (`TEST_FUNCTION_CEILING = 94`) and **nesting depth** (`TEST_DEPTH_CEILING = 7`), with crowd counts on the same band the package uses. One test at 94 logic lines is not "more tests" - it is one test nobody can follow, and when it fails it will not say what broke.

**There is deliberately no file ceiling over `tests/`, and that is the decision rather than an omission.** A ratchet pins its ceiling to today's maximum, so a file ceiling here would be pinned to `test_mutation_registry.py` at 1887 - and that file is 237 registry entries at about eight lines each, which is data, not code. Every new mutation would redden the suite. That is a threshold which taxes adding a proven guard, and making guards cheap to add is the point of the whole arrangement. A test file growing means more tests; nothing should charge for it.

The reason is written above the constants so a later session does not read the missing axis as an oversight to correct.

## One walk, one anchor

The suite axes arrived with their own copy of the directory walk, and that immediately broke something: the registry entry that empties the walk anchors on that exact line, which now existed twice, so the runner reported "occurs 2 times, not 1" and skipped instead of proving anything. A duplicated helper turning a proven guard into a non-result is the failure mode this repository spends the most effort on, so the two walks are now one helper - one anchor, and the mutation proves both canaries at once.

## What did not get done, and why

The other half of the plan was to disarm the function ceiling's missing headroom by carving `gui/app.py::_build_ui`. Measuring it first showed the plan was aimed at the wrong function:

- headroom is `123 - max(decide, __init__) / 0.7`, so it is set by the **larger** of the two runners-up, and cutting one alone buys nothing. Taking `core.decide` from 86 to 50 moves the headroom from 0.1 lines to 0.1 lines - a hot-path change to the decision core, paid for a return of zero.
- `App.__init__` is 86 logic lines of which only two are a block; the rest is one `self.x = ...` after another. That is not a function that can be split. It is the 80-attribute god object showing through.

So this ceiling is unblocked by narrowing `App`'s contract and by nothing else - it is the same work as the `AppContext` step, wearing a different hat. The measurement is recorded next to the constant rather than left to be rediscovered.

## Verification

Full suite: **1405 passed**. Ruff clean. All four new constants were mutated by hand and all four fire (ceiling above the truth, on both axes; crowd count loosened, on both axes). Two registry entries: a test function growing past the ceiling, and the re-labelled tree walk - both `caught`. Mutations for every changed file: 6 caught, 0 survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
