### PR TITLE
refactor(core): give the token bucket its own function

### DIFF
--- a/beantester/core.py
+++ b/beantester/core.py
@@ -983,6 +983,64 @@ class BeanCore:
         with self._lock:
             return bool(self.target_active)
 
+    def _charge(self, is_outbound, size, now, rate):
+        """Admit one packet to the shaped link, or refuse it. MAY NOT be called
+        without ``rate > 0`` (it divides by it) and assumes ``self._lock`` is held.
+
+        Returns the moment the link becomes free again after carrying this packet,
+        or ``None`` when the bounded buffer has no room for it. ``self._bucket`` is
+        advanced only when the packet is admitted, so a refusal leaves the link
+        exactly as it was.
+
+        ``b`` is the link's virtual finish time: the moment it becomes free after
+        everything queued so far. The delay a packet sits through before its own
+        transmit is ``b - now``.
+
+        A real shaped link buffers only so much before it drops. With
+        ``buffer_s == 0`` the buffer is unbounded (legacy behaviour: the bucket
+        could run tens of seconds ahead, which both injected huge latency AND meant
+        a rate INCREASE never took effect - the stale bucket kept gating every later
+        high-rate step). With ``buffer_s > 0`` a packet that would push the queueing
+        delay past the buffer is TAIL-DROPPED: the delivered rate stays exactly at
+        ``rate``, the added latency is bounded by ``buffer_s``, and after a rate
+        rise the buffer drains within ``buffer_s`` instead of never. An empty buffer
+        (``queued == 0``) always accepts the packet, so a tiny buffer throttles hard
+        but never blacks the link out completely.
+
+        🔴 ONE function for what used to be two copies of this arithmetic. Step 11
+        admitted the packet and step 12 admitted its duplicate, and the second copy
+        was written without the ``b < now`` clamp - correct only because step 11 had
+        just run and left the bucket at or beyond ``now``. That is a true fact about
+        today's ordering and not a property either step stated, so it was one
+        reordering away from being wrong in a way no counter would have shown.
+        """
+        b = self._bucket[is_outbound]
+        if b < now:
+            b = now
+        queued = b - now
+        if self.buffer_s > 0 and queued > 0 and queued + size / rate > self.buffer_s:
+            return None
+        b += size / rate
+        self._bucket[is_outbound] = b
+        return b
+
+    def _shape(self, is_outbound, size, now, rate, release):
+        """Step 11 for one packet: the release time after shaping, or ``None``.
+
+        ``None`` means the bounded buffer refused the packet and the caller must
+        drop it with reason ``rate`` - the counter that reason maps to is
+        ``damage.DROP_BY_REASON``, and moving this out of ``decide`` does not move
+        the attribution with it.
+
+        A packet is never released EARLIER than it already would have been: the
+        shaped link can delay a packet, and nothing here may undo a delay that
+        latency, jitter or a spike has already decided on.
+        """
+        finish = self._charge(is_outbound, size, now, rate)
+        if finish is None:
+            return None
+        return finish if finish > release else release
+
     def decide(self, size, is_outbound, local_port, now, rng,
                remote_ip=None, remote_port=None, is_syn=False, is_tcp=False):
         with self._lock:
@@ -1228,35 +1286,20 @@ class BeanCore:
             down_bps, up_bps = self._current_rates(now)
             rate = up_bps if is_outbound else down_bps
             if rate > 0:
-                b = self._bucket[is_outbound]
-                if b < now:
-                    b = now
-                queued = b - now
-                if self.buffer_s > 0 and queued > 0 and \
-                        queued + size / rate > self.buffer_s:
+                release = self._shape(is_outbound, size, now, rate, release)
+                if release is None:
                     return Decision(True, False, [], "rate")
-                b += size / rate
-                self._bucket[is_outbound] = b
-                if b > release:
-                    release = b
 
             releases = [release]
             # 12) duplication
             if imp.dup > 0 and rng.random() < imp.dup:
                 dup_release = release + rng.uniform(0.0, 0.02)
