### PR TITLE
fix(release): number the signing steps out of one total

### DIFF
--- a/tests/test_version_and_release.py
+++ b/tests/test_version_and_release.py
@@ -664,6 +664,29 @@ def test_a_release_candidate_gets_no_installer():
         check(f"{tag} is a release", not module.is_release_candidate(tag))
 
 
+def test_the_signing_steps_are_numbered_consecutively_out_of_the_same_total():
+    """The step markers are read by a person mid-ceremony, so they have to add up.
+
+    Adding a step means editing every marker, and editing only the ones below it is
+    the natural mistake: it happened the day the installer step was inserted, leaving
+    the script printing "[4/7] signing with the card" and then "[5/8] repacking".
+    Nothing failed - it just told the person holding the card a different story each
+    line, at the one moment they are counting.
+    """
+    import re
+
+    script = _read_text(os.path.join(ROOT, "tools", "sign_release.py"))
+    markers = [(int(a), int(b)) for a, b in re.findall(r"\[(\d+)/(\d+)\]", script)]
+    check("the script prints numbered steps at all", markers, "(none found)")
+    totals = {total for _, total in markers}
+    check("every marker counts out of the same total", len(totals) == 1, f"({sorted(totals)})")
+    numbers = [number for number, _ in markers]
+    check("the steps run 1..n with none missing or repeated",
+          numbers == list(range(1, len(numbers) + 1)), f"({numbers})")
+    check("and the total is the number of steps there actually are",
+          totals == {len(numbers)}, f"(total {sorted(totals)}, {len(numbers)} steps)")
+
+
 def test_the_candidate_rule_is_the_same_one_in_both_places():
     """Two places decide "is this a candidate", and they must decide it the same way.
 

--- a/tools/sign_release.py
+++ b/tools/sign_release.py
@@ -383,7 +383,7 @@ def main(argv=None):
     os.makedirs(work)
     print("working in %s" % work)
 
-    print("\n[1/7] fetching the build this tag produced")
+    print("\n[1/8] fetching the build this tag produced")
     run(["gh", "run", "download", "--repo", REPO, "--name",
          "unsigned-build-%s" % args.tag, "--dir", work])
     archives = [f for f in os.listdir(work) if f.endswith(".zip")]
@@ -392,10 +392,10 @@ def main(argv=None):
                          % archives)
     archive = os.path.join(work, archives[0])
 
-    print("\n[2/7] verifying what the workflow says it built")
+    print("\n[2/8] verifying what the workflow says it built")
     run(["gh", "attestation", "verify", archive, "--repo", REPO])
 
-    print("\n[3/7] unpacking")
+    print("\n[3/8] unpacking")
     unpacked = os.path.join(work, "unpacked")
     with zipfile.ZipFile(archive) as zf:
         zf.extractall(unpacked)
@@ -408,7 +408,7 @@ def main(argv=None):
     exe = exes[0]
     print("  %s (%d bytes, unsigned)" % (os.path.basename(exe), os.path.getsize(exe)))
 
-    print("\n[4/7] signing with the card")
+    print("\n[4/8] signing with the card")
     thumbprint = signing_thumbprint()
     signtool = find_signtool()
     command = [signtool, "sign", "/sha1", thumbprint, "/fd", "sha256",


### PR DESCRIPTION
Follow-up to #186, found while reviewing the merged branch.

Inserting the installer step renumbered the steps below it and left the ones above alone, so `sign_release.py` announced `[4/7] signing with the card` and then `[5/8] repacking`. Nothing failed and no test noticed. It simply told the person holding the signing card a different story on each line, at the one moment they are counting steps.

A guard now checks that the markers share one total, run 1..n with none missing or repeated, and that the total matches how many steps there actually are. Confirmed to bite rather than assumed: putting one `[4/7]` back turns it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
