### PR TITLE
docs: link the README to the website, and print the command the front page promised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   The guides there cover packet loss, latency, speed limits, aiming at one app and testing with
   no internet, each with the numbers worth trying and the command that does it.
 
+- **The website's front page now shows the command it was talking about.** It said one command is
+  enough to check that a service survives 10 percent packet loss, and then did not print one,
+  which every other page on the site does. It now shows the command, says that the run stops
+  itself when the time is up, and points at the rehearsal switch that changes no real traffic.
+
 ## [0.6.0] - 2026-09-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
   refused. Every full flag still works, so saved reproduction commands and every example in
   this documentation are unaffected - only hand-typed abbreviations need writing out in full.
 
+### Docs
+
+- **The README now points at the website.** One link under the badges, and a second after the
+  quick start for anyone who wants a walkthrough of a single task instead of the full manual.
+  The guides there cover packet loss, latency, speed limits, aiming at one app and testing with
+  no internet, each with the numbers worth trying and the command that does it.
+
 ## [0.6.0] - 2026-09-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/14154/badge)](https://www.bestpractices.dev/projects/14154)
 ![Platform: Windows](https://img.shields.io/badge/platform-Windows-0078D6)
 
+📖 **Guides and examples: [beannetworktester.donislawdev.com](https://beannetworktester.donislawdev.com/)**
+
 **Bean Network Tester** is a tool for testers and developers: check how your application behaves
 on a poor connection. Like Clumsy or NetLimiter, it lets you deliberately degrade the network -
 add ping, drop packets, cap the speed, tear connections down, and more. It works by intercepting
@@ -94,6 +96,11 @@ tooltip explaining what it does.
 
 > Note: selecting a preset only fills in the fields - impairment starts only on **START**.
 > Without administrator rights the WinDivert driver will not load.
+
+Looking for one specific task rather than the full manual below? The
+[guides on the website](https://beannetworktester.donislawdev.com/) walk through packet loss,
+latency, speed limits, aiming at a single app and testing with no internet, each with the numbers
+worth trying and the command that does it.
 
 ## Language
 

--- a/site/pages/home/en.html
+++ b/site/pages/home/en.html
@@ -58,7 +58,10 @@
     <li>Pick a ready profile such as "{{app.presets.3g}}", press START, and use your app.</li>
   </ol>
   <p>There is a text mode in the same file, so the whole thing also runs in a pipeline.
-  One command is enough to check that your service survives 10 percent packet loss.</p>
+  One command is enough to check that your service survives 10 percent packet loss:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --target myapp.exe --duration 60</code></pre>
+  <p>It stops on its own when the time is up, so a step that hangs cannot leave a broken network
+  behind it. Add <code>--simulate</code> to rehearse a command without touching real traffic.</p>
 </section>
 
 <section>

--- a/site/pages/home/pl.html
+++ b/site/pages/home/pl.html
@@ -62,7 +62,10 @@
     <li>Wybierz gotowy profil, na przykład "{{app.presets.3g}}", wciśnij START i korzystaj z aplikacji.</li>
   </ol>
   <p>W tym samym pliku jest tryb tekstowy, więc całość działa też w pipeline. Jedna komenda
-  wystarczy, żeby sprawdzić, czy Twoja usługa przetrwa 10 procent utraty pakietów.</p>
+  wystarczy, żeby sprawdzić, czy Twoja usługa przetrwa 10 procent utraty pakietów:</p>
+<pre><code>BeanNetworkTester.exe --loss 10 --target myapp.exe --duration 60</code></pre>
+  <p>Zatrzyma się sam po zadanym czasie, więc zawieszony krok nie zostawi po sobie zepsutej sieci.
+  Dopisz <code>--simulate</code>, żeby przećwiczyć komendę bez ruszania prawdziwego ruchu.</p>
 </section>
 
 <section>


### PR DESCRIPTION
Search Console reports 16 of the site's 30 addresses indexed. The other 14 sit in
two buckets that need different remedies: 8 are "Discovered - currently not
indexed" (never fetched at all) and 6 are "Crawled - currently not indexed"
(fetched and declined).

URL inspection of the front page rules the technical layer out: `Crawl allowed:
Yes`, `Page fetch: Successful`, `Indexing allowed: Yes`, and `Google-selected
canonical: Inspected URL`, so Google did not pick some other page as the
canonical. The decisive field is `Referring page`, which names exactly one, and
it is the site's own Polish front page. The repository's website field is served
with `rel="nofollow"`, so it passes nothing.

## What is here

**The README links to the website.** Two links, both placed where a reader
benefits rather than for a crawler alone: one under the badges, and one after the
quick start for anyone who wants a walkthrough of a single task instead of the
full manual.

**The front page prints the command it promised, in both languages.** It said one
command is enough to check that a service survives 10 percent packet loss and
then showed none, while all fourteen other pages show one. This one is a gap in
the page rather than an indexing fix.

## What was deliberately left out

Lengthening the six pages in the "Crawled - currently not indexed" bucket, which
was the original plan. The site's own data does not support it. Median words in
`<main>`: indexed 411 (n=16), crawled and declined 426 (n=6), never crawled 407
(n=8), so the declined pages are longer than the indexed ones. The clearest
counterexamples: one Polish guide is indexed at 335 words, another is declined at
649, and the longest page on the site at 787 words was never crawled at all.

## Checks

- `tests/test_site.py`: 49 passed
- README and convention guards: 39 passed
- `ruff` and `mypy`: clean
- `tools/check_public_text.py` over both commits: clean
- The command added to the front page was verified by running it, not by reading
  the parser: `--simulate --loss 10 --target myapp.exe --duration 3` exits 0 with
  `reason=duration` and drops 174 of 1851 packets.

The full suite runs here on CI rather than locally, on both runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