-                # a duplicate is a second copy on the wire: charge the bucket for it,
+                # A duplicate is a second copy on the wire: charge the bucket for it,
                 # or the shaped link quietly carries (1 + dup%) of its limit. If the
-                # bounded buffer has no room for the copy, the copy is what gets
-                # dropped - the original already went through.
-                if rate > 0:
-                    b = self._bucket[is_outbound]
-                    if self.buffer_s > 0 and (b - now) > 0 and \
-                            (b - now) + size / rate > self.buffer_s:
-                        pass                # no room for the duplicate; original stands
-                    else:
-                        self._bucket[is_outbound] = b + size / rate
-                        releases.append(dup_release)
-                else:
+                # bounded buffer has no room for the copy, the COPY is what gets
+                # dropped - the original already went through, so this appends
+                # nothing rather than returning a drop.
+                if rate <= 0 or self._charge(is_outbound, size, now, rate) is not None:
                     releases.append(dup_release)
 
             return Decision(False, corrupt, releases)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,23 @@ max-args = 14
 #
 # Down is routine, up is a decision. Splitting something means lowering this in
 # the same change.
-max-complexity = 27
+#
+# 2026-09-06: 27 -> 26. `core.decide` went 27 -> 24 by giving the token bucket its
+# own function, so the ceiling is now `summary.settings_summary` at 26.
+# 🔴 WHY IT WAS WORTH DOING, since the number moved by one: the ceiling is pinned
+# to the measurement, so whatever stands at the top has ZERO headroom - and what
+# stood there was `decide`, whose complexity is the product's own feature list.
+# Adding a 13th impairment is step 3 of the "how to add an impairment" recipe, and
+# it took `decide` to 28: **the recipe blocked its own required check** (measured
+# by mutation, 2026-09-06). Below somebody else's ceiling `decide` has room again.
+# 🔴 AND HOW MUCH: two more impairments, not six. Extraction gives back less than
+# it looks like - each moved body costs one `if` for checking the helper's answer,
+# so a gate with a single nested branch yields nothing at all. The whole harvest
+# left in `decide` is about three points. This axis cannot absorb the twelve-step
+# pipeline growing indefinitely, and the next time it jams the honest options are
+# to lower `settings_summary` (which hands its ceiling to `decide` again) or to
+# decide that a pipeline of N product features is allowed to score N.
+max-complexity = 26
 
 [tool.ruff.lint.per-file-ignores]
 # A test suite for a packet mangler asserts, randomises, spawns subprocesses and

--- a/tests/test_bandwidth_buffer.py
+++ b/tests/test_bandwidth_buffer.py
@@ -182,3 +182,49 @@ def test_tiny_positive_rate_is_not_silently_unlimited():
     assert core.rate_down == 0 and core.rate_up == 0
     core.set_schedule([(1.0, 0.0004, 0)])              # same rule inside a schedule
     assert core.schedule[0][1] == 1, core.schedule
+
+
+def test_an_idle_shaped_link_does_not_bank_burst_credit():
+    """The bucket is clamped to ``now`` before it is charged - `_charge`, step 11.
+
+    ``self._bucket`` is a VIRTUAL FINISH TIME, not a token count: the moment the
+    link becomes free after everything queued so far. A link that has been quiet
+    leaves that moment in the PAST, and charging from a stale one is charging a
+    link that has been paying for its idleness. Two things then break at once:
+    the packet is scheduled from a moment already gone, so the shaper adds no
+    delay at all until the bucket catches up to the present, and ``queued``
+    (``b - now``) comes out NEGATIVE, so the bounded-buffer tail-drop cannot fire
+    either. The longer the pause, the bigger the burst that walks through a link
+    with a speed limit on it.
+
+    🔴 Found unguarded on 2026-09-06, while giving the token bucket its own
+    function: deleting the clamp survived the WHOLE suite. It is one line, it
+    predates this test by months, and nothing in 1405 tests noticed - so this is
+    written from the mutation rather than from the code, which is the only way it
+    could have been written honestly.
+    """
+    core = BeanCore()
+    core.set_params(0, 0, 0, 0, 0, 100, 100)      # 100 KB/s each way
+    core.set_buffer(0)                             # unbounded buffer: isolate the clamp
+    core.reset_buckets(0.0)
+    rng = random.Random(1)
+
+    # One packet at t=0 leaves the link busy until ~0.0146 s (1500 B at 100 KB/s).
+    first = core.decide(1500, True, 5000, 0.0, rng, remote_ip="1.2.3.4")
+    assert first.releases and first.releases[0] > 0.0, first.releases
+
+    # Now go quiet for ten seconds. The finish time is long past by the time the
+    # next packet arrives, and the link may not treat that as credit.
+    later = 10.0
+    delays = []
+    for _ in range(5):
+        d = core.decide(1500, True, 5000, later, rng, remote_ip="1.2.3.4")
+        assert d.releases, "a shaped packet is delayed, never dropped, with buffer=0"
+        delays.append(d.releases[0] - later)
+
+    # Each of the five queues behind the one before it: ~14.6 ms apart. Without
+    # the clamp the first few are released at or before `later` (the stale finish
+    # time is still in the past) and the sequence does not climb.
+    assert all(x > 0 for x in delays), delays
+    assert delays == sorted(delays), delays
+    assert delays[-1] > delays[0] * 3, delays

