### PR TITLE
feat(packaging): an MSI installer for corporate deployment

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -68,13 +68,31 @@ jobs:
           mkdir -p published && cd published
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY"
           ls -l
-          # Four assets ship: the archive, the checksums, the SBOM and the bundle.
-          # A missing one means a phase did not finish, which is precisely the
-          # half-failure nobody would notice by looking at the page.
+          # Four assets always ship: the archive, the checksums, the SBOM and the
+          # bundle. A missing one means a phase did not finish, which is precisely
+          # the half-failure nobody would notice by looking at the page.
           for pattern in '*.zip' 'SHA256SUMS.txt' '*.spdx.json' '*.sigstore.json'; do
             # shellcheck disable=SC2086
             ls $pattern >/dev/null 2>&1 || { echo "MISSING asset: $pattern"; exit 1; }
           done
+          # A fifth ships on a full release only. 🔴 The rule is `-rc` in the tag and
+          # it is the SAME rule as `is_release_candidate` in tools/sign_release.py -
+          # `test_the_candidate_rule_is_the_same_one_in_both_places` keeps the pair
+          # honest, because two different answers here would mean either a release
+          # published without its installer or every candidate failing this job.
+          # Checked in BOTH directions on purpose: a candidate that somehow carried
+          # an MSI would be the bug that strands whoever installed it, since Windows
+          # Installer cannot tell `-rc.1` from the release.
+          case "$TAG" in
+            *-rc*)
+              ! ls ./*.msi >/dev/null 2>&1 || {
+                echo "a release candidate must NOT carry an .msi: $(ls ./*.msi)"; exit 1; }
+              echo "$TAG is a release candidate: no installer expected, and none present"
+              ;;
+            *)
+              ls ./*.msi >/dev/null 2>&1 || { echo "MISSING asset: *.msi"; exit 1; }
+              ;;
+          esac
 
       - name: The checksum users are told to compare
         shell: bash
@@ -143,6 +161,27 @@ jobs:
           "pinned  : $pinned"
           "actual  : $actual"
           if ($actual -ne $pinned) { throw "the shipped file was signed by a DIFFERENT certificate" }
+
+          # The installer is a second signed artefact, and an unsigned one is worse
+          # than no installer: it is the file corporate deployment pushes to machines
+          # nobody will ever log into. It carries the executable checked above, so a
+          # valid signature here is what says the wrapper was not rebuilt around it.
+          $msi = Get-ChildItem -Filter *.msi -ErrorAction SilentlyContinue |
+                 Select-Object -First 1
+          if (-not $msi) {
+            "no .msi on this release - a release candidate ships none, on purpose"
+          } else {
+            $msiSig = Get-AuthenticodeSignature -LiteralPath $msi.FullName
+            "installer: $($msi.Name)"
+            "status   : $($msiSig.Status)"
+            if ($msiSig.Status -ne 'Valid') { throw "installer signature status is $($msiSig.Status)" }
+            if (-not $msiSig.TimeStamperCertificate) { throw "the installer signature carries no timestamp" }
+            $msiBytes = [System.Security.Cryptography.SHA256]::Create().ComputeHash(
+                          $msiSig.SignerCertificate.RawData)
+            $msiActual = ($msiBytes | ForEach-Object { $_.ToString('x2') }) -join ''
+            "actual   : $msiActual"
+            if ($msiActual -ne $pinned) { throw "the installer was signed by a DIFFERENT certificate" }
+          }
 
       - name: A full release must be the one the website offers
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Added
 
-- **An installer (`.msi`), next to the zip.** Run it and the program is installed for
-  everyone on the computer, added to `PATH` so `BeanNetworkTester` works from any command
-  prompt, and given a Start Menu entry. It appears in "Apps and features" like any other
-  program, and removing it there takes the files, the `PATH` entry and the shortcut with
-  it. Your profiles, window state and CSV exports are untouched by installing, upgrading
-  or removing it - they live in your own folder, not in the program's.
-  It needs Administrator rights, and it is the format company IT usually asks for, because
-  it can be rolled out to many computers at once. **The zip is unchanged and stays the
-  simplest option** if you want to run the program without installing anything, or you do
-  not have Administrator rights. Release candidates ship the zip only.
+- **An installer (`.msi`), next to the zip.** It installs the program for everyone on the
+  computer, puts `BeanNetworkTester` on `PATH` so it works from any command prompt, and
+  adds a Start Menu entry. It shows up in "Apps and features", and removing it there takes
+  the files, the `PATH` entry and the shortcut with it. Your profiles, window state and CSV
+  exports are never touched. It needs Administrator rights; company IT usually asks for
+  this format. The zip is unchanged and is still the simplest way to run the program
+  without installing anything.
 
 - **Different values for uploads and downloads.** A new "Asymmetry" card. Leave it off and
   one set of numbers applies both ways, as before. Tick it and the fields above it describe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions fol
 
 ### Added
 
+- **An installer (`.msi`), next to the zip.** Run it and the program is installed for
+  everyone on the computer, added to `PATH` so `BeanNetworkTester` works from any command
+  prompt, and given a Start Menu entry. It appears in "Apps and features" like any other
+  program, and removing it there takes the files, the `PATH` entry and the shortcut with
+  it. Your profiles, window state and CSV exports are untouched by installing, upgrading
+  or removing it - they live in your own folder, not in the program's.
+  It needs Administrator rights, and it is the format company IT usually asks for, because
+  it can be rolled out to many computers at once. **The zip is unchanged and stays the
+  simplest option** if you want to run the program without installing anything, or you do
+  not have Administrator rights. Release candidates ship the zip only.
+
 - **Different values for uploads and downloads.** A new "Asymmetry" card. Leave it off and
   one set of numbers applies both ways, as before. Tick it and the fields above it describe
   downloads only, while seven new ones describe uploads: latency, jitter, spike chance and

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ exists.
 
 ## Quick start (3 steps)
 
-1. Download `BeanNetworkTester` (or build it: `pyinstaller --noconfirm BeanNetworkTester.spec`).
+1. Download `BeanNetworkTester`: the **zip** runs without installing anything, the **`.msi`**
+   installs it for everyone on the computer, on `PATH` and in the Start Menu (needs
+   Administrator rights). Or build it: `pyinstaller --noconfirm BeanNetworkTester.spec`.
 2. Run `BeanNetworkTester.exe` - the program **asks for administrator rights by itself**
    (WinDivert needs them). From the repository: `python bean_network_tester.py`.
 3. Pick a preset from the "Profiles" list (e.g. "3G network") and click **START**.
@@ -1296,8 +1298,15 @@ in English.
 
 Releases go out through a second workflow (`.github/workflows/release.yml`) on a `v*` tag. It
 checks the tag against `VERSION.txt`, refuses to publish while the changelogs are still open,
-builds and smoke-tests the exe, then publishes three assets: the zip, the `SHA256SUMS.txt` this
-README tells you to verify, and an SPDX SBOM signed against the archive it describes.
+builds and smoke-tests the exe, and opens a **draft** carrying the SPDX SBOM. It deliberately
+publishes no archive: the signing key lives on a hardware card that no runner can reach, so the
+archive is signed on the maintainer's machine (`tools/sign_release.py`) and uploaded from there,
+and a third workflow then attests the bytes that actually ship.
+
+A published release therefore carries the zip, the `SHA256SUMS.txt` this README tells you to
+verify, the SBOM, and the attestation bundle. A full release carries a fifth file, the `.msi`
+installer. A release candidate does not, because Windows Installer ignores the `-rc.1` and would
+treat a candidate and its release as the same version.
 
 ## Project layout
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,4 +1,4 @@
-# Package sources: Chocolatey and WinGet
+# Package sources: Chocolatey, WinGet and the MSI
 
 These are **templates**, not packages. Every `{{PLACEHOLDER}}` is filled by
 `tools/build_packages.py` from the one place that owns the value: the version from
@@ -37,6 +37,12 @@ carries the move, not before it.
 `release.yml`: a bad manifest is public and moderated, and the cost of catching it
 after the fact is somebody else's review time.
 
+**The MSI is the exception, and not because it is special.** It is built and signed by
+`tools/sign_release.py` during the release itself, because it carries the executable:
+building it anywhere else would either wrap an unsigned program in a signed installer,
+or require the signing card to be somewhere it will never be. Nothing is submitted -
+the MSI is simply an asset on the release.
+
 ## What each package has to get right
 
 **Chocolatey.** It downloads the release archive rather than embedding it, so the
@@ -56,6 +62,19 @@ through one - it needs the `_internal` directory beside it. The field puts the
 directory holding the nested file on `PATH` instead, which is what winget's source
 does with it rather than what the field's one-line description implies.
 
+**The MSI.** Three things carry it. `UpgradeCode` is the identity of the product and can
+never be regenerated - Windows Installer finds a machine's previous version through that
+GUID and nothing else, so a new one would strand the old install on every machine that
+already has it, unreachable. `Scope="perMachine"` is what Group Policy, SCCM and Intune
+need, and it is only safe because user files already live in `%LOCALAPPDATA%`: Program
+Files is read-only for ordinary users. And a running session has to be closed **before**
+`InstallValidate`, not before `InstallFiles` where WiX puts `CloseApplication` by default -
+Restart Manager cannot close a console process that has no window to ask, so it waits
+thirty seconds and fails the upgrade, and `InstallValidate` is what decides a reboot is
+needed. Measured: Restart Manager on gives 1601, off gives 3010, off plus an early close
+gives 0.
+
 Neither manifest can keep a file safe on its own: WinGet portables take no scripts at
 all, and that is why the program itself had to stop writing into the directory the
-package manager owns.
+package manager owns. The MSI is the one of the three that behaves like Chocolatey here -
+a file it did not install survives both an upgrade and an uninstall.

--- a/packaging/msi/BeanNetworkTester.wxs.in
+++ b/packaging/msi/BeanNetworkTester.wxs.in
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Rendered by tools/build_packages.py - do not edit the generated copy.
+
+  This is the MSI corporate deployment wants: one file, silent, per-machine, and
+  visible to Group Policy, SCCM and Intune. The zip stays the primary download and
+  the WinGet and Chocolatey packages keep using it; this is an ADDITIONAL asset,
+  not a replacement for either.
+
+  Why an MSI is even possible here, and it was not always:
+  ADR 2026-08-12 moved profiles, window state and CSV exports out of the install
+  directory into %LOCALAPPDATA%. A per-machine install lands in Program Files,
+  which an ordinary user cannot write to - so without that decision this package
+  would install and then fail for every non-administrator who ran it.
+
+  The payload is passed in rather than named here, because the same source has to
+  build the signed release and a throwaway test build:
+
+      wix build BeanNetworkTester.wxs -arch x64 -d PayloadDir=<dir> -o <out>.msi
+
+  where <dir> is the extracted `BeanNetworkTester` folder from the release archive.
+  `$(...)` is the WiX preprocessor, which the placeholder renderer leaves untouched -
+  it only ever substitutes its own doubled-brace markers.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package
+      Name="{{APP_NAME}}"
+      Manufacturer="{{PUBLISHER}}"
+      Version="{{VERSION}}"
+      UpgradeCode="{{UPGRADE_CODE}}"
+      Scope="perMachine"
+      Compressed="yes"
+      InstallerVersion="500">
+
+    <!--
+      🔴 The UpgradeCode above is the identity of the PRODUCT, not of a build, and
+      it must never change. Every installed machine finds its previous version
+      through it; a new one would leave the old install in place forever, on every
+      machine that already has it, with no way to reach it. It lives in
+      tools/build_packages.py and a test pins the value.
+
+      MajorUpgrade is what makes the next release a replacement for the previous one
+      instead of a second copy beside it. Scheduled afterInstallExecute so the new
+      files are laid down before the old ones are removed: the reverse order deletes
+      shared files and reinstalls nothing, which is the classic way an MSI upgrade
+      eats its own payload.
+    -->
+    <MajorUpgrade
+        Schedule="afterInstallExecute"
+        DowngradeErrorMessage="A newer version of [ProductName] is already installed. Remove it first if you want to go back." />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- Programs and Features reads these. A tool that asks for Administrator
+         rights should say who wrote it and where to complain. -->
+    <Property Id="ARPURLINFOABOUT" Value="{{PROJECT_URL}}" />
+    <Property Id="ARPHELPLINK" Value="{{REPO_URL}}/issues" />
+    <Property Id="ARPURLUPDATEINFO" Value="{{RELEASE_NOTES_URL}}" />
+    <Property Id="ARPPRODUCTICON" Value="AppIcon" />
+    <Property Id="ARPNOREPAIR" Value="1" />
+
+    <Icon Id="AppIcon" SourceFile="$(PayloadDir)\_internal\bean.ico" />
+
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="{{APP_NAME}}" />
+    </StandardDirectory>
+
+    <!--
+      One element harvests the whole tree. The exe needs its sibling _internal
+      directory to run at all, so the shape of this folder is load-bearing and not
+      a packaging detail: `**` keeps it exactly as the release archive built it.
+    -->
+    <ComponentGroup Id="ProductFiles" Directory="INSTALLFOLDER">
+      <Files Include="$(PayloadDir)\**" />
+    </ComponentGroup>
+
+    <!--
+      The command line is half of this tool - it reports every outcome as an exit
+      code so it can run from a pipeline - so the exe belongs on PATH. System="yes"
+      because this is a per-machine install; a user-scoped PATH entry would be
+      invisible to the scheduled task or build agent that actually runs it.
+    -->
+    <ComponentGroup Id="PathEntry" Directory="INSTALLFOLDER">
+      <Component Id="AddToPath" Guid="*">
+        <Environment Id="UpdatePath" Name="PATH" Value="[INSTALLFOLDER]"
+                     Part="last" Action="set" System="yes" Permanent="no" />
+        <RegistryValue Root="HKLM" Key="Software\{{PUBLISHER}}\{{TOOL_ID}}"
+                       Name="Path" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Component Id="StartMenuShortcut" Guid="*">
+        <Shortcut Id="AppShortcut"
+                  Name="{{APP_NAME}}"
+                  Description="{{TAGLINE}}"
+                  Target="[INSTALLFOLDER]{{EXE_NAME}}"
+                  WorkingDirectory="INSTALLFOLDER"
+                  Icon="AppIcon" />
+        <RegistryValue Root="HKLM" Key="Software\{{PUBLISHER}}\{{TOOL_ID}}"
+                       Name="Shortcut" Type="integer" Value="1" KeyPath="yes" />
+      </Component>
+    </StandardDirectory>
+
+    <Feature Id="Main" Title="{{APP_NAME}}" Level="1">
+      <ComponentGroupRef Id="ProductFiles" />
+      <ComponentGroupRef Id="PathEntry" />
+      <ComponentRef Id="StartMenuShortcut" />
+    </Feature>
+
+  </Package>
+</Wix>

--- a/packaging/msi/BeanNetworkTester.wxs.in
+++ b/packaging/msi/BeanNetworkTester.wxs.in
@@ -22,7 +22,8 @@
   `$(...)` is the WiX preprocessor, which the placeholder renderer leaves untouched -
   it only ever substitutes its own doubled-brace markers.
 -->
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
   <Package
       Name="{{APP_NAME}}"
       Manufacturer="{{PUBLISHER}}"
@@ -45,11 +46,92 @@
       shared files and reinstalls nothing, which is the classic way an MSI upgrade
       eats its own payload.
     -->
+    <!--
+      🔴 AllowSameVersionUpgrades is here because of something this project has
+      actually done, not a hypothetical. Chocolatey's moderation once held a release
+      over a packaging fault and the SAME version number was rebuilt and shipped
+      again - the runbook documents that as the normal answer, since a version in
+      moderation does not get its number bumped.
+
+      An MSI does not treat that as an upgrade by default: measured here, installing
+      a rebuilt package of the same version left TWO entries in Programs and Features,
+      side by side, because MajorUpgrade ignores an equal version unless told not to.
+    -->
     <MajorUpgrade
         Schedule="afterInstallExecute"
+        AllowSameVersionUpgrades="yes"
         DowngradeErrorMessage="A newer version of [ProductName] is already installed. Remove it first if you want to go back." />
 
     <MediaTemplate EmbedCab="yes" />
+
+    <!--
+      🔴 Without this, an upgrade FAILS while a session is running. Measured on
+      Windows Server 2025: the same upgrade returns 0 with nothing running and 1601
+      with a session up, and the log says why -
+      "RESTART MANAGER: Failed to shut down all applications in the service's
+      session. Error: 351" after exactly thirty seconds of waiting.
+
+      Restart Manager asks an application to close and waits. This one is a console
+      process running a timed session: it has no window, no message loop and no
+      Restart Manager registration, so there is nothing to ask, and the wait can
+      only end in a timeout. Closing it politely is therefore not an option this
+      package has, and TerminateProcess is not impatience.
+
+      Killing the process is also what releases the driver, which is the part that
+      matters for the file operations that follow: WinDivert marks its own service
+      for deletion when it installs it, so the service goes away once the last
+      handle to it is closed, and terminating the process closes them.
+
+      This is the same job `chocolateybeforemodify.ps1` does for Chocolatey, for the
+      same reason, and it is scheduled by the extension before InstallValidate -
+      that is, before the step where Restart Manager would otherwise start counting
+      to thirty.
+    -->
+    <util:CloseApplication
+        Id="CloseRunningSession"
+        Target="{{EXE_NAME}}"
+        TerminateProcess="1"
+        RebootPrompt="no" />
+
+    <!--
+      🔴 And this property is what gives the action above a chance to run at all.
+
+      WiX schedules CloseApplication `Before="InstallFiles"`, which is AFTER
+      InstallValidate - and InstallValidate is exactly where Restart Manager spends
+      its thirty seconds and then fails the transaction. Read out of the built
+      package rather than assumed:
+      `<Custom Action="Wix4CloseApplications_X64" Before="InstallFiles" />`.
+      So with Restart Manager left on, the upgrade never reaches the action meant to
+      unblock it. Turning it off removes the wait, and the file this package needs
+      to replace is freed a moment later by the action above.
+    -->
+    <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
+
+    <!--
+      🔴 And this one has to run BEFORE InstallValidate, which is the whole reason it
+      exists separately from the action above.
+
+      Measured, in this order:
+        * Restart Manager on, no action    -> 1601 after a 30 s timeout, nothing installed
+        * Restart Manager off, action only -> 3010, installed but asking for a reboot
+      InstallValidate is what decides a reboot is needed, and it runs BEFORE
+      CloseApplication - so by the time the session is closed, the answer has already
+      been given. Closing the session earlier is the only thing that changes it.
+
+      `Return="ignore"` is not laziness: this is a best-effort cleanup that runs before
+      the operation the user actually asked for, and refusing to upgrade because a kill
+      failed would be worse than the leftover. That is the same rule
+      `chocolateybeforemodify.ps1` states for itself.
+    -->
+    <CustomAction Id="StopRunningSession"
+                  Directory="INSTALLFOLDER"
+                  ExeCommand="[System64Folder]taskkill.exe /F /IM {{EXE_NAME}}"
+                  Execute="immediate"
+                  Return="ignore" />
+
+    <InstallExecuteSequence>
+      <Custom Action="StopRunningSession" Before="InstallValidate" />
+    </InstallExecuteSequence>
 
     <!-- Programs and Features reads these. A tool that asks for Administrator
          rights should say who wrote it and where to complain. -->

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1737,10 +1737,15 @@ MUTATIONS = [
         # "Signed" going back to being a claim instead of a measurement. A second
         # code-signing certificate on the same machine would then sign a release
         # under this project's name and nothing would say so.
+        # Anchored on the line ABOVE as well, and that is not decoration: the
+        # installer is signed by the same ritual and carries the same check one
+        # indent deeper, so the bare `if actual != ...` line became a SUBSTRING of
+        # its own copy and the count went to two. `certificate_of(exe)` is the half
+        # that stays unique.
         "label": "release: the signing script stops checking WHICH certificate signed",
         "file": "tools/sign_release.py",
-        "old": "        if actual != CODESIGN_SHA256:",
-        "new": "        if actual == CODESIGN_SHA256:",
+        "old": "        actual = certificate_of(exe)\n        if actual != CODESIGN_SHA256:",
+        "new": "        actual = certificate_of(exe)\n        if actual == CODESIGN_SHA256:",
         "test": "test_the_signing_certificate_is_pinned_by_its_bytes",
     },
     {

--- a/tests/test_mutation_registry.py
+++ b/tests/test_mutation_registry.py
@@ -1749,6 +1749,17 @@ MUTATIONS = [
         "test": "test_the_signing_certificate_is_pinned_by_its_bytes",
     },
     {
+        # The installer is the SECOND thing this ritual signs, and it needed its own
+        # entry the moment it existed: the guard above was written when there was one
+        # comparison in the file, and a bare substring search cannot tell which copy
+        # it found. It reported SURVIVED on the day the installer landed.
+        "label": "release: the signing script stops checking who signed the INSTALLER",
+        "file": "tools/sign_release.py",
+        "old": "            actual = certificate_of(msi)\n            if actual != CODESIGN_SHA256:",
+        "new": "            actual = certificate_of(msi)\n            if actual == CODESIGN_SHA256:",
+        "test": "test_the_signing_certificate_is_pinned_by_its_bytes",
+    },
+    {
         # The tempting shortcut in the attestation half: it was HANDED a digest, so
         # why download the file. Because then it attests something nobody checked -
         # a rumour with a signature on it.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,8 +1,10 @@
-"""The Chocolatey and WinGet package sources, and the renderer that fills them.
+"""The Chocolatey, WinGet and MSI package sources, and the renderer that fills them.
 
-These files are published under our name to two feeds we do not control, so the
-cost of a mistake is somebody else's moderation queue and, for the two lines that
-matter, a user whose install does not work at all.
+These files are published under our name to feeds we do not control, so the cost of
+a mistake is somebody else's moderation queue and, for the two lines that matter, a
+user whose install does not work at all. The MSI raises that cost again: it is what
+corporate deployment pushes to machines nobody will ever log into, and its
+UpgradeCode is the one value here that cannot be corrected after the fact.
 
 What is guarded here is what a reviewer cannot catch for us:
 
@@ -134,6 +136,81 @@ def test_the_chocolatey_icon_is_a_pinned_cdn_url(tmp_path, monkeypatch):
         check(f"the icon is not served from {host}", host not in url, f"({url})")
     check("the icon is pinned to the tag being packaged, not to a branch",
           f"@v{appinfo.__version__}/" in url, f"({url})")
+
+
+# -- the MSI, whose mistakes are the ones that cannot be taken back ------------- #
+def test_the_msi_upgrade_code_never_changes():
+    """The one value in this repository that may never be regenerated.
+
+    Windows Installer finds a machine's previous version through the UpgradeCode and
+    through nothing else. A new one does not "reset" anything: every machine that
+    already has the package keeps the old install, forever, beside the new one - and
+    the correction would have to run on machines we cannot reach. So the literal is
+    pinned here, and a regenerated GUID reddens instead of shipping.
+    """
+    check("the MSI UpgradeCode is the one this product was published with",
+          bp.MSI_UPGRADE_CODE == "4BE626D0-E975-4E56-92B4-146EF6AEDF3C",
+          f"({bp.MSI_UPGRADE_CODE})")
+
+
+def test_the_msi_is_a_per_machine_install(tmp_path, monkeypatch):
+    """Corporate deployment installs once, for everybody, from SYSTEM.
+
+    A per-user MSI cannot be pushed by Group Policy or SCCM, which is the entire
+    reason this package exists. This is also what makes ADR 2026-08-12 load-bearing
+    rather than tidy: Program Files is read-only for ordinary users, so the profiles
+    and exports have to live in %LOCALAPPDATA% or the program breaks for everyone
+    who is not an administrator.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check('the package installs per machine', 'Scope="perMachine"' in wxs)
+
+
+def test_the_msi_replaces_the_previous_version_instead_of_joining_it(tmp_path, monkeypatch):
+    """Without MajorUpgrade an MSI installs a SECOND copy and both stay listed.
+
+    The schedule matters as much as the element. `afterInstallExecute` lays the new
+    files down before the old product is removed; scheduling the removal first
+    deletes files the new version shares and reinstalls none of them, which is the
+    classic way an upgrade eats its own payload.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check("the package upgrades in place", "<MajorUpgrade" in wxs)
+    check("and lays the new files down before removing the old ones",
+          'Schedule="afterInstallExecute"' in wxs)
+
+
+def test_the_msi_keeps_the_exe_with_its_siblings(tmp_path, monkeypatch):
+    """The same requirement `ArchiveBinariesDependOnPath` carries for WinGet.
+
+    The exe cannot run without the `_internal` directory beside it, so the whole
+    tree has to be harvested as it is. A harvest that flattened it, or that picked
+    files one by one, would install something that starts and then cannot find its
+    own language tables.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check("the whole payload tree is harvested",
+          re.search(r"<Files\s+Include=\"\$\(PayloadDir\)\\\*\*\"", wxs) is not None)
+
+
+def test_the_msi_puts_the_command_line_on_the_system_path(tmp_path, monkeypatch):
+    """A user-scoped PATH entry is invisible to the account that actually runs it.
+
+    This tool reports outcomes as exit codes so it can run from a pipeline, and the
+    thing running that pipeline is a service account or a scheduled task, not the
+    person who installed it.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    found = re.search(r"<Environment[^>]*Name=\"PATH\"[^>]*>", wxs, re.S)
+    check("the install directory is added to PATH", found is not None)
+    check("and to the machine's PATH, not one account's",
+          found is not None and 'System="yes"' in found.group(0))
+
+
+def test_the_msi_version_is_the_one_being_released(tmp_path, monkeypatch):
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check("the rendered package carries VERSION.txt's version",
+          f'Version="{appinfo.__version__}"' in wxs)
 
 
 # -- the inputs that would look fine and be wrong ------------------------------- #

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -207,6 +207,49 @@ def test_the_msi_puts_the_command_line_on_the_system_path(tmp_path, monkeypatch)
           found is not None and 'System="yes"' in found.group(0))
 
 
+def test_the_msi_closes_a_running_session_before_it_validates(tmp_path, monkeypatch):
+    """An upgrade with a session running fails without this, and the order is the fix.
+
+    Measured on Windows Server 2025, same starting point each time, a session holding
+    the WinDivert driver throughout:
+
+        Restart Manager on                       -> 1601, nothing installed
+        Restart Manager off, close-app action    -> 3010, installed but wants a reboot
+        Restart Manager off, close before validate -> 0
+
+    Restart Manager cannot close this program - it is a console process with no window
+    and no message loop, so there is nothing to ask, and it can only time out (thirty
+    seconds, `Error: 351`). And InstallValidate is what decides a reboot is needed, so
+    an action scheduled after it, which is where WiX puts CloseApplication by default,
+    cannot change that answer. Hence a second action, scheduled Before InstallValidate.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check("Restart Manager is turned off, so InstallValidate does not wait for it",
+          'Id="MSIRESTARTMANAGERCONTROL" Value="Disable"' in wxs)
+    check("a running session is closed",
+          'Id="StopRunningSession"' in wxs)
+    check("and it is closed BEFORE InstallValidate, which is what decides the reboot",
+          re.search(r'<Custom\s+Action="StopRunningSession"\s+Before="InstallValidate"', wxs)
+          is not None)
+    check("closing is best effort and never fails the upgrade",
+          re.search(r'Id="StopRunningSession"[^>]*Return="ignore"', wxs, re.S) is not None)
+
+
+def test_a_reshipped_version_upgrades_instead_of_installing_beside_itself(
+        tmp_path, monkeypatch):
+    """Rebuilding one release under the same number is something this project does.
+
+    A version sitting in moderation is corrected by shipping the same number again -
+    the packaging runbook says so, and Chocolatey held 0.5.0 over exactly that. Each
+    rebuild gets a fresh ProductCode, and MajorUpgrade ignores an equal version unless
+    told otherwise: measured, that left two entries in Programs and Features side by
+    side.
+    """
+    wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
+    check("a rebuild of the same version replaces the installed one",
+          'AllowSameVersionUpgrades="yes"' in wxs)
+
+
 def test_the_msi_version_is_the_one_being_released(tmp_path, monkeypatch):
     wxs = _rendered(tmp_path, monkeypatch)["msi/BeanNetworkTester.wxs"]
     check("the rendered package carries VERSION.txt's version",

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -631,6 +631,64 @@ def test_the_signing_certificate_is_pinned_by_its_bytes():
           "(without a timestamp the signature dies when the certificate expires)")
 
 
+def test_a_release_candidate_gets_no_installer():
+    """Windows Installer has nowhere to put the `-rc.1`, and that is the whole reason.
+
+    ProductVersion is three numeric fields; anything after them is ignored for upgrade
+    detection, so `v0.7.0-rc.1` and `v0.7.0` are the SAME version to it. A machine that
+    installed the candidate would refuse the release as already installed - and the
+    person who tested the candidate is exactly the person who must not be stranded.
+    Shipping no MSI for a candidate makes that impossible rather than unlikely.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "sign_release", os.path.join(ROOT, "tools", "sign_release.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    for tag in ("v0.7.0-rc.1", "v1.0.0-rc.12", "v0.6.0-rc.2"):
+        check(f"{tag} is a release candidate", module.is_release_candidate(tag))
+    for tag in ("v0.7.0", "v1.0.0", "v0.6.0"):
+        check(f"{tag} is a release", not module.is_release_candidate(tag))
+
+
+def test_the_installer_is_built_from_bytes_that_are_already_signed():
+    """Order, not presence: an MSI built before the exe is signed ships an unsigned
+    program inside a signed wrapper, which is worse than either - the wrapper makes
+    it look checked.
+    """
+    script = _read_text(os.path.join(ROOT, "tools", "sign_release.py"))
+    signing = script.index("] signing with the card")
+    building = script.index("] building the installer")
+    check("the installer is built AFTER the executable is signed", signing < building,
+          "(building first would wrap an unsigned program in a signed installer)")
+    check("and the installer is signed as well",
+          "the installer was signed by a DIFFERENT" in script)
+    check("against the same pinned certificate",
+          script.count("!= CODESIGN_SHA256") >= 2,
+          "(the archive and the installer are two separate checks)")
+    check("the installer harvests the payload the archive was made from",
+          "PayloadDir=" in script)
+
+
+def test_the_draft_is_incomplete_without_the_installer_it_should_carry():
+    """The completeness check has to follow the KIND of release, not a fixed count.
+
+    A final release ships the installer and a candidate does not, so a hard-coded
+    "four assets" would either pass a final that is missing its MSI or fail every
+    candidate. Both of those are the failure this step was added to prevent.
+    """
+    script = _read_text(os.path.join(ROOT, "tools", "sign_release.py"))
+    check("the expected assets depend on whether an installer was built",
+          "expect_msi" in script)
+    check("and the installer is one of the things that can be missing",
+          "MSI_ASSET" in script)
+    check("the pass line no longer claims a fixed number",
+          "PASS: four assets" not in script,
+          "(it says how many were actually expected)")
+
+
 def _read_text(path):
     with open(path, encoding="utf-8") as handle:
         return handle.read()

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -653,6 +653,29 @@ def test_a_release_candidate_gets_no_installer():
         check(f"{tag} is a release", not module.is_release_candidate(tag))
 
 
+def test_the_candidate_rule_is_the_same_one_in_both_places():
+    """Two places decide "is this a candidate", and they must decide it the same way.
+
+    Phase B decides whether to BUILD an installer; phase D decides whether to demand
+    one. If they ever disagree, the result is either a release published without its
+    installer or every candidate failing verification - and both look like a broken
+    pipeline rather than a rule that drifted.
+    """
+    script = _read_text(os.path.join(ROOT, "tools", "sign_release.py"))
+    workflow = _read_text(os.path.join(ROOT, ".github", "workflows",
+                                       "verify-release.yml"))
+    check("phase B decides on '-rc' in the tag",
+          'return "-rc" in tag' in script)
+    check("phase D matches the same string",
+          "*-rc*)" in workflow,
+          "(a different rule here strands a release or every candidate)")
+    check("phase D refuses an installer on a candidate too",
+          "must NOT carry an .msi" in workflow,
+          "(a candidate that carried one would strand whoever installed it)")
+    check("phase D demands one on a full release",
+          "MISSING asset: *.msi" in workflow)
+
+
 def test_the_installer_is_built_from_bytes_that_are_already_signed():
     """Order, not presence: an MSI built before the exe is signed ships an unsigned
     program inside a signed wrapper, which is worse than either - the wrapper makes

--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -621,8 +621,19 @@ def test_the_signing_certificate_is_pinned_by_its_bytes():
     script = _read_text(os.path.join(ROOT, "tools", "sign_release.py"))
     check("the signing script reads the pin rather than carrying its own copy",
           "from beantester.legal import CODESIGN_SHA256" in script)
-    check("it compares what actually signed the file against the pin",
-          "actual != CODESIGN_SHA256" in script)
+    # 🔴 Anchored per artefact, and that is the whole point. This used to look for a
+    # bare `actual != CODESIGN_SHA256` anywhere in the file, which was a real guard
+    # while the ritual signed one thing. The moment the installer added a SECOND copy
+    # of that comparison, flipping the archive's check to `==` left the installer's
+    # copy behind for the substring to find - and the mutation came back SURVIVED.
+    # Two artefacts are signed, so two checks are named, and either one going soft
+    # has to redden on its own.
+    for what, variable in (("archive", "exe"), ("installer", "msi")):
+        pattern = (r"actual = certificate_of\(%s\)\s*\n\s*if actual != CODESIGN_SHA256:"
+                   % variable)
+        check(f"it compares what actually signed the {what} against the pin",
+              re.search(pattern, script) is not None,
+              f"(certificate_of({variable}) is not followed by the comparison)")
     check("and refuses without uploading anything",
           "Nothing has been uploaded." in script,
           "(a mismatch caught after the upload is not caught)")

--- a/tools/build_packages.py
+++ b/tools/build_packages.py
@@ -56,6 +56,18 @@ WINGET_ID = f"{appinfo.AUTHOR}.{appinfo.TOOL_ID}"
 # `ElevationRequirement`.
 WINGET_SCHEMA = "1.12.0"
 
+# 🔴 The MSI's UpgradeCode: the identity of the PRODUCT, generated once and never
+# again. Windows Installer finds a machine's previous version through this GUID and
+# nothing else. Change it and every machine that already has the package keeps the
+# old install forever, side by side with the new one, with no upgrade path and no
+# way to reach the old one from the new package - and it is not fixable afterwards,
+# because the fix would have to run on machines we cannot reach.
+#
+# This is why it is a constant here and not a value in the template: the renderer is
+# the one place that owns a value, and `test_the_msi_upgrade_code_never_changes`
+# pins this literal so a careless regeneration reddens instead of shipping.
+MSI_UPGRADE_CODE = "4BE626D0-E975-4E56-92B4-146EF6AEDF3C"
+
 
 def _read_json(*parts):
     with open(os.path.join(ROOT, *parts), encoding="utf-8") as f:
@@ -114,6 +126,7 @@ def values(version, digest, asset):
         "CHOCO_ID": CHOCO_ID,
         "WINGET_ID": WINGET_ID,
         "WINGET_SCHEMA": WINGET_SCHEMA,
+        "UPGRADE_CODE": MSI_UPGRADE_CODE,
         "APP_NAME": appinfo.APP_NAME,
         "TOOL_ID": appinfo.TOOL_ID,          # the data folder's name, which has no spaces
         "EXE_NAME": appinfo.EXE_NAME,

--- a/tools/sign_release.py
+++ b/tools/sign_release.py
@@ -26,12 +26,19 @@ What it does, in order, and what it refuses
    same machine - a renewal, a test one, one from another project - is exactly the
    accident this catches;
 5. repacks the archive, writes ``SHA256SUMS.txt`` over what it just made;
-6. uploads both to the DRAFT release and asks the workflow to attest the signed
-   bytes, so the ``.sigstore.json`` a user verifies describes the file they hold;
-7. **waits for that attestation and confirms the draft is complete** - four assets,
-   the published checksums naming the digest that was actually signed, and the
-   release still a draft. Until this existed the script ended at "dispatched, go
-   look", and a draft missing one file looks almost exactly like a finished one.
+6. **builds the MSI from the payload it has just signed, and signs that too.** The
+   order is the point: the installer carries the executable, so building it first
+   would ship an unsigned program inside a signed wrapper - worse than either, since
+   the wrapper makes it look checked. This is also why the release workflow cannot
+   build it: the runner has the payload but never the card. A release candidate gets
+   no MSI at all, on purpose - see ``is_release_candidate``;
+7. uploads everything to the DRAFT release and asks the workflow to attest the signed
+   archive, so the ``.sigstore.json`` a user verifies describes the file they hold;
+8. **waits for that attestation and confirms the draft is complete** - every asset
+   this kind of release ships, the published checksums naming the digest that was
+   actually signed, and the release still a draft. Until this existed the script
+   ended at "dispatched, go look", and a draft missing one file looks almost exactly
+   like a finished one.
 
 Nothing here publishes. The release stays a draft until a person looks at it and
 presses the button - and pressing it runs ``verify-release.yml``, which downloads
@@ -143,6 +150,80 @@ def expiry_notice(not_after, now):
 
 
 EXPECTED_ASSETS = (".zip", "SHA256SUMS.txt", ".spdx.json", ".sigstore.json")
+# The MSI is only expected on a final release - see `is_release_candidate`.
+MSI_ASSET = ".msi"
+
+
+def is_release_candidate(tag):
+    """Does this tag name a release candidate rather than a release?
+
+    🔴 A release candidate gets NO MSI, and that is a decision rather than an
+    omission. Windows Installer has nowhere to put the `-rc.1`: ProductVersion is
+    three numeric fields and everything after them is ignored, so `v0.7.0-rc.1` and
+    `v0.7.0` would be the SAME version to it. A machine that took the candidate
+    would then refuse the release as "already installed", and the person who tested
+    the candidate is exactly the person who must not be stranded.
+
+    Publishing no MSI for a candidate keeps that from being possible at all, which
+    is worth more than a numbering scheme nobody would remember.
+    """
+    return "-rc" in tag
+
+
+def find_wix():
+    """The WiX tool, or a refusal that says how to get it.
+
+    WiX is a .NET global tool, so it lands in ~/.dotnet/tools and is on PATH only if
+    that directory is - which it is not in every shell. Looking there directly means
+    the ritual does not fail three steps later with "wix is not recognised".
+    """
+    candidates = [shutil.which("wix")]
+    home = os.path.expanduser("~")
+    candidates.append(os.path.join(home, ".dotnet", "tools", "wix.exe"))
+    for candidate in candidates:
+        if candidate and os.path.exists(candidate):
+            return candidate
+    raise SystemExit(
+        "sign_release: the WiX tool is not installed, so the MSI cannot be built.\n"
+        "  dotnet tool install --global wix --version 5.0.2\n"
+        "  wix extension add -g WixToolset.Util.wixext/5.0.2\n"
+        "Nothing has been uploaded.")
+
+
+def build_msi(work, unpacked, tag, sums_path):
+    """Build the MSI from the payload that has ALREADY been signed.
+
+    🔴 The order is the point. The MSI carries the executable inside it, so it has to
+    be built after the exe is signed and signed itself afterwards - build it first
+    and it ships an unsigned program inside a signed wrapper, which is worse than
+    either, because the wrapper makes it look checked.
+
+    This is also why the MSI cannot be built by the release workflow: the runner has
+    the payload but never the card, so anything it built would have to be rebuilt
+    here anyway.
+    """
+    # Rendered by running the renderer, not by importing it. It is a command-line
+    # tool with a documented interface, the runbook calls it exactly this way, and
+    # importing it would give the same file two module names - which is an error
+    # mypy reports at whoever changes this file next, for no benefit here.
+    version = tag[1:] if tag.startswith("v") else tag
+    run([sys.executable, os.path.join(ROOT, "tools", "build_packages.py"),
+         "--sums", sums_path, "--version", version])
+    wxs = os.path.join(ROOT, "build", "packaging", "msi", "BeanNetworkTester.wxs")
+    if not os.path.exists(wxs):
+        raise SystemExit("sign_release: %s was not rendered - nothing uploaded" % wxs)
+
+    payload = os.path.join(unpacked, "BeanNetworkTester")
+    if not os.path.isdir(payload):
+        raise SystemExit(
+            "sign_release: the archive has no BeanNetworkTester directory, so the "
+            "MSI would harvest the wrong tree. Nothing has been uploaded.")
+
+    out = os.path.join(work, "BeanNetworkTester-%s-windows-x64.msi" % tag)
+    run([find_wix(), "build", wxs, "-arch", "x64",
+         "-d", "PayloadDir=%s" % payload,
+         "-ext", "WixToolset.Util.wixext", "-o", out])
+    return out
 
 
 def _gh_json(*args):
@@ -156,7 +237,7 @@ def _gh_json(*args):
         return None
 
 
-def confirm_draft(tag, digest, wait_seconds):
+def confirm_draft(tag, digest, wait_seconds, expect_msi=False):
     """Is the draft actually complete and describing the bytes we just signed?
 
     🔴 This step exists because the script used to end at "dispatched, go look". The
@@ -173,12 +254,15 @@ def confirm_draft(tag, digest, wait_seconds):
     Returns (ok, lines_to_print) and never raises, so the caller decides.
     """
     deadline = time.monotonic() + max(0, wait_seconds)
+    # A final release ships the installer as well, and a candidate does not - so what
+    # "complete" means is decided by the caller, not by counting to a fixed number.
+    wanted = EXPECTED_ASSETS + ((MSI_ASSET,) if expect_msi else ())
     lines, assets = [], []
     while True:
         data = _gh_json("release", "view", tag, "--repo", REPO,
                         "--json", "assets,isDraft")
         assets = [a.get("name", "") for a in (data or {}).get("assets", [])]
-        missing = [kind for kind in EXPECTED_ASSETS
+        missing = [kind for kind in wanted
                    if not any(name.endswith(kind) for name in assets)]
         if not missing:
             break
@@ -217,7 +301,7 @@ def confirm_draft(tag, digest, wait_seconds):
             {}).get("isDraft") is False:
         lines.append("  🔴 this release is NOT a draft any more - it is already public")
         return False, lines
-    lines.append("  PASS: four assets, digests agree, still a draft")
+    lines.append("  PASS: %d assets, digests agree, still a draft" % len(wanted))
     return True, lines
 
 
@@ -342,33 +426,68 @@ def main(argv=None):
                 % (CODESIGN_SHA256, actual))
         print("  signed by the pinned certificate, timestamped")
 
-    print("\n[5/7] repacking and checksumming")
+    print("\n[5/8] repacking and checksumming")
+    # Repacking happens on a dry run too. It writes only into the scratch directory,
+    # and it is what lets the installer below actually be built - a dry run that
+    # skipped it could not tell you the package source is broken, which is most of
+    # what a dry run is for.
     signed = os.path.join(work, archives[0])
-    if not args.dry_run:
-        os.remove(archive)
-        with zipfile.ZipFile(signed, "w", zipfile.ZIP_DEFLATED) as zf:
-            for base, _dirs, names in os.walk(unpacked):
-                for name in names:
-                    full = os.path.join(base, name)
-                    zf.write(full, os.path.relpath(full, unpacked))
-        sums = os.path.join(work, "SHA256SUMS.txt")
-        with open(sums, "w", encoding="utf-8", newline="\n") as handle:
-            handle.write("%s *%s\n" % (sha256_of(signed), archives[0]))
-        print("  %s" % sha256_of(signed))
+    os.remove(archive)
+    with zipfile.ZipFile(signed, "w", zipfile.ZIP_DEFLATED) as zf:
+        for base, _dirs, names in os.walk(unpacked):
+            for name in names:
+                full = os.path.join(base, name)
+                zf.write(full, os.path.relpath(full, unpacked))
+    sums = os.path.join(work, "SHA256SUMS.txt")
+    sum_lines = ["%s *%s\n" % (sha256_of(signed), archives[0])]
+    with open(sums, "w", encoding="utf-8", newline="\n") as handle:
+        handle.writelines(sum_lines)
+    print("  %s" % sha256_of(signed))
 
-    print("\n[6/7] handing it back to the workflow")
+    print("\n[6/8] building the installer")
+    msi = None
+    if is_release_candidate(args.tag):
+        print("  %s is a release candidate - no MSI, deliberately: Windows Installer "
+              "has nowhere to put the suffix, so a candidate and its release would "
+              "be the same version to it" % args.tag)
+    else:
+        msi = build_msi(work, unpacked, args.tag, sums)
+        command = [signtool, "sign", "/sha1", thumbprint, "/fd", "sha256",
+                   "/tr", TIMESTAMP_URL, "/td", "sha256", "/v", msi]
+        if args.dry_run:
+            print("  DRY RUN, would run: %s" % " ".join(command))
+        else:
+            run(command)
+            run([signtool, "verify", "/pa", "/v", msi])
+            actual = certificate_of(msi)
+            if actual != CODESIGN_SHA256:
+                raise SystemExit(
+                    "sign_release: the installer was signed by a DIFFERENT "
+                    "certificate\n  expected %s\n  got      %s\n"
+                    "Nothing has been uploaded." % (CODESIGN_SHA256, actual))
+            print("  signed by the pinned certificate, timestamped")
+        # The checksum file carries the installer too, so the published release can be
+        # checked in one `sha256sum -c` - which is exactly what verify-release.yml runs.
+        sum_lines.append("%s *%s\n" % (sha256_of(msi), os.path.basename(msi)))
+        with open(sums, "w", encoding="utf-8", newline="\n") as handle:
+            handle.writelines(sum_lines)
+        print("  %s" % os.path.basename(msi))
+
+    print("\n[7/8] handing it back to the workflow")
     if args.dry_run:
-        print("  DRY RUN, would upload the archive and SHA256SUMS.txt to the draft")
+        print("  DRY RUN, would upload the archive, the installer and SHA256SUMS.txt")
         print("  DRY RUN, would dispatch %s with the digest" % ATTEST_WORKFLOW)
         print("\ndry run finished - nothing was signed, uploaded or published")
         return 0
-    run(["gh", "release", "upload", args.tag, signed, sums,
-         "--repo", REPO, "--clobber"])
+    uploads = [signed, sums] + ([msi] if msi else [])
+    run(["gh", "release", "upload", args.tag] + uploads +
+        ["--repo", REPO, "--clobber"])
     run(["gh", "workflow", "run", ATTEST_WORKFLOW, "--repo", REPO,
          "-f", "tag=%s" % args.tag, "-f", "digest=%s" % sha256_of(signed)])
 
-    print("\n[7/7] confirming the draft is complete")
-    ok, lines = confirm_draft(args.tag, sha256_of(signed), args.wait)
+    print("\n[8/8] confirming the draft is complete")
+    ok, lines = confirm_draft(args.tag, sha256_of(signed), args.wait,
+                              expect_msi=msi is not None)
     for line in lines:
         print(line)
     if not ok:


### PR DESCRIPTION
Adds an `.msi` installer as a release asset, next to the zip. Corporate deployment pushes one file silently through Group Policy, SCCM or Intune, and a zip cannot do that. WinGet and Chocolatey can, but only where those tools are installed and allowed.

The zip is unchanged and stays the portable option. Nothing about the WinGet or Chocolatey packages is touched.

## What it does

Per-machine install into Program Files, the install directory on the SYSTEM `PATH`, a Start Menu entry, and the Programs-and-Features fields filled in. One `Files` element harvests the whole payload tree, so the executable keeps the `_internal` directory it cannot run without.

This was only possible because ADR 2026-08-12 had already moved profiles, window state and CSV exports to `%LOCALAPPDATA%`: a per-machine install lands in a directory ordinary users cannot write to.

## Three things that are not obvious

**The `UpgradeCode` can never be regenerated.** Windows Installer finds a machine's previous version through that GUID and nothing else, so a new one would strand the old install on every machine that already has it, with no way to reach it afterwards. It lives in the renderer and a test pins the literal.

**An upgrade failed outright while a session was running.** Three runs on Windows Server 2025, same verified starting point, a session holding the WinDivert driver throughout:

| package | result |
|---|---|
| Restart Manager on (the default) | 1601, nothing installed, 31 s |
| Restart Manager off, `util:CloseApplication` only | 3010, installed but demanding a reboot |
| plus a close scheduled before `InstallValidate` | 0, 4 s |

Restart Manager cannot close this program at all: it is a console process with no window, no message loop and no Restart Manager registration, so there is nothing to ask and the wait can only expire (`Error: 351`, after exactly thirty seconds). And WiX schedules `CloseApplication` before `InstallFiles`, which is after `InstallValidate` - the step that decides a reboot is needed. So the action meant to unblock the upgrade runs after the answer has been given.

**A release candidate gets no MSI.** `ProductVersion` is three numeric fields and anything after them is ignored for upgrade detection, so `v0.7.0-rc.1` and `v0.7.0` are the same version to Windows Installer. A machine that installed the candidate would refuse the release as already installed, stranding exactly the person who tested it. Phase B does not build one and phase D refuses one, and a test pins both to the same rule.

## Where it is built

Phase B (`tools/sign_release.py`, now eight steps), from the payload it has already signed, and signed itself afterwards. Building it earlier would ship an unsigned program inside a signed wrapper, which is worse than either because the wrapper makes it look checked. It is also why the release workflow cannot build it: the runner has the payload but never the card. Phase D checks the installer's signature against the same pinned certificate.

Built with WiX v5.0.2. The Open Source Maintenance Fee starts at v6, so v5 carries no fee, and v3.14 has been out of community support since February 2025. The deciding argument was migration rather than support: v5 shares the schema line of v6 and v7, so moving later is an upgrade, while v3 depends on the removed `heat.exe` and would be a rewrite.

## Verified

Windows 11 and Windows Server 2025, against the final package source. Clean install exits 0 with one entry in Programs and Features, exactly one `PATH` entry and one Start Menu shortcut; the program runs from Program Files with `pydivert importable`; the upgrade from the previous version leaves one entry, brings the new release's files in and queues no reboot; uninstall exits 0 and leaves no directory, `PATH` entry, shortcut or registry entry. User data came through every step byte-identical.

Also measured: a file the installer did not install survives both an upgrade and an uninstall, so on that axis the MSI behaves like Chocolatey rather than WinGet, which replaces its unpacked directory wholesale.

Full suite run locally before opening this: 1418 tests across 89 files, plus ruff and mypy.

## Not in this change

The installer is not attested through Sigstore the way the archive is - it carries an Authenticode signature from the same hardware card, timestamped, and its hash is in `SHA256SUMS.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