--- a/tests/test_code_shape.py
+++ b/tests/test_code_shape.py
@@ -147,7 +147,11 @@ FUNCTIONS_NEAR_CEILING = 2      # _build_ui, build_arg_parser
 # percentage OF, and depth here runs 0 to 5.
 DEPTH_CEILING = 5               # beantester/gui/icon.py::make_gear_icon
 DEPTH_BAND = 4                  # absolute: see above
-DEPTHS_NEAR_CEILING = 12        # make_gear_icon at 5, eleven more at 4
+# Lowered 2026-09-06 from 12, the routine direction: `core.decide` gave the
+# token bucket its own function, which took `core.py::decide` out of the band
+# without anyone aiming at this axis. Lowering a crowd count is free; the test
+# below is what forces it, and that is the whole point of pinning it.
+DEPTHS_NEAR_CEILING = 11        # make_gear_icon at 5, ten more at 4
 
 
 def _logic_lines(source):

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -653,7 +653,7 @@ MUTATIONS = [
         # once, and an entry that fells a crowd proves nothing about any one of them.
         "label": "ratchet: the nesting crowd count is frozen looser than the measurement",
         "file": "tests/test_code_shape.py",
-        "old": "DEPTHS_NEAR_CEILING = 12        # make_gear_icon at 5, eleven more at 4",
+        "old": "DEPTHS_NEAR_CEILING = 11        # make_gear_icon at 5, ten more at 4",
         "new": "DEPTHS_NEAR_CEILING = 20        # make_gear_icon at 5, eleven more at 4",
         "test": "test_the_depth_ceiling_and_its_count_are_not_set_so_loosely_they_never_fire",
     },
@@ -720,6 +720,32 @@ MUTATIONS = [
         "old": "CLASS_ATTR_CEILING = 80         # gui/app.py::App",
         "new": "CLASS_ATTR_CEILING = 88         # gui/app.py::App",
         "test": "test_the_class_numbers_are_the_measurement_not_a_number_above_them",
+    },
+    {
+        # The bucket is a virtual FINISH TIME, not a token count, so a link that
+        # has been quiet leaves it in the past. Charging from a stale one banks
+        # the idleness as burst credit: the shaper adds no delay until the bucket
+        # catches up, and `queued` goes negative so the bounded buffer cannot
+        # tail-drop either. Found UNGUARDED on 2026-09-06 - deleting this clamp
+        # survived all 1405 tests - while giving the token bucket its own
+        # function, and the test was written from this mutation rather than from
+        # the code.
+        "label": "rate: an idle shaped link banks its silence as burst credit",
+        "file": "beantester/core.py",
+        "old": "        b = self._bucket[is_outbound]\n        if b < now:\n            b = now\n",
+        "new": "        b = self._bucket[is_outbound]\n",
+        "test": "test_an_idle_shaped_link_does_not_bank_burst_credit",
+    },
+    {
+        # The other half of what the shared helper now owns: the duplicate is a
+        # second copy on the wire and has to be charged for, or a shaped link
+        # quietly carries (1 + dup%) of its limit. This one WAS guarded before the
+        # extraction and the entry records that it still is afterwards.
+        "label": "rate: a duplicate rides the shaped link for free",
+        "file": "beantester/core.py",
+        "old": "                if rate <= 0 or self._charge(is_outbound, size, now, rate) is not None:",
+        "new": "                if True:",
+        "test": "test_a_duplicate_is_charged_to_the_speed_limit",
     },
     {
         # The suite's own axes, added 2026-09-06. Aimed at a test GROWING, which


### PR DESCRIPTION
Point 2 of the codebase-health work, after #181 and #182.

## The jam: the recipe blocked its own required check

`decide()` sat exactly on the complexity ceiling, and that ceiling is pinned to the measurement - so whatever stands at the top has **zero** headroom. What stood there was `decide`, whose complexity is the product's own feature list.

Step 3 of the documented "how to add an impairment" recipe is *handle it in `core.decide()` at the right pipeline step*. Measured by mutation before anything was touched: a 13th gate takes `decide` from 27 to 28, `ruff C901` fails, and that is a required check on every pull request. The recipe could not be followed.

## What changed

The token bucket becomes `_charge`, and step 11's use of it becomes `_shape`. `decide` goes **27 -> 24**, `max-complexity` **27 -> 26** (now `settings_summary`), so `decide` has room under somebody else's ceiling.

The pipeline order is untouched. The twelve gates stay exactly where they are - only two bodies moved - and the gate-precedence property still passes.

It also removes a real duplication rather than only branches: steps 11 and 12 each carried their own copy of the bucket arithmetic, and the second copy left out the `b < now` clamp. That was correct only because step 11 had just run and left the bucket at or past `now` - a true fact about today's ordering, and not something either step stated.

## A defect the extraction surfaced: an unguarded line

That clamp turned out to have no guard at all. **Deleting it survives all 1405 tests.**

The bucket holds a virtual finish time, not a token count, so a link that has been quiet leaves it in the past. Without the clamp two things break at once: the shaper adds no delay until the bucket catches up to the present, and `queued` (`b - now`) goes negative, so the bounded-buffer tail-drop cannot fire either. The longer the pause, the bigger the burst that walks through a link with a speed limit on it.

The line was always correct and is unchanged. What is new is `test_an_idle_shaped_link_does_not_bank_burst_credit`, written from that mutation rather than from the code, plus registry entries for it and for the duplicate's charge.

## The harvest is smaller than it looks

An earlier estimate said seven complexity points were available here. The real number is about **three**, and the reason is written next to `max-complexity` so it is not re-derived optimistically: each moved body pays one `if` back for checking the helper's answer, so a gate with a single nested branch yields nothing at all.

That is **two more impairments of room, not six**. This axis cannot absorb a twelve-step pipeline growing indefinitely, and when it jams again the honest options are to lower `settings_summary` - which hands the ceiling straight back to `decide` - or to decide that a pipeline of N product features is allowed to score N.

`DEPTHS_NEAR_CEILING` fell 12 -> 11 on its own, which is the routine direction.

## Verification

Full suite **1406 passed**, crash log empty, ruff and mypy clean. Every mutation for the changed files caught, including the four `core:` entries and both new `rate:` ones.

The paired `decide` benchmark **could not produce a usable number**, and that is reported rather than rounded away: the canary moved between runs (50 -> 86 in the same units), so the machine moved, and the rig's own rule is that two runs then cannot be compared. What is solid from it: retained blocks and bytes are identical in every mix on both trees (13/608, 15/776, 15/656), and the default path gains no call at all - both helpers sit inside gates that only an armed impairment enters, which the unchanged `idle`, `udp` and `targeted-miss` mixes agree with.

## Not done

`settings_summary` (26) has the same shape - 20 top-level branches, one per setting, while the upload half twenty lines above it already uses a table for exactly this and says why in its docstring. It is deliberately left alone here: lowering it takes the ceiling off it and drops the band back onto `decide`, giving away the room this change buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
